### PR TITLE
Re-enable bin/console

### DIFF
--- a/timur/lib/commands.rb
+++ b/timur/lib/commands.rb
@@ -78,7 +78,6 @@ class Timur
     def setup(config)
       super
       Timur.instance.setup_db
-      Timur.instance.setup_magma
     end
   end
 


### PR DESCRIPTION
The removal of Magma::Client in favor of Etna::Client resulted in the loss of `bin/console`, which was still trying to setup the magma client and would crash. Removed here.