### PR TITLE
Issue#94 add pauseUpload action and tie to the worker

### DIFF
--- a/etna/packages/etna-js/upload/actions/upload_actions.jsx
+++ b/etna/packages/etna-js/upload/actions/upload_actions.jsx
@@ -1,31 +1,42 @@
-import { postAuthorizeUpload } from '../api/upload_api';
+import {postAuthorizeUpload} from '../api/upload_api';
 import {errorMessage, message as showDialog} from './message_actions';
-import {AddUploadCommand, CancelUploadCommand, UnpauseUploadCommand, Upload} from "../workers/uploader";
+import {
+  AddUploadCommand,
+  CancelUploadCommand,
+  UnpauseUploadCommand,
+  Upload,
+  PauseUploadCommand
+} from '../workers/uploader';
 
 export const ADD_FILES = 'ADD_FILES';
 export const WORK = 'WORK';
 export const WORK_FAILED = 'WORK_FAILED';
 export const UNPAUSE_UPLOAD = 'UNPAUSE_UPLOAD';
-export {PAUSE_UPLOAD, CANCEL_UPLOAD} from "../workers/uploader";
+export {PAUSE_UPLOAD, CANCEL_UPLOAD} from '../workers/uploader';
 
+const dispatchUploadWork = (dispatch, command) =>
+  dispatch({
+    type: WORK,
+    work_type: 'upload',
+    command
+  });
 
-const dispatchUploadWork = (dispatch, command) => dispatch({
-  type: WORK, work_type: 'upload', command,
-});
-
-export const fileSelected = ({ file, folder_name, bucket_name }) => (dispatch, getState) => {
+export const fileSelected = ({file, folder_name, bucket_name}) => (
+  dispatch,
+  getState
+) => {
   // Note: webkitRelativePath is NOT on the standards track, although it is supported in Firefox and Chrome currently.
   // There doesn't currently (June 2020) seem to be a standards way of getting these relative paths of directory uploads
   // other than using this attribute, which seems to work well enough for our target audiences for now.
   // TODO: Check for more standards way of doing this in the future, or if IE support is required.
   const relativePath = file.webkitRelativePath;
   const dest = relativePath || file.name;
-  const { project_name }  = CONFIG;
-  let file_name = [folder_name, dest].filter(_ => _).join('/');
+  const {project_name} = CONFIG;
+  let file_name = [folder_name, dest].filter((_) => _).join('/');
 
   // In the case of a directory upload, we need to first ensure that a containing directory exists.
   if (relativePath) {
-    const parentDir = relativePath.split("/").slice(0, -1).join('/');
+    const parentDir = relativePath.split('/').slice(0, -1).join('/');
     if (parentDir) {
       return performMkdir(parentDir).then(performUpload);
     }
@@ -34,45 +45,72 @@ export const fileSelected = ({ file, folder_name, bucket_name }) => (dispatch, g
   return performUpload();
 
   function performMkdir(parentDir) {
-    return dispatch({ type: 'CREATE_FOLDER', bucket_name, folder_name: parentDir, parent_folder: folder_name });
+    return dispatch({
+      type: 'CREATE_FOLDER',
+      bucket_name,
+      folder_name: parentDir,
+      parent_folder: folder_name
+    });
   }
 
   function performUpload() {
-    return postAuthorizeUpload(window.location.origin, project_name, bucket_name, file_name)
-      .then(
-        ({ url }) => {
-          dispatchUploadWork(dispatch, AddUploadCommand(Upload({
-            file_name,
-            url,
-            file,
-            project_name
-          })))
-        }
+    return postAuthorizeUpload(
+      window.location.origin,
+      project_name,
+      bucket_name,
+      file_name
+    )
+      .then(({url}) => {
+        dispatchUploadWork(
+          dispatch,
+          AddUploadCommand(
+            Upload({
+              file_name,
+              url,
+              file,
+              project_name
+            })
+          )
+        );
+      })
+      .catch(
+        errorMessage(dispatch, 'warning', 'Upload failed', (error) => error)
       )
       .catch(
-        errorMessage(dispatch, 'warning', 'Upload failed', error => error)
-      )
-      .catch(
-        errorMessage(dispatch, 'error', 'Upload failed',
-          error => `Something bad happened: ${error}`)
+        errorMessage(
+          dispatch,
+          'error',
+          'Upload failed',
+          (error) => `Something bad happened: ${error}`
+        )
       );
   }
-}
+};
 
-export const unpauseUpload = ({ upload }) => (dispatch) => {
+export const unpauseUpload = ({upload}) => (dispatch) => {
   dispatchUploadWork(dispatch, UnpauseUploadCommand(upload));
-}
+};
 
-export const uploadComplete = ({ upload }) => (dispatch) => {
-  let { file } = upload;
-  dispatch({ type: ADD_FILES, files: [file] });
-}
+export const pauseUpload = ({upload}) => (dispatch) => {
+  dispatchUploadWork(dispatch, PauseUploadCommand(upload));
+};
 
-export const cancelUpload = ({ upload }) => (dispatch) => {
-  if (upload.status !== 'complete' && !confirm('Are you sure you want to remove this upload?')) return;
-  dispatchUploadWork(dispatch, CancelUploadCommand(upload))
-}
+export const uploadComplete = ({upload}) => (dispatch) => {
+  let {file} = upload;
+  dispatch({type: ADD_FILES, files: [file]});
+};
 
-export const uploadError = ({ message_type, message, title, upload }) => (dispatch) => {
+export const cancelUpload = ({upload}) => (dispatch) => {
+  if (
+    upload.status !== 'complete' &&
+    !confirm('Are you sure you want to remove this upload?')
+  )
+    return;
+  dispatchUploadWork(dispatch, CancelUploadCommand(upload));
+};
+
+export const uploadError = ({message_type, message, title, upload}) => (
+  dispatch
+) => {
   dispatch(showDialog(message_type, title, message));
-}
+};

--- a/metis/webpack.config.js
+++ b/metis/webpack.config.js
@@ -11,14 +11,20 @@
 var path = require('path');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 const EventHooksPlugin = require('event-hooks-webpack-plugin');
-const fs = require('fs-extra')
+const fs = require('fs-extra');
 
 module.exports = {
   context: path.resolve(__dirname),
   resolve: {
     extensions: ['.js', '.jsx'],
     alias: {
-      'font-awesome': path.join(__dirname, 'node_modules/@fortawesome/fontawesome-free')
+      'font-awesome': path.join(
+        __dirname,
+        'node_modules/@fortawesome/fontawesome-free'
+      ),
+      react: path.join(__dirname, 'node_modules/react'),
+      'react-dom': path.join(__dirname, 'node_modules/react-dom'),
+      'react-redux': path.join(__dirname, 'node_modules/react-redux')
     },
     symlinks: false
   },
@@ -29,7 +35,7 @@ module.exports = {
   output: {
     path: __dirname,
     filename: 'public/js/[name].bundle.js',
-    publicPath: '/js/',
+    publicPath: '/js/'
   },
   module: {
     rules: [
@@ -40,19 +46,19 @@ module.exports = {
           path.resolve(__dirname, 'node_modules/downzip/'),
           path.resolve(__dirname, 'lib/client/jsx')
         ],
-        test: /\.jsx?$/,
+        test: /\.jsx?$/
       },
       {
         loader: 'file-loader',
         test: /\.(jpe?g|png|svg)$/i,
-        include: [
-          path.resolve(__dirname, 'lib/client/images'),
-        ],
+        include: [path.resolve(__dirname, 'lib/client/images')],
         options: {
           name: '[name].[ext]',
           outputPath: 'public/images/',
           publicPath: function (url) {
-            return url.match(/^public/) ? url.replace(/public/, '') : `/images/${url}`
+            return url.match(/^public/)
+              ? url.replace(/public/, '')
+              : `/images/${url}`;
           }
         }
       },
@@ -70,7 +76,9 @@ module.exports = {
           name: '[name].[ext]',
           outputPath: 'public/fonts/',
           publicPath: function (url) {
-            return url.match(/^public/) ? url.replace(/public/, '') : `/fonts/${url}`
+            return url.match(/^public/)
+              ? url.replace(/public/, '')
+              : `/fonts/${url}`;
           }
         }
       },
@@ -84,15 +92,16 @@ module.exports = {
     ]
   },
   plugins: [
-    new ExtractTextPlugin({ // define where to save the file
+    new ExtractTextPlugin({
+      // define where to save the file
       filename: 'public/css/metis.bundle.css',
-      allChunks: true,
+      allChunks: true
     }),
     new EventHooksPlugin({
       'after-emit': (compilation, done) => {
-        console.log('\n\nCopying source files to compiled\n\n')
+        console.log('\n\nCopying source files to compiled\n\n');
         fs.copy('downzip-sw.js', 'public/js/downzip-sw.js', done);
       }
     })
   ]
-}
+};


### PR DESCRIPTION
This PR hooks the `UploadControl` component's Pause button into the upload dispatcher, and addresses mountetna/metis#94. Before this change, the pause button was not dispatching actions, and it was not possible to pause uploads.

To test, you can verify that the pause button now pauses large uploads when clicked, and the play button that replaces it continues the upload.