### PR TITLE
Log any rescued exceptions

### DIFF
--- a/magma/lib/magma/actions/add_attribute.rb
+++ b/magma/lib/magma/actions/add_attribute.rb
@@ -17,6 +17,7 @@ class Magma
     def save_attribute
       attribute.save
     rescue Sequel::ValidationFailed => e
+      Magma.instance.logger.log_error(e)
       @errors << Magma::ActionError.new(
         message: 'Create attribute failed',
         source: @action_params.slice(:project_name, :model_name),

--- a/magma/lib/magma/actions/model_update_actions.rb
+++ b/magma/lib/magma/actions/model_update_actions.rb
@@ -20,6 +20,8 @@ class Magma
         true
       end
     rescue => e
+      Magma.instance.logger.log_error(e)
+
       @actions.each(&:rollback)
 
       if @errors.empty?

--- a/magma/lib/magma/actions/update_attribute.rb
+++ b/magma/lib/magma/actions/update_attribute.rb
@@ -3,6 +3,8 @@ class Magma
     def perform
       attribute.update(@action_params.slice(*Magma::Attribute::EDITABLE_OPTIONS))
     rescue Sequel::ValidationFailed => e
+      Magma.instance.logger.log_error(e)
+
       @errors << Magma::ActionError.new(
         message: 'Update attribute failed',
         source: @action_params.slice(:attribute_name, :model_name),

--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -175,6 +175,7 @@ class Magma
       return unless validation
       validation_object
     rescue => e
+      Magma.instance.logger.log_error(e)
       errors.add(:validation, "is not properly formatted")
     end
 

--- a/magma/lib/magma/attributes/link.rb
+++ b/magma/lib/magma/attributes/link.rb
@@ -38,6 +38,7 @@ class Magma
       super
       link_model
     rescue => e
+      Magma.instance.logger.log_error(e)
       field = link_model_name ? :link_model_name : :attribute_name
       errors.add(field, "doesn't match an existing model")
     end

--- a/metis/lib/server/controllers/folder_controller.rb
+++ b/metis/lib/server/controllers/folder_controller.rb
@@ -127,6 +127,7 @@ class FolderController < Metis::Controller
         ## Note: find_or_create does not fix this, it still does not handle the unique constraint and simply
         ## queries or creates, which is not good enough for READ COMMITTED isolation where a read might not see a yet
         ## committed create.
+        Metis.instance.logger.log_error(e)
         parents << Metis::Folder.find(bucket_id: bucket&.id, folder_id: parents.last&.id, folder_name: folder_name)
       end
     end

--- a/timur/lib/models/archimedes/manifest.rb
+++ b/timur/lib/models/archimedes/manifest.rb
@@ -77,7 +77,7 @@ module Archimedes
       else
         raise Archimedes::LanguageError, "Type error in #{current_fragment}"
       end
-    rescue ZeroDivisionError
+    rescue ZeroDivisionError => e
       Timur.instance.logger.log_error(e)
       raise Archimedes::LanguageError, "Divided by zero in #{current_fragment}"
     rescue Exception => e

--- a/timur/lib/models/archimedes/manifest.rb
+++ b/timur/lib/models/archimedes/manifest.rb
@@ -59,23 +59,29 @@ module Archimedes
     def fill_manifest
       resolve(@manifest)
     rescue RLTK::NotInLanguage => e
+      Timur.instance.logger.log_error(e)
       current_position = e.current.position
       line = current_position.line_number
       position = current_position.line_offset
       raise Archimedes::LanguageError, "Syntax error in #{line_fragment(line,position)}"
     rescue Etna::Error => e
+      Timur.instance.logger.log_error(e)
       raise Archimedes::LanguageError, e.message
     rescue ArgumentError => e
+      Timur.instance.logger.log_error(e)
       raise Archimedes::LanguageError, "#{e.message} in #{current_fragment}"
     rescue TypeError => e
+      Timur.instance.logger.log_error(e)
       if e.message =~ /nil/
         raise Archimedes::LanguageError, "Nil value error in #{current_fragment}"
       else
         raise Archimedes::LanguageError, "Type error in #{current_fragment}"
       end
     rescue ZeroDivisionError
+      Timur.instance.logger.log_error(e)
       raise Archimedes::LanguageError, "Divided by zero in #{current_fragment}"
     rescue Exception => e
+      Timur.instance.logger.log_error(e)
       puts e.message
       puts e.backtrace
       raise Archimedes::LanguageError, "Unspecified error in #{current_fragment}"

--- a/timur/lib/server/controllers/archimedes_controller.rb
+++ b/timur/lib/server/controllers/archimedes_controller.rb
@@ -36,6 +36,7 @@ class ArchimedesController <  Timur::Controller
 
     success_json(consignments)
   rescue Archimedes::LanguageError => e
+    Timur.instance.logger.log_error(e)
     raise Etna::BadRequest, e.message.to_s
   end
 

--- a/timur/lib/server/controllers/manifests_controller.rb
+++ b/timur/lib/server/controllers/manifests_controller.rb
@@ -18,6 +18,7 @@ class ManifestsController < Timur::Controller
       manifest: @manifest.to_hash(current_user)
     )
   rescue Sequel::ValidationFailed => e
+    Timur.instance.logger.log_error(e)
     raise Etna::BadRequest, e.message
   end
 


### PR DESCRIPTION
Related to mountetna/magma#191, this adds logging for any Errors that happen in Timur, Metis, and Magma ,including the `update_model` route in Magma. Would have been helpful while I was trying to test adding models and attributes locally, but didn't realize I needed to add a config param.