### PR TITLE
track time of removal

### DIFF
--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -100,7 +100,7 @@ class Metis
 
     def remove!
       delete_block!
-      update(removed: true)
+      update(removed: true, updated_at: DateTime.now)
     end
 
     private

--- a/metis/spec/data_block_spec.rb
+++ b/metis/spec/data_block_spec.rb
@@ -76,6 +76,8 @@ describe Metis::DataBlock do
 
   context '#remove!' do
     it 'removes the data_block from disk and sets removed flag' do
+      @creation_time = DateTime.now - 10
+      Timecop.freeze(@creation_time)
       wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
 
@@ -83,11 +85,17 @@ describe Metis::DataBlock do
 
       expect(::File.exists?(wisdom_data.location)).to eq(true)
       expect(wisdom_data.removed).to eq(false)
+      expect(wisdom_data.updated_at.iso8601).to eq(@creation_time.to_s)
+
+      @update_time = DateTime.now
+      Timecop.freeze(@update_time)
 
       wisdom_data.remove!
 
       expect(::File.exists?(wisdom_data.location)).to eq(false)
       expect(wisdom_data.removed).to eq(true)
+      expect(wisdom_data.updated_at.iso8601).to eq(@update_time.to_s)
+      Timecop.return
     end
 
     it 'only changes removed flag if the block location does not exist on disk' do


### PR DESCRIPTION
Inspired by @corps 's work on #50, we should certainly update and track the time of removal for a data_block for auditing purposes.