### PR TITLE
only show timur attributes that are not hidden

### DIFF
--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import AttributeViewer from '../attributes/attribute_viewer';
 
 const PaneAttribute = ({attribute, mode, value, revised_value, model_name, record_name, template, record}) => (
-  (attribute.shown != false && (mode != 'edit' || attribute.editable)) ?
+  (attribute.hidden !== true && (mode != 'edit' || attribute.editable)) ?
     <div className='attribute_row'>
       <div className={ `attribute_name ${ (mode == 'edit' && value != revised_value) ? 'revised' : '' }` }
         title={attribute.desc}>


### PR DESCRIPTION
This PR updates the Timur attribute flag used to detect if it should render the attribute. In the past, `attribute.shown` was set by Magma. That has since been changed to `attribute.hidden`, so this PR updates that test.

For example, `created_at` and `updated_at` are sent by Magma with `hidden` set to `true`. Those should not appear in the attributes shown in Timur.