### PR TITLE
add command to delete orphaned data blocks

### DIFF
--- a/metis/bin/delete-orphan-data-blocks
+++ b/metis/bin/delete-orphan-data-blocks
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Should put this in CRONTAB?
+source ~/.bashrc
+
+cd $(dirname `dirname "$0"`)
+echo $(date)
+bin/metis delete_orphan_data_blocks

--- a/metis/bin/remove-orphan-data-blocks
+++ b/metis/bin/remove-orphan-data-blocks
@@ -5,4 +5,4 @@ source ~/.bashrc
 
 cd $(dirname `dirname "$0"`)
 echo $(date)
-bin/metis delete_orphan_data_blocks
+bin/metis remove_orphan_data_blocks

--- a/metis/config.yml.template
+++ b/metis/config.yml.template
@@ -29,7 +29,6 @@
 
 :development:
   :log_file: log/error.log
-  :md5_log_file: log/md5_deletions.log
   :auth_redirect: https://janus.development.local
   :token_name: JANUS_DEV_TOKEN
   :token_algo: RS256

--- a/metis/config.yml.template
+++ b/metis/config.yml.template
@@ -1,7 +1,7 @@
 ---
 :test:
   :log_file: /dev/null
-  :secret_key: 
+  :secret_key:
   :upload_expiration: 60
   :download_expiration: 60
   :metis_uid_name: METIS_TEST_UID
@@ -29,6 +29,7 @@
 
 :development:
   :log_file: log/error.log
+  :md5_log_file: log/md5_deletions.log
   :auth_redirect: https://janus.development.local
   :token_name: JANUS_DEV_TOKEN
   :token_algo: RS256
@@ -60,5 +61,5 @@
   :backup:
     :directory: 'metis-dev-ucsf-immunoprofiler-ipi'
     :credentials:
-      :aws_access_key_id: 
-      :aws_secret_access_key: 
+      :aws_access_key_id:
+      :aws_secret_access_key:

--- a/metis/db/migrations/021_add_data_block_removed.rb
+++ b/metis/db/migrations/021_add_data_block_removed.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+    change do
+      alter_table(:data_blocks) do
+        add_column :removed, TrueClass, default: false
+      end
+    end
+  end

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -164,7 +164,7 @@ class Metis
 
       logger = Etna::Logger.new(
         # The name of the log_file, required.
-        Metis.instance.config(:md5_log_file),
+        Metis.instance.config(:md5_log_file) || 'md5_deletions.log',
         # Number of old copies of the log to keep.
         Metis.instance.config(:md5_log_copies) || 5,
         # How large the log can get before overturning.

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -155,4 +155,20 @@ class Metis
       end
     end
   end
+
+  class DeleteOrphanDataBlocks < Etna::Command
+    usage '# delete unused (orphaned) data blocks'
+
+    def execute
+      used_data_block_ids = Metis::File.all().map { |file| file.data_block.id }.uniq
+      orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids).all
+      puts "Found #{orphaned_data_blocks.count} orphaned data blocks to be deleted."
+      orphaned_data_blocks.each(&:delete)
+    end
+
+    def setup(config)
+      super
+      Metis.instance.load_models
+    end
+  end
 end

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -162,10 +162,34 @@ class Metis
     def execute
       zero_hash = 'd41d8cd98f00b204e9800998ecf8427e'
 
+      logger = Etna::Logger.new(
+        # The name of the log_file, required.
+        Metis.instance.config(:md5_log_file),
+        # Number of old copies of the log to keep.
+        Metis.instance.config(:md5_log_copies) || 5,
+        # How large the log can get before overturning.
+        Metis.instance.config(:md5_log_size) || 1048576
+      )
+
+      logger.level = Logger::INFO
+
       used_data_block_ids = Metis::File.all().map { |file| file.data_block.id }.uniq
       orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids).exclude(md5_hash: zero_hash).all
-      puts "Found #{orphaned_data_blocks.count} orphaned data blocks to be deleted."
-      orphaned_data_blocks.each(&:delete)
+      count_message = "Found #{orphaned_data_blocks.count} orphaned data blocks to be deleted."
+      puts count_message
+      logger.info(count_message) if orphaned_data_blocks.count > 0
+      orphaned_data_blocks.each do |orphaned_data_block|
+        begin
+          md5_hash_to_delete = orphaned_data_block.md5_hash
+          orphaned_data_block.delete
+          delete_confirm_message = "Deleted data_block with hash #{md5_hash_to_delete}"
+          puts delete_confirm_message
+          logger.info(delete_confirm_message)
+        rescue Error => e
+          puts e.message
+          logger.error("Error deleting data_block with id #{orphaned_data_block.id}: #{e.message}")
+        end
+      end
     end
 
     def setup(config)

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -160,8 +160,10 @@ class Metis
     usage '# delete unused (orphaned) data blocks'
 
     def execute
+      zero_hash = 'd41d8cd98f00b204e9800998ecf8427e'
+
       used_data_block_ids = Metis::File.all().map { |file| file.data_block.id }.uniq
-      orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids).all
+      orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids).exclude(md5_hash: zero_hash).all
       puts "Found #{orphaned_data_blocks.count} orphaned data blocks to be deleted."
       orphaned_data_blocks.each(&:delete)
     end

--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -97,5 +97,18 @@ class Metis
         )
       )
     end
+
+    def remove!
+      delete_block!
+      update(removed: true)
+    end
+
+    private
+
+    def delete_block!
+      if ::File.exists?(location)
+        ::File.delete(location)
+      end
+    end
   end
 end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -47,8 +47,8 @@ describe MetisShell do
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
       expect_output("metis://athena/armor", "ls", "-l") {
-        "metis  Jun 17 04:37    helmet/\n"+
-        "metis  Jun 17 04:37 helmet.jpg\n"
+        "metis    Jun 17 04:37    helmet/\n"+
+        "metis 13 Jun 17 04:37 helmet.jpg\n"
       }
       Timecop.return
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -46,6 +46,8 @@ describe MetisShell do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
+      stubs.create_file('athena', 'armor', 'helmet.jpg', HELMET)
+
       expect_output("metis://athena/armor", "ls", "-l") {
         "metis    Jun 17 04:37    helmet/\n"+
         "metis 13 Jun 17 04:37 helmet.jpg\n"

--- a/metis/spec/data_block_spec.rb
+++ b/metis/spec/data_block_spec.rb
@@ -73,4 +73,38 @@ describe Metis::DataBlock do
       expect(@wisdom_data.archive_id).to eq('archive_id')
     end
   end
+
+  context '#remove!' do
+    it 'removes the data_block from disk and sets removed flag' do
+      wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      wisdom_data = wisdom_file.data_block
+
+      expect(::File.exists?(wisdom_data.location)).to eq(true)
+      expect(wisdom_data.removed).to eq(false)
+
+      wisdom_data.remove!
+
+      expect(::File.exists?(wisdom_data.location)).to eq(false)
+      expect(wisdom_data.removed).to eq(true)
+    end
+
+    it 'only changes removed flag if the block location does not exist on disk' do
+      wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      wisdom_data = wisdom_file.data_block
+
+      ::File.delete(wisdom_data.location)
+
+      expect(::File.exists?(wisdom_data.location)).to eq(false)
+      expect(wisdom_data.removed).to eq(false)
+
+      wisdom_data.remove!
+
+      expect(::File.exists?(wisdom_data.location)).to eq(false)
+      expect(wisdom_data.removed).to eq(true)
+    end
+  end
 end

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 describe 'Metis Commands' do
   describe Metis::RemoveOrphanDataBlocks do
     subject(:remove_orphan_data_blocks) { described_class.new.execute }

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -1,0 +1,164 @@
+describe 'Metis Commands' do
+  describe Metis::DeleteOrphanDataBlocks do
+    subject(:delete_orphan_data_blocks) { described_class.new.execute }
+
+    it "does not delete used data blocks" do
+        expected = "Found 0 orphaned data blocks to be deleted.\n"
+
+        @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+        stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+        @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
+        stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
+
+        expect(Metis::File.count).to eq(2)
+        expect(Metis::DataBlock.count).to eq(2)
+
+        expect {
+          delete_orphan_data_blocks
+        }.to output(expected).to_stdout
+
+        expect(Metis::File.count).to eq(2)
+        expect(Metis::DataBlock.count).to eq(2)
+
+        # Clean up the test
+        @wisdom_file.delete
+        @helmet_file.delete
+      end
+
+    it "deletes orphaned data blocks" do
+      expected = "Found 1 orphaned data blocks to be deleted.\n"
+
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
+      stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
+
+      expect(Metis::File.count).to eq(2)
+      expect(Metis::DataBlock.count).to eq(2)
+
+      @wisdom_file.update({data_block: @helmet_file.data_block})
+
+      expect {
+        delete_orphan_data_blocks
+      }.to output(expected).to_stdout
+
+      expect(Metis::File.count).to eq(2)
+      expect(Metis::DataBlock.count).to eq(1)
+
+      # Clean up the test
+      @wisdom_file.delete
+      @helmet_file.delete
+    end
+  end
+
+  let(:metis_instance) { double('Metis') }
+
+  describe Metis::Help do
+    subject(:help) { described_class.new.execute }
+
+    let(:command_double) { double('command', usage: 'Usage') }
+    let(:expected) { "Commands:\nUsage\n" }
+
+    before do
+      allow(Metis).to receive(:instance).and_return(metis_instance)
+      allow(metis_instance).to receive(:commands).and_return({"test" => command_double})
+    end
+
+    it "calls puts once for each command present" do
+      expect {
+        help
+      }.to output(expected).to_stdout
+    end
+  end
+
+  describe Metis::Migrate do
+    subject(:migrate) { described_class.new.execute(version) }
+    let(:directory) { "db/migrations" }
+
+    before do
+      Sequel.extension(:migration)
+      allow(Metis.instance).to receive(:db).and_return(metis_instance)
+    end
+
+    describe 'when a version is specified' do
+      let(:version) { '001' }
+
+      before do
+        allow(Sequel::Migrator).to receive(:run).with(metis_instance, directory, target: version.to_i).and_return(true)
+      end
+
+      it 'calls run with a version number' do
+        migrate
+
+        expect(Sequel::Migrator)
+        .to have_received(:run)
+        .with(metis_instance, directory, target: version.to_i)
+        .once
+      end
+    end
+
+    describe 'without a version specified' do
+      let(:version) { nil }
+
+      before do
+        allow(Sequel::Migrator).to receive(:run).with(metis_instance, directory).and_return(true)
+      end
+
+      it 'calls run without a version number' do
+        migrate
+
+        expect(Sequel::Migrator)
+        .to have_received(:run)
+        .with(metis_instance, directory)
+        .once
+      end
+    end
+  end
+
+  describe Metis::Console do
+    subject(:console) { described_class.new.execute }
+    before do
+      require 'irb'
+      allow(ARGV).to receive(:clear)
+      allow(IRB).to receive(:start)
+    end
+
+    it 'calls ARGV and IRB' do
+      console
+
+      expect(ARGV).to have_received(:clear).once
+      expect(IRB).to have_received(:start).once
+    end
+  end
+
+  describe Metis::CreateDb do
+    let(:createdb_instance) { described_class.new }
+    let(:config_double) { double('config') }
+    let(:expected) { "Database is setup. Please run `bin/metis migrate `.\n" }
+    subject(:create_db) { createdb_instance.execute() }
+
+    before do
+      allow(Metis).to receive(:instance).and_return(metis_instance)
+      allow(metis_instance).to receive(:config).with(:db).and_return({ database: 'database' })
+    end
+
+    describe 'with @no_db = true' do
+      before do
+        allow(metis_instance).to receive(:setup_db).and_raise Sequel::DatabaseConnectionError
+        allow(metis_instance).to receive(:configure).with(config_double)
+        createdb_instance.setup(config_double)
+        allow(createdb_instance).to receive(:create_db)
+      end
+
+      it 'calls create_db' do
+        expect {
+        create_db
+        }.to output(expected).to_stdout
+
+        expect(createdb_instance).to have_received(:create_db).once
+      end
+    end
+  end
+end

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -51,6 +51,38 @@ describe 'Metis Commands' do
       @wisdom_file.delete
       @helmet_file.delete
     end
+
+    it "does not delete the zero-hash data block" do
+        expected = "Found 0 orphaned data blocks to be deleted.\n"
+
+        zero_hash = 'd41d8cd98f00b204e9800998ecf8427e'
+
+        @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+        stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+        @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
+        stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
+
+        @zero_hash_data_block = create(:data_block,
+          description: 'zero-byte hash',
+          md5_hash: zero_hash
+        )
+
+        expect(Metis::File.count).to eq(2)
+        expect(Metis::DataBlock.count).to eq(3)
+
+        expect {
+          delete_orphan_data_blocks
+        }.to output(expected).to_stdout
+
+        expect(Metis::File.count).to eq(2)
+        expect(Metis::DataBlock.count).to eq(3)
+
+        # Clean up the test
+        @wisdom_file.delete
+        @helmet_file.delete
+        @zero_hash_data_block.delete
+      end
   end
 
   let(:metis_instance) { double('Metis') }

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -3,37 +3,37 @@ describe 'Metis Commands' do
     subject(:delete_orphan_data_blocks) { described_class.new.execute }
 
     it "does not delete used data blocks" do
-        expected = "Found 0 orphaned data blocks to be deleted.\n"
-
-        @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
-        stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
-
-        @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
-        stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
-
-        expect(Metis::File.count).to eq(2)
-        expect(Metis::DataBlock.count).to eq(2)
-
-        expect {
-          delete_orphan_data_blocks
-        }.to output(expected).to_stdout
-
-        expect(Metis::File.count).to eq(2)
-        expect(Metis::DataBlock.count).to eq(2)
-
-        # Clean up the test
-        @wisdom_file.delete
-        @helmet_file.delete
-      end
-
-    it "deletes orphaned data blocks" do
-      expected = "Found 1 orphaned data blocks to be deleted.\n"
+      expected = "Found 0 orphaned data blocks to be deleted.\n"
 
       @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
 
       @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
       stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
+
+      expect(Metis::File.count).to eq(2)
+      expect(Metis::DataBlock.count).to eq(2)
+
+      expect {
+        delete_orphan_data_blocks
+      }.to output(expected).to_stdout
+
+      expect(Metis::File.count).to eq(2)
+      expect(Metis::DataBlock.count).to eq(2)
+
+      # Clean up the test
+      @wisdom_file.delete
+      @helmet_file.delete
+    end
+
+    it "deletes orphaned data blocks" do
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET)
+      stubs.create_file('athena', 'files', 'helmet.jpg', HELMET)
+
+      expected = "Found 1 orphaned data blocks to be deleted.\nDeleted data_block with hash #{@wisdom_file.data_block.md5_hash}\n"
 
       expect(Metis::File.count).to eq(2)
       expect(Metis::DataBlock.count).to eq(2)


### PR DESCRIPTION
I think a "delete orphaned data blocks" command might be helpful as we transition to the new Magma-Metis data deletion scheme, and maybe as a regular garbage-collection task to run. There are already orphaned data blocks that we should remove and not back up (see Kanban card). 

This PR adds a Metis command to detect and remove orphaned data_blocks, where orphaned means the data_block is not referred to by any Metis::File. It does not delete the zero-byte data_block, which is a generic pointer (like `/dev/null`) and could have no file references at any given moment though we don't want to remove it.

The new behavior is that:

1) The data_block is removed from disk.
2) The Database entry data_block is kept (with corresponding md5_hash), but has a `removed` boolean flag set to `true` in the database. This can then be used for auditing the data deletion and preventing re-uploads.

Also adds some tests around the commands (copied from Magma).

I think the new Magma -> Metis annotation scheme will overtake this in time and may make this command irrelevant once all the data blocks are clean and consistent.