### PR TITLE
set up logger for remove orphan command

### DIFF
--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -178,6 +178,7 @@ class Metis
 
     def setup(config)
       super
+      Metis.instance.setup_logger
       Metis.instance.load_models
     end
   end


### PR DESCRIPTION
Neglected to call `setup_logger` since it is not automatically invoked as part of the application (only automatically for servers).