### PR TITLE
catch QuestionError in /retrieve and add test

### DIFF
--- a/magma/lib/magma/server/retrieve.rb
+++ b/magma/lib/magma/server/retrieve.rb
@@ -59,6 +59,8 @@ class RetrieveController < Magma::Controller
       return failure(422, errors: @errors) unless success?
 
       perform
+    rescue Magma::QuestionError => e
+      return failure(422, errors: [ e.message ])
     rescue ArgumentError => e
       puts e.backtrace
       return failure 422, errors: [ e.message ]

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -474,6 +474,24 @@ describe RetrieveController do
 
       expect(json_body[:models][:labor][:count]).to eq(9)
     end
+
+    it 'returns a descriptive error when no results are retrieved on paginated query' do
+      lion = create(:labor, :lion)
+      hydra = create(:labor, :hydra)
+      stables = create(:labor, :stables)
+      retrieve(
+        project_name: 'labors',
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: 'name~xyz123',
+        page: 1,
+        page_size: 10
+      )
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(["Page 1 not found"])
+    end
   end
 
   context 'restriction' do


### PR DESCRIPTION
Cherry-picking just the one commit for this issue, so that this PR doesn't show the merged history. Not sure why the previous PR didn't show those as already merged into `master`.

This PR addresses mountetna/magma#193. It catches a Magma::QuestionError in the /retrieve endpoint, which can be thrown when no results are returned for a paginated query (hence the requested page cannot be found). Also adds a test for the condition.