### PR TITLE
Support whitespaces escaped in magma retrieve

### DIFF
--- a/magma/lib/magma/retrieval.rb
+++ b/magma/lib/magma/retrieval.rb
@@ -183,6 +183,8 @@ class Magma
         match, att_name, operator, value = term.match(FILTER_TERM).to_a
         raise ArgumentError, "Filter term '#{term}' does not parse" if match.nil?
 
+        value = unescape(value)
+
         att = attributes.find{|a| a.name == att_name.to_sym}
         raise ArgumentError, "#{att_name} is not an attribute" unless att.is_a?(Magma::Attribute)
         case att
@@ -201,6 +203,11 @@ class Magma
         else
           raise ArgumentError, "Cannot query for #{att_name}"
         end
+      end
+
+      def unescape(value)
+        # spaces are escaped with a '-', and '-' is escaped with '--'
+        value.gsub(/--|-/, { '--' => '-', '-' => ' ' })
       end
 
       def string_op operator

--- a/magma/lib/magma/retrieval.rb
+++ b/magma/lib/magma/retrieval.rb
@@ -206,8 +206,8 @@ class Magma
       end
 
       def unescape(value)
-        # spaces are escaped with a '-', and '-' is escaped with '--'
-        value.gsub(/--|-/, { '--' => '-', '-' => ' ' })
+        # spaces are escaped with a '_', and '_' is escaped with '__'
+        value.gsub(/__|_/, { '__' => '_', '_' => ' ' })
       end
 
       def string_op operator

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -341,6 +341,20 @@ describe RetrieveController do
       expect(json_body[:models][:labor][:documents].count).to eq(2)
     end
 
+    it 'can filter with escaped spaces in the value' do
+      lion = create(:labor, :lion, name: 'L i-on')
+      retrieve(
+          project_name: 'labors',
+          model_name: 'labor',
+          record_names: 'all',
+          attribute_names: 'all',
+          filter: 'name~L-i--'
+      )
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:labor][:documents].count).to eq(1)
+    end
+
     it 'can filter on numbers' do
       poison = create(:prize, name: 'poison', worth: 5)
       poop = create(:prize, name: 'poop', worth: 0)

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -342,13 +342,13 @@ describe RetrieveController do
     end
 
     it 'can filter with escaped spaces in the value' do
-      lion = create(:labor, :lion, name: 'L i-on')
+      lion = create(:labor, :lion, name: 'L i_on')
       retrieve(
           project_name: 'labors',
           model_name: 'labor',
           record_names: 'all',
           attribute_names: 'all',
-          filter: 'name~L-i--'
+          filter: 'name~L_i__'
       )
 
       expect(last_response.status).to eq(200)

--- a/timur/lib/client/jsx/components/search/query_builder.jsx
+++ b/timur/lib/client/jsx/components/search/query_builder.jsx
@@ -10,7 +10,7 @@ import TreeView, {getSelectedLeaves} from 'etna-js/components/TreeView';
 import SelectInput from "../inputs/select_input";
 
 function escapeValueWhitespace(string) {
-  return string.replace(/[ \-]/, (v) => v === ' ' ? '-' : '--');
+  return string.replace(/[ \_]/, (v) => v === ' ' ? '_' : '__');
 }
 
 function escapeRegexValue(string) {

--- a/timur/lib/client/jsx/components/search/search_query.jsx
+++ b/timur/lib/client/jsx/components/search/search_query.jsx
@@ -19,7 +19,6 @@ export function SearchQuery({
 }) {
   const buttonDisabled = !selectedModel || loading;
   const buttonClasses = buttonDisabled ? 'button disabled' : 'button';
-  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const tableOptionsLine = <React.Fragment>
     <span className='label'>Show table</span>
@@ -63,25 +62,10 @@ export function SearchQuery({
     />
   </React.Fragment>;
 
-  const advancedSearch = <div>
-    <input
-      type='text'
-      className='filter'
-      placeholder='Filter query'
-      defaultValue={filter_string}
-      onBlur={(e) => setFilterString(e.target.value)}
-    />
-    <a className='pointer' onClick={() => setShowAdvanced(false)}>
-      Basic Search
-    </a>
-  </div>;
-
   return (
     <div className='query'>
       <CollapsibleArrow label={tableOptionsLine}>
-        { selectedModel && <div>
-          {showAdvanced ? advancedSearch : <QueryBuilder setShowAdvanced={setShowAdvanced} selectedModel={selectedModel} display_attributes={display_attributes} /> }
-        </div> }
+        { selectedModel && <QueryBuilder selectedModel={selectedModel} display_attributes={display_attributes} /> }
       </CollapsibleArrow>
     </div>
   );


### PR DESCRIPTION
1. Support whitespace in retrieve endpoints, escaped with '_'.  Supports escaping '_' as well to preserve ability to use those.
2. Advanced search shows column filtering