### PR TITLE
add some tests around Metis Client...

### DIFF
--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.12)
+    etna (0.1.14)
       jwt
       multipart-post
       net-http-persistent

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -710,13 +710,16 @@ EOT
           break
         rescue MetisClient::UploadError => e
           puts "#{e.message}"
-          upload = Upload.new(actual_path)
-          upload_json = @shell.client.reset_upload(upload_path, upload)
-          upload.current_byte_position = 0
-
           current_attempt_number += 1
-          puts "UploadError -- retrying the upload" if current_attempt_number <= max_number_attempts
-          puts "UploadError -- max retries reached. Giving up." if current_attempt_number > max_number_attempts
+
+          if current_attempt_number <= max_number_attempts
+            puts "UploadError -- retrying the upload"
+            upload = Upload.new(actual_path)
+            upload_json = @shell.client.reset_upload(upload_path, upload)
+            upload.current_byte_position = 0
+          else
+            puts "UploadError -- max retries reached. Giving up."
+          end
         end
       end
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -89,16 +89,65 @@ describe MetisShell do
   end
 
   describe MetisShell::Put do
+    # WebMock does not handle multipart/form-data, so it
+    #   strips out the body data on those POST requests.
+    # So this is actually impossible to test except in
+    #   a 'production' environment.
     xit 'puts a file into a bucket' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_path = stubs.create_data('stubs', 'helmet.txt', HELMET)
       #expect_output("metis://athena/armor", "put", helmet_path) { '' }
       #expect(Metis::File.first.file_name).to eq('helmet.txt')
     end
+
+    it 'retries to upload a file into a bucket on a 422 response' do
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      helmet_path = stubs.create_data('stubs', 'helmet.txt', HELMET)
+
+      expect_output("metis://athena/armor", "put", helmet_path, '.') { nil }
+
+      # There is a call to authorize the upload
+      expect(WebMock).to have_requested(:post, /https:\/\/metis.test\/authorize\/upload/).
+        with(body: hash_including({
+          "project_name": "athena",
+          "bucket_name": "armor",
+          "file_path": "helmet.txt"
+        }))
+
+      # There is a non-reset call to start the upload
+      expect(WebMock).to have_requested(:post, /https:\/\/metis.test\/athena\/upload\/armor\/helmet.txt/).
+        with(query: hash_including({
+          "X-Etna-Id": "metis"
+        })).
+        with(headers: {
+          "Content-Type": "application/json"
+        }).
+        with { |req| (req.body.include? 'start') && !(req.body.include? 'reset')}
+
+      # There are two attempts to upload blobs. One for the original attempt,
+      #   and one for the retry.
+      expect(WebMock).to have_requested(:post, /https:\/\/metis.test\/athena\/upload\/armor\/helmet.txt/).
+        with(query: hash_including({
+          "X-Etna-Id": "metis"
+        })).
+        with(headers: {
+          "Content-Type": "multipart/form-data"
+        }).twice
+
+      # There is a call to reset the upload
+      expect(WebMock).to have_requested(:post, /https:\/\/metis.test\/athena\/upload\/armor\/helmet.txt/).
+        with(query: hash_including({
+          "X-Etna-Id": "metis"
+        })).
+        with(headers: {
+          "Content-Type": "application/json"
+        }).
+        with { |req| (req.body.include? 'start') && (req.body.include? 'reset')}
+    end
   end
 
   describe MetisShell::Get do
-    xit 'downloads a folder from a bucket' do
+    it 'downloads a folder from a bucket' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
@@ -106,12 +155,19 @@ describe MetisShell do
 
       # it shows download progress
       expect_output("metis://athena/armor", "get", "helmet", "spec/data") { /helmet.jpg/ }
-      expect(::File.read("spec/data/helmet/helmet.jpg")).to eq(HELMET)
+
+      # This ideally would equal HELMET, but because we don't use Apache X-Sendfile
+      #   while testing, no bits are sent by Metis and the local file has no data.
+      # expect(::File.read("spec/data/helmet/helmet.jpg")).to eq(HELMET)
+
+      expect(::File.read("spec/data/helmet/helmet.jpg")).to eq('')
 
       # cleanup
       FileUtils.rm_rf('spec/data/helmet')
     end
 
+    # We aren't able to test this because Metis uses Apache's X-Sendfile module
+    #   to send the actual bits. So we require a 'production' environment.
     xit 'does not download data twice' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
@@ -123,6 +179,26 @@ describe MetisShell do
 
       # second time it shows no progress
       expect_output("metis://athena/armor", "get", "helmet", "spec/data") { "" }
+
+      # cleanup
+      FileUtils.rm_rf('spec/data/helmet')
+    end
+
+    it 'will re-download data if the file size does not match' do
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
+      stubs.create_file('athena', 'files', 'armor/helmet/helmet.jpg', HELMET)
+
+      # first time it shows download progress
+      expect_output("metis://athena/armor", "get", "helmet", "spec/data") { /helmet.jpg/ }
+
+      # At this point there will be a file created locally, but it will be 0 bytes
+      #   because no bits are sent. So the file size will not be matched with remote
+      #   and calling the command again should result in a re-download.
+
+      # second time it still shows download progress
+      expect_output("metis://athena/armor", "get", "helmet", "spec/data") { /helmet.jpg/ }
 
       # cleanup
       FileUtils.rm_rf('spec/data/helmet')


### PR DESCRIPTION
This PR adds some testing around the Metis Client. Ideally the tests would be more ignorant of the underlying implementation, but there are some challenges to testing Metis Client:

1) Without Apache X-Sendfile module in the loop, any GET request for a file does not actually send the file back. So the file is created by the client, but with 0 bytes.
2) [WebMock does not support multipart/form-data bodies](https://github.com/vcr/vcr/issues/295#issuecomment-20181472), either in stubbing or in mocking Net HTTP Post requests. So we can't Post blobs to the Metis API in CI testing right now, so the new test just makes sure that the APIs are called correctly.

So this PR is meant as a lets-have-something testing step, that should help us catch some Metis Client bugs. But to make it better we would probably have to run smoke-tests on a server somewhere instead of via CI.