### PR TITLE
call upload_start in metis client, properly

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -660,6 +660,12 @@ EOT
 
       upload = Upload.new(actual_path)
 
+      upload_json = @shell.client.start_upload(upload_path, upload)
+      # start our upload
+
+      upload.current_byte_position = upload_json[:current_byte_position].to_i
+      upload.next_blob_size = upload_json[:next_blob_size].to_i
+
       max_number_attempts = MetisConfig[:max_attempts] || 2
       current_attempt_number = 1
 


### PR DESCRIPTION
I accidentally removed this code when fixing merge conflicts in #23. This replaced the required upload_start call to Metis for a file upload.