### PR TITLE
Adding waiver warning in search and browser

### DIFF
--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -36,6 +36,7 @@ import {
   selectTemplate, selectDocument, selectRevision
 } from '../../selectors/magma';
 import { selectUserProjectRole } from '../../selectors/user_selector';
+import {showMessages} from "../../actions/message_actions";
 
 class Browser extends React.Component{
   constructor(props){
@@ -129,7 +130,14 @@ class Browser extends React.Component{
         attribute_names,
         exchange_name,
         success: this.browseMode.bind(this)
-      });
+      }).then(payload => {
+        let model = payload.models[model_name];
+        if (TIMUR_CONFIG.project_name === 'mvir1' && model_name === 'patient') {
+          if (Object.values(model.documents).find(({ consent }) => consent === 'Initial Waiver')) {
+            showMessages(['This patient has not completed their consent form!'])
+          }
+        }
+      })
     }
   }
 
@@ -248,6 +256,8 @@ export default connect(
   // map dispatch
   {
     requestPlots, requestManifests, requestView, requestAnswer,
-    requestDocuments, discardRevision, sendRevisions, setLocation
+    requestDocuments, discardRevision, sendRevisions, setLocation,
+    showMessages,
   }
 )(Browser);
+

--- a/timur/lib/client/jsx/components/search/query_builder.jsx
+++ b/timur/lib/client/jsx/components/search/query_builder.jsx
@@ -56,7 +56,7 @@ export function QueryBuilder({ display_attributes, setFilterString, selectedMode
   }, [setFilterString, filtersState]);
 
   const onOpenAttributeFilter = () => {
-    openModal(<FilterAttributesModal display_attributes={display_attributes} />);
+    openModal(<FilterAttributesModal display_attributes={display_attributes} selectedModel={selectedModel} />);
   };
 
   const onOpenFilters = () => {
@@ -81,14 +81,19 @@ export function QueryBuilder({ display_attributes, setFilterString, selectedMode
   </div>;
 }
 
-function FilterAttributesModal({ setSearchAttributeNames, display_attributes, attributeNames, attributeNamesAndTypes }) {
+function disabledAttributeForProject(projectName, modelName) {
+  return ([name, type]) => type === 'identifier' || type === 'parent' ||
+    (projectName === 'mvir1' && modelName === 'patient' && name === 'consent')
+}
+
+function FilterAttributesModal({ setSearchAttributeNames, display_attributes, attributeNames, attributeNamesAndTypes, selectedModel }) {
   const displayAttributeOptions = [['All', display_attributes.map(e => [e])]];
   const { dismissModal } = useModal();
   const [selectedState, setSelectedState] = useState(() => attributeNamesToSelected(attributeNames));
 
   const disabledAttributeNames = useMemo(() => {
     return attributeNamesAndTypes
-      .filter(([_, type]) => type === 'identifier' || type === 'parent')
+      .filter(disabledAttributeForProject(TIMUR_CONFIG.project_name, selectedModel))
       .map(([name]) => name);
   }, [attributeNamesAndTypes]);
 

--- a/timur/lib/client/jsx/components/search/search.jsx
+++ b/timur/lib/client/jsx/components/search/search.jsx
@@ -39,6 +39,7 @@ import ModelViewer from '../model_viewer';
 import useAsyncWork from "etna-js/hooks/useAsyncWork";
 import SearchQuery from "./search_query";
 import {Loading} from "etna-js/components/Loading";
+import {showMessages} from "../../actions/message_actions";
 
 const spinnerCss = css`
   display: block;
@@ -53,11 +54,10 @@ const loadingSpinner =
     loading={true}
   />
 
-
 export function Search({
   queryableAttributes, cache, requestDocuments, setSearchPageSize, cacheSearchPage, setSearchPage,
   selectedModel, requestModels, emptySearchCache, setSearchAttributeNames, filter_string,
-  setSelectedModel, display_attributes, attributesNamesState,
+  setSelectedModel, display_attributes, attributesNamesState, showMessages
 }) {
   const [pageSize, setPageSize] = useState(10);
   const [results, setResults] = useState(0);
@@ -96,6 +96,14 @@ export function Search({
 
     let model = payload.models[selectedModel];
     if ('count' in model) setResults(model.count);
+
+
+    if (TIMUR_CONFIG.project_name === 'mvir1' && selectedModel === 'patient') {
+      if (Object.values(model.documents).find(({ consent }) => consent === 'Initial Waiver')) {
+        showMessages(['One or more patients in this result set are still in Initial Waiver status!'])
+      }
+    }
+
     setLastLoadedAttributeState(attributesNamesState);
     cacheSearchPage(
       page,
@@ -194,5 +202,6 @@ export default connect(
     requestDocuments,
     requestTSV,
     setSelectedModel,
+    showMessages,
   }
 )(Search);


### PR DESCRIPTION
Quick hack in for https://www.notion.so/ucsfdatascience/dff110a355f44962a8c7c21b754e0256?v=1931f65e395242bd964f71640382a19e&p=dd8065a5ba434e86a2e0905138620d47

1.  In search, if any patient row contains a Waiver status, show warning.
2.  In browser for patient, if they have Waiver status, show warning.
3.  Disable unselection for consent value from columns.