### PR TITLE
Add server_pidfile to config template

### DIFF
--- a/magma/config.yml.template
+++ b/magma/config.yml.template
@@ -15,6 +15,7 @@
     :host: metis.development.local
     :download_expiration: 1440
     :upload_expiration: 720
+  :server_pidfile: tmp/pids/puma.pid
   :token_algo: RS256
   :token_name: JANUS_DEV_TOKEN
   :rsa_public: |


### PR DESCRIPTION
This PR adds a `server_pidfile` to the Magma config template. This setting is required to tell Magma where to find the Puma pid file, so that it can restart the server when using the new `update_model_actions` route (`add_model`, `add_attribute`, etc.).

If this configuration setting is not present, any attempt to use `update_model_actions` will result in a vague and confusing error message like:

```
[{"message":"Unexpected error","source":null,"reason":"no implicit conversion of nil into String"}] (Etna::Error)
```