### PR TITLE
Magma fixes for model loading and project loading

### DIFF
--- a/magma/lib/magma/commands.rb
+++ b/magma/lib/magma/commands.rb
@@ -21,6 +21,11 @@ class Magma
       end
     end
 
+    def setup(config)
+      super
+      Magma.instance.setup_db
+    end
+
     private
 
     def load_model(project_name, model_name, template)

--- a/magma/lib/magma/project.rb
+++ b/magma/lib/magma/project.rb
@@ -62,12 +62,12 @@ class Magma
         dictionary(model_data[:dictionary].symbolize_keys) if model_data[:dictionary]
       end
 
-      project_container.const_set(model_data[:model_name].classify, model_class)
+      project_container.const_set(model_data[:model_name].camelize, model_class)
     end
 
     def unload_model(model_name)
       models.delete(model_name)
-      project_container.send(:remove_const, model_name.to_s.classify)
+      project_container.send(:remove_const, model_name.to_s.camelize)
     end
 
     private
@@ -99,7 +99,7 @@ class Magma
 
     def load_models
       Magma.instance.db[:models].where(project_name: @project_name.to_s).
-        reject { |model| project_container.const_defined?(model[:model_name].classify) }.
+        reject { |model| project_container.const_defined?(model[:model_name].camelize) }.
         each { |model| load_model(model) }
     end
 

--- a/magma/spec/magma_project_spec.rb
+++ b/magma/spec/magma_project_spec.rb
@@ -101,6 +101,13 @@ describe Magma::Project do
         updated_at: Time.now
       )
 
+      Magma.instance.db[:models].insert(
+          project_name: "movies",
+          model_name: "status",
+          created_at: Time.now,
+          updated_at: Time.now
+      )
+
       Magma.instance.db[:attributes].insert(
         project_name: "movies",
         model_name: "hero",
@@ -115,6 +122,8 @@ describe Magma::Project do
 
       expect(project.models[:hero]).to eq(Movies::Hero)
       expect(Movies::Hero.attributes[:name].description).to eq("The hero's name")
+
+      expect(project.models[:status]).to eq(Movies::Status)
     end
   end
 


### PR DESCRIPTION
Two quick but important fixes:

1.  load_project command was not working because Magma instance db wasn't be setup.  Makes me think we should write a test for this one day.
2.  When I did load mvir1 project into magma locally, magma failed to validate models.  I tracked it down to the load_model, which used `classify`.  Unfortunately, sequel's implementation of `classify` invokves a poor implementation of `singularize` which converts `Status` -> `Statu` and breaks things.  `camelize` is actually what we want --- whatever the name is in the model_name, we basically just want a camelized form of it.  Trying to change the casing or do other grammatic transformations is a recipe for danger.  This currently was not an issue in production only because mvir1::status was not defined in the models database table (currently relies on by hand model classes).  Since we will need to add it to the model table to support model book keeping going forward, fixing this is still important.