### PR TITLE
remove the semicolon -- in the wrong place and appeared on the screen

### DIFF
--- a/timur/lib/client/jsx/components/attributes/date_time_attribute.jsx
+++ b/timur/lib/client/jsx/components/attributes/date_time_attribute.jsx
@@ -16,7 +16,7 @@ const DateTimeAttribute = ({value, mode, revised_value,
         new_date => reviseDocument(
           document, template, attribute, new_date && new_date.toISOString()
         )
-      } />;
+      } />
   </div>
 }
 


### PR DESCRIPTION
When editing any DateTime attribute, you see an extraneous `;` after the datepicker. This PR removes that semicolon.

Before:

![Screenshot from 2020-07-28 07-03-58](https://user-images.githubusercontent.com/4930129/88657902-961c4000-d0a0-11ea-8239-5d6558a47086.png)

After:

![Screenshot from 2020-07-28 07-05-46](https://user-images.githubusercontent.com/4930129/88658024-cd8aec80-d0a0-11ea-801e-51621387a5fa.png)
