### PR TITLE
Metis Thumbnails

### DIFF
--- a/metis/Gemfile
+++ b/metis/Gemfile
@@ -7,6 +7,8 @@ gem 'pg'
 gem 'sequel'
 gem 'fog-aws'
 gem 'etna'
+gem 'ruby-vips'
+gem 'mimemagic'
 
 group :test do
   gem 'rspec'

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     excon (0.73.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
+    ffi (1.13.1)
     fog-aws (3.6.5)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -56,6 +57,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
+    mimemagic (0.3.5)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     multi_json (1.14.1)
@@ -91,6 +93,8 @@ GEM
     rspec-support (3.9.3)
     ruby-debug-ide (0.7.2)
       rake (>= 0.8.1)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     safe_yaml (1.0.5)
     sequel (5.32.0)
     simplecov (0.18.5)
@@ -116,6 +120,7 @@ DEPENDENCIES
   etna
   factory_bot
   fog-aws
+  mimemagic
   pg
   pry
   pry-byebug
@@ -123,6 +128,7 @@ DEPENDENCIES
   rack-test
   rspec
   ruby-debug-ide
+  ruby-vips
   sequel
   simplecov
   timecop

--- a/metis/docker/app/Dockerfile.development
+++ b/metis/docker/app/Dockerfile.development
@@ -18,6 +18,8 @@ RUN apt-get update \
       libopenblas-base \
       libcurl4-openssl-dev \
       libssl-dev \
+      libvips \
+      libvips-dev \
       parallel \
       postgresql-client-10 \
       --no-install-recommends &&\

--- a/metis/docker/app/Dockerfile.development
+++ b/metis/docker/app/Dockerfile.development
@@ -19,7 +19,6 @@ RUN apt-get update \
       libcurl4-openssl-dev \
       libssl-dev \
       libvips \
-      libvips-dev \
       parallel \
       postgresql-client-10 \
       --no-install-recommends &&\

--- a/metis/lib/server/controllers/download_controller.rb
+++ b/metis/lib/server/controllers/download_controller.rb
@@ -14,17 +14,24 @@ class DownloadController < Metis::Controller
 
     raise Etna::Error.new('File not found', 404) unless file && file.has_data?
 
-    puts @params
     if @params.fetch(:thumbnail, nil)
-      puts file.data_block.location
       thumbnail = Vips::Image.thumbnail(file.data_block.location, 240)
-      puts thumbnail
-      puts thumbnail.filename
-      puts MimeMagic.by_path(file.file_name)
+      mimetype = MimeMagic.by_path(file.file_name)
+
+      case mimetype.to_s
+      when /jpe?g$/
+        buffer = thumbnail.jpegsave_buffer
+      when 'image/tiff'
+        buffer = thumbnail.tiffsave_buffer
+      when 'image/png'
+        buffer = thumbnail.pngsave_buffer
+      else
+        raise Etna::Error.new("Thumbnails not supported for mimetype #{mimetype}", 422)
+      end
       return [
         200,
-        { 'Content-Type' => MimeMagic.by_path(file.file_name) },
-        [ thumbnail.tiffsave_buffer ]
+        { 'Content-Type' => mimetype },
+        [ buffer ]
       ]
     end
 
@@ -33,5 +40,8 @@ class DownloadController < Metis::Controller
       { 'X-Sendfile' => file.data_block.location },
       [ '' ]
     ]
+  rescue Vips::Error => e
+    Metis.instance.logger.log_error(e)
+    raise Etna::Error.new('Unknown file format -- not supported with thumbnails', 422)
   end
 end

--- a/metis/lib/server/controllers/download_controller.rb
+++ b/metis/lib/server/controllers/download_controller.rb
@@ -1,3 +1,6 @@
+require 'mimemagic'
+require 'vips'
+
 class DownloadController < Metis::Controller
   # This is the endpoint that allows you to make a download.
   # You may call this with a token
@@ -10,6 +13,20 @@ class DownloadController < Metis::Controller
     file = Metis::File.from_path(bucket, @params[:file_path])
 
     raise Etna::Error.new('File not found', 404) unless file && file.has_data?
+
+    puts @params
+    if @params.fetch(:thumbnail, nil)
+      puts file.data_block.location
+      thumbnail = Vips::Image.thumbnail(file.data_block.location, 240)
+      puts thumbnail
+      puts thumbnail.filename
+      puts MimeMagic.by_path(file.file_name)
+      return [
+        200,
+        { 'Content-Type' => MimeMagic.by_path(file.file_name) },
+        [ thumbnail.tiffsave_buffer ]
+      ]
+    end
 
     return [
       200,

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -47,8 +47,8 @@ describe MetisShell do
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
       expect_output("metis://athena/armor", "ls", "-l") {
-        "metis  Jun 17 04:37    helmet/\n"+
-        "metis  Jun 17 04:37 helmet.jpg\n"
+        "metis    Jun 17 04:37    helmet/\n"+
+        "metis 13 Jun 17 04:37 helmet.jpg\n"
       }
       Timecop.return
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -47,8 +47,8 @@ describe MetisShell do
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
       expect_output("metis://athena/armor", "ls", "-l") {
-        "metis    Jun 17 04:37    helmet/\n"+
-        "metis 13 Jun 17 04:37 helmet.jpg\n"
+        "metis  Jun 17 04:37    helmet/\n"+
+        "metis  Jun 17 04:37 helmet.jpg\n"
       }
       Timecop.return
     end

--- a/metis/spec/download_spec.rb
+++ b/metis/spec/download_spec.rb
@@ -56,5 +56,14 @@ describe DownloadController do
 
       expect(last_response.status).to eq(401)
     end
+
+    it 'fails with the thumbnail query param if not a recognized image mimetype' do
+      create_file('labors', 'readme_hercules.txt', @tips)
+
+      hmac_header(params={thumbnail: true})
+      get('/labors/download/files/readme_hercules.txt')
+
+      expect(last_response.status).to eq(422)
+    end
   end
 end

--- a/metis/spec/download_spec.rb
+++ b/metis/spec/download_spec.rb
@@ -65,5 +65,16 @@ describe DownloadController do
 
       expect(last_response.status).to eq(422)
     end
+
+    it 'can fetch thumbnail version of a valid image mimetype' do
+      red_square_png = "\x89PNG\r\n\u001A\n\u0000\u0000\u0000\rIHDR\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0004\b\u0002\u0000\u0000\u0000&\x93\t)\u0000\u0000\u0001\x84iCCPICC profile\u0000\u0000(\x91}\x91=H\xC3@\u001C\xC5_ӊE*\x82\xED \xE2\u0010\xA4:Y\u0010\u0015q\xD4*\u0014\xA1B\xA9\u0015Zu0\xB9\xF4\v\x9A4$).\x8E\x82k\xC1\xC1\x8FŪ\x83\x8B\xB3\xAE\u000E\xAE\x82 \xF8\u0001\xE2\xE4\xE8\xA4\xE8\"%\xFE/)\xB4\x88\xF1\xE0\xB8\u001F\xEF\xEE=\xEE\xDE\u0001B\xA3\xC2T30\u000E\xA8\x9Ae\xA4\u0013q1\x9B[\u0015\xBB_\u0011D\u0000a\xF4cXb\xA6>\x97J%\xE19\xBE\xEE\xE1\xE3\xEB]\x8Cgy\x9F\xFBs\xF4*y\x93\u0001>\x91x\x96\xE9\x86E\xBCA<\xBDi\xE9\x9C\xF7\x89#\xAC$)\xC4\xE7\xC4c\u0006]\x90\xF8\x91\xEB\xB2\xCBo\x9C\x8B\u000E\v<3bd\xD2\xF3\xC4\u0011b\xB1\xD8\xC1r\a\xB3\x92\xA1\u0012O\u0011G\u0015U\xA3|!\xEB\xB2\xC2y\x8B\xB3Z\xA9\xB1\xD6=\xF9\vCyme\x99\xEB4\x87\x90\xC0\"\x96\x90\x82\b\u00195\x94Q\x81\x85\u0018\xAD\u001A)&Ҵ\u001F\xF7\xF0\u000F:\xFE\u0014\xB9dr\x95\xC1ȱ\x80*TH\x8E\u001F\xFC\u000F~wk\u0016&'ܤP\u001C\xE8z\xB1\xED\x8F\u0011\xA0{\u0017h\xD6m\xFB\xFBض\x9B'\x80\xFF\u0019\xB8\xD2\xDA\xFEj\u0003\x98\xF9$\xBD\xDE֢G@\xDF6pq\xDD\xD6\xE4=\xE0r\a\u0018x\xD2%Cr$?M\xA1P\u0000\xDE\xCF\xE8\x9Br@\xF8\u0016\xE8Ys{k\xED\xE3\xF4\u0001\xC8PW\xC9\e\xE0\xE0\u0010\u0018-R\xF6\xBAǻ\x83\x9D\xBD\xFD{\xA6\xD5\xDF\u000F9nr\x90݁ږ\u0000\u0000\u0000\tpHYs\u0000\u0000.#\u0000\u0000.#\u0001x\xA5?v\u0000\u0000\u0000\atIME\a\xE4\b\u0004\u0013\u0014&\u001C\xD0`#\u0000\u0000\u0000\u0014IDAT\b\xD7c|\xAE\xAA\xCA\u0000\u0003L\fH\u00007\a\u0000=X\u00019\u0014\u001Dh\u001C\u0000\u0000\u0000\u0000IEND\xAEB`\x82"
+      stubs.create_file('labors', 'files', 'red_square.png', red_square_png)
+      helmet_file = create_file('labors', 'red_square.png', red_square_png, bucket: default_bucket('labors'))
+
+      hmac_header(params={thumbnail: true})
+      get('/labors/download/files/red_square.png')
+
+      expect(last_response.status).to eq(200)
+    end
   end
 end

--- a/timur/lib/client/jsx/components/attributes/image_attribute.jsx
+++ b/timur/lib/client/jsx/components/attributes/image_attribute.jsx
@@ -2,18 +2,29 @@
 import * as React from 'react';
 import * as ReactRedux from 'react-redux';
 
-import FileAttribute from './file_attribute';
+import FileAttribute, {STUB} from './file_attribute';
 
 const ImageAttribute = (props) => {
-  // When we get thumbnails working, we can put this back into
-  //   expose those.
-  // if (mode != "edit") {
-  //   return <div className='attribute'> {
-  //     value
-  //       ? <a href={ value.url } ><img src={ value.thumb }/></a>
-  //       : <div className="document_empty">No file.</div>
-  //   } </div>
-  // }
+  let {mode, value} = props;
+  if (mode != 'edit') {
+    return (
+      <div className='attribute'>
+        {' '}
+        {value && value.path !== STUB ? (
+          <a href={value.url}>
+            <img
+              className='image-thumbnail'
+              src={`${value.url}&thumbnail=true`}
+            />
+          </a>
+        ) : value && value.path === STUB ? (
+          <span className='file-blank'> Blank file </span>
+        ) : (
+          <div className='document_empty'>No file</div>
+        )}{' '}
+      </div>
+    );
+  }
 
   return <FileAttribute {...props} />;
 };

--- a/timur/test/javascript/components/attributes/__snapshots__/image_attribute.test.js.snap
+++ b/timur/test/javascript/components/attributes/__snapshots__/image_attribute.test.js.snap
@@ -2,54 +2,46 @@
 
 exports[`ImageAttribute does not render action buttons while not editing 1`] = `
 <div
-  className="attribute file"
+  className="attribute"
 >
-  <span
-    className="file-missing"
+   
+  <a
+    href="https://example.com?HMAC-header=foo"
   >
-     No file 
-  </span>
+    <img
+      className="image-thumbnail"
+      src="https://example.com?HMAC-header=foo&thumbnail=true"
+    />
+  </a>
+   
 </div>
 `;
 
 exports[`ImageAttribute renders "missing file" correctly while not editing 1`] = `
 <div
-  className="attribute file"
+  className="attribute"
 >
-  <span
-    className="file-missing"
+   
+  <div
+    className="document_empty"
   >
-     No file 
-  </span>
+    No file
+  </div>
+   
 </div>
 `;
 
 exports[`ImageAttribute renders blank paths correctly while not editing 1`] = `
 <div
-  className="attribute file"
+  className="attribute"
 >
+   
   <span
     className="file-blank"
   >
      Blank file 
   </span>
-</div>
-`;
-
-exports[`ImageAttribute renders existing files correctly when not editing 1`] = `
-<div
-  className="attribute file"
->
-  <span
-    className="file-upload"
-  >
-     
-    conquest.txt
-     (
-    text/plain
-    )
-     
-  </span>
+   
 </div>
 `;
 
@@ -102,5 +94,22 @@ exports[`ImageAttribute renders the button bar while editing 1`] = `
   >
      No file 
   </span>
+</div>
+`;
+
+exports[`ImageAttribute renders thumbnail in view mode if file exists 1`] = `
+<div
+  className="attribute"
+>
+   
+  <a
+    href="https://example.com?HMAC-header=foo"
+  >
+    <img
+      className="image-thumbnail"
+      src="https://example.com?HMAC-header=foo&thumbnail=true"
+    />
+  </a>
+   
 </div>
 `;

--- a/timur/test/javascript/components/attributes/image_attribute.test.js
+++ b/timur/test/javascript/components/attributes/image_attribute.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
-import { mockStore } from '../../helpers';
+import {mount, shallow} from 'enzyme';
+import {mockStore} from '../../helpers';
 import renderer from 'react-test-renderer';
 import ButtonBar from '../../../../lib/client/jsx/components/button_bar';
-import { STUB } from '../../../../lib/client/jsx/components/attributes/file_attribute';
+import {STUB} from '../../../../lib/client/jsx/components/attributes/file_attribute';
 import ImageAttribute from '../../../../lib/client/jsx/components/attributes/image_attribute';
 
 import * as magmaActions from '../../../../lib/client/jsx/actions/magma_actions';
@@ -22,14 +22,14 @@ describe('ImageAttribute', () => {
   it('renders the button bar while editing', () => {
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
+        model_name='conquests'
+        record_name='Persia'
         template={null}
         value={null}
-        mode="edit"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
+        mode='edit'
+        attribute='gravatar'
+        document='Timur'
+        revised_value=''
         store={store}
       />
     );
@@ -40,14 +40,14 @@ describe('ImageAttribute', () => {
     const tree = renderer
       .create(
         <ImageAttribute
-          model_name="conquests"
-          record_name="Persia"
+          model_name='conquests'
+          record_name='Persia'
           template={null}
           value={null}
-          mode="edit"
-          attribute="gravatar"
-          document="Timur"
-          revised_value=""
+          mode='edit'
+          attribute='gravatar'
+          document='Timur'
+          revised_value=''
           store={store}
         />
       )
@@ -57,36 +57,82 @@ describe('ImageAttribute', () => {
   });
 
   it('does not render action buttons while not editing', () => {
-    const value = null;
+    const value = {
+      url: 'https://example.com?HMAC-header=foo'
+    };
 
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
+        model_name='conquests'
+        record_name='Persia'
         template={null}
         value={value}
-        mode="view"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
+        mode='view'
+        attribute='gravatar'
+        document='Timur'
+        revised_value=''
         store={store}
       />
     );
 
-    const buttons = component.find('file-buttons');
+    const buttons = component.find('.file-buttons');
     expect(buttons.exists()).toBeFalsy();
+
+    const thumbnail = component.find('.image-thumbnail');
+    expect(thumbnail.exists()).toBeTruthy();
 
     const tree = renderer
       .create(
         <ImageAttribute
-          model_name="conquests"
-          record_name="Persia"
+          model_name='conquests'
+          record_name='Persia'
           template={null}
           value={value}
-          mode="view"
-          attribute="gravatar"
-          document="Timur"
-          revised_value=""
+          mode='view'
+          attribute='gravatar'
+          document='Timur'
+          revised_value=''
+          store={store}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders thumbnail in view mode if file exists', () => {
+    const value = {
+      url: 'https://example.com?HMAC-header=foo'
+    };
+
+    const component = mount(
+      <ImageAttribute
+        model_name='conquests'
+        record_name='Persia'
+        template={null}
+        value={value}
+        mode='view'
+        attribute='gravatar'
+        document='Timur'
+        revised_value=''
+        store={store}
+      />
+    );
+
+    const thumbnail = component.find('.image-thumbnail');
+    expect(thumbnail.exists()).toBeTruthy();
+
+    const tree = renderer
+      .create(
+        <ImageAttribute
+          model_name='conquests'
+          record_name='Persia'
+          template={null}
+          value={value}
+          mode='view'
+          attribute='gravatar'
+          document='Timur'
+          revised_value=''
           store={store}
         />
       )
@@ -96,36 +142,18 @@ describe('ImageAttribute', () => {
   });
 
   it('renders blank paths correctly while not editing', () => {
-    let value = { path: '::blank' };
+    let value = {path: '::blank'};
 
     let component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
+        model_name='conquests'
+        record_name='Persia'
         template={null}
         value={value}
-        mode="view"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
-        store={store}
-      />
-    );
-
-    expect(component.text().trim()).toEqual('Blank file');
-
-    value = '::blank';
-
-    component = mount(
-      <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={null}
-        value={value}
-        mode="view"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
+        mode='view'
+        attribute='gravatar'
+        document='Timur'
+        revised_value=''
         store={store}
       />
     );
@@ -135,14 +163,14 @@ describe('ImageAttribute', () => {
     const tree = renderer
       .create(
         <ImageAttribute
-          model_name="conquests"
-          record_name="Persia"
+          model_name='conquests'
+          record_name='Persia'
           template={null}
           value={value}
-          mode="view"
-          attribute="gravatar"
-          document="Timur"
-          revised_value=""
+          mode='view'
+          attribute='gravatar'
+          document='Timur'
+          revised_value=''
           store={store}
         />
       )
@@ -156,14 +184,14 @@ describe('ImageAttribute', () => {
 
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
+        model_name='conquests'
+        record_name='Persia'
         template={null}
         value={value}
-        mode="view"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
+        mode='view'
+        attribute='gravatar'
+        document='Timur'
+        revised_value=''
         store={store}
       />
     );
@@ -173,56 +201,14 @@ describe('ImageAttribute', () => {
     const tree = renderer
       .create(
         <ImageAttribute
-          model_name="conquests"
-          record_name="Persia"
+          model_name='conquests'
+          record_name='Persia'
           template={null}
           value={value}
-          mode="view"
-          attribute="gravatar"
-          document="Timur"
-          revised_value=""
-          store={store}
-        />
-      )
-      .toJSON();
-
-    expect(tree).toMatchSnapshot();
-  });
-
-  it('renders existing files correctly when not editing', () => {
-    const value = new File(
-      ['Believe me, you are but pismire ant:'],
-      'conquest.txt',
-      { type: 'text/plain' }
-    );
-
-    const component = mount(
-      <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={null}
-        value={value}
-        mode="view"
-        attribute="gravatar"
-        document="Timur"
-        revised_value=""
-        store={store}
-      />
-    );
-
-    expect(component.text().trim()).toEqual('conquest.txt (text/plain)');
-
-    const tree = renderer
-      .create(
-        <ImageAttribute
-          model_name="conquests"
-          record_name="Persia"
-          template={null}
-          value={value}
-          mode="view"
-          attribute="gravatar"
-          document="Timur"
-          revised_value=""
+          mode='view'
+          attribute='gravatar'
+          document='Timur'
+          revised_value=''
           store={store}
         />
       )
@@ -234,14 +220,14 @@ describe('ImageAttribute', () => {
   it('accepts a valid Metis path', () => {
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={{ name: 'Conquests', identifier: 1 }}
+        model_name='conquests'
+        record_name='Persia'
+        template={{name: 'Conquests', identifier: 1}}
         value={null}
-        mode="edit"
-        attribute={{ name: 'ExpansionPlans' }}
-        document={{ '1': 'Timur' }}
-        revised_value=""
+        mode='edit'
+        attribute={{name: 'ExpansionPlans'}}
+        document={{'1': 'Timur'}}
+        revised_value=''
         store={store}
       />
     );
@@ -264,7 +250,7 @@ describe('ImageAttribute', () => {
         model_name: 'Conquests',
         record_name: 'Timur',
         revision: {
-          ['ExpansionPlans']: { path: 'metis://project/bucket/file_name.txt' }
+          ['ExpansionPlans']: {path: 'metis://project/bucket/file_name.txt'}
         }
       }
     ]);
@@ -273,14 +259,14 @@ describe('ImageAttribute', () => {
   it('shows an error message when given an invalid Metis path', () => {
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={{ name: 'Conquests', identifier: 1 }}
+        model_name='conquests'
+        record_name='Persia'
+        template={{name: 'Conquests', identifier: 1}}
         value={null}
-        mode="edit"
-        attribute={{ name: 'ExpansionPlans' }}
-        document={{ '1': 'Timur' }}
-        revised_value=""
+        mode='edit'
+        attribute={{name: 'ExpansionPlans'}}
+        document={{'1': 'Timur'}}
+        revised_value=''
         store={store}
       />
     );
@@ -303,14 +289,14 @@ describe('ImageAttribute', () => {
   it('dispatches an action to mark a file as blank', () => {
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={{ name: 'Conquests', identifier: 1 }}
+        model_name='conquests'
+        record_name='Persia'
+        template={{name: 'Conquests', identifier: 1}}
         value={null}
-        mode="edit"
-        attribute={{ name: 'ExpansionPlans' }}
-        document={{ '1': 'Timur' }}
-        revised_value=""
+        mode='edit'
+        attribute={{name: 'ExpansionPlans'}}
+        document={{'1': 'Timur'}}
+        revised_value=''
         store={store}
       />
     );
@@ -325,7 +311,7 @@ describe('ImageAttribute', () => {
         model_name: 'Conquests',
         record_name: 'Timur',
         revision: {
-          ['ExpansionPlans']: { path: STUB }
+          ['ExpansionPlans']: {path: STUB}
         }
       }
     ]);
@@ -334,14 +320,14 @@ describe('ImageAttribute', () => {
   it('dispatches an action to remove a file', () => {
     const component = mount(
       <ImageAttribute
-        model_name="conquests"
-        record_name="Persia"
-        template={{ name: 'Conquests', identifier: 1 }}
+        model_name='conquests'
+        record_name='Persia'
+        template={{name: 'Conquests', identifier: 1}}
         value={null}
-        mode="edit"
-        attribute={{ name: 'ExpansionPlans' }}
-        document={{ '1': 'Timur' }}
-        revised_value=""
+        mode='edit'
+        attribute={{name: 'ExpansionPlans'}}
+        document={{'1': 'Timur'}}
+        revised_value=''
         store={store}
       />
     );
@@ -356,7 +342,7 @@ describe('ImageAttribute', () => {
         model_name: 'Conquests',
         record_name: 'Timur',
         revision: {
-          ['ExpansionPlans']: { path: null }
+          ['ExpansionPlans']: {path: null}
         }
       }
     ]);


### PR DESCRIPTION
This PR enables thumbnail support in Metis for PNG, JPEG, and TIFF files via a `thumbnail=<anything>` URL param when used with the `download_file` route. Thumbnails are generated on the fly and served to the client. I've hardcoded the thumbnail width to be 240px, and the library keeps the aspect ratio.

Not sure if there are other image types we should support?

It also updates the `image_attribute` component in Timur to take advantage of this feature and shows it in the UI, like the previous behavior.

The Metis feature relies on the [vips](https://github.com/libvips/libvips) library, and so there is a related update to mountetna/cbc-chef#18.

