### PR TITLE
Prevent re-removing data blocks

### DIFF
--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -163,7 +163,7 @@ class Metis
       zero_hash = 'd41d8cd98f00b204e9800998ecf8427e'
 
       used_data_block_ids = Metis::File.all().map { |file| file.data_block.id }.uniq
-      orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids, removed: false).exclude(md5_hash: zero_hash).all
+      orphaned_data_blocks = Metis::DataBlock.exclude(id: used_data_block_ids).exclude(removed: true).exclude(md5_hash: zero_hash).all
       Metis.instance.logger.info("Found #{orphaned_data_blocks.count} orphaned data blocks to be removed.") if orphaned_data_blocks.count > 0
       orphaned_data_blocks.each do |orphaned_data_block|
         begin

--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -99,8 +99,10 @@ class Metis
     end
 
     def remove!
-      delete_block!
-      update(removed: true, updated_at: DateTime.now)
+      if !removed
+        delete_block!
+        update(removed: true, updated_at: DateTime.now)
+      end
     end
 
     private

--- a/metis/spec/data_block_spec.rb
+++ b/metis/spec/data_block_spec.rb
@@ -114,5 +114,28 @@ describe Metis::DataBlock do
       expect(::File.exists?(wisdom_data.location)).to eq(false)
       expect(wisdom_data.removed).to eq(true)
     end
+
+    it 'does not execute anything if block already removed' do
+      past_time = DateTime.now - 10
+      Timecop.freeze(past_time)
+      wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      wisdom_data = wisdom_file.data_block
+      wisdom_data.update(removed: true)
+
+      expect(::File.exists?(wisdom_data.location)).to eq(true)
+      expect(wisdom_data.removed).to eq(true)
+      expect(wisdom_data.updated_at.iso8601).to eq(past_time.to_s)
+
+      Timecop.return
+
+      wisdom_data.remove!
+
+      # Since no action should have been taken
+      expect(::File.exists?(wisdom_data.location)).to eq(true)
+      expect(wisdom_data.removed).to eq(true)
+      expect(wisdom_data.updated_at.iso8601).to eq(past_time.to_s)
+    end
   end
 end


### PR DESCRIPTION
The metis command for removing orphaned blocks was re-removing data blocks, so messing up the `updated_at` time. This fixes that so that data_blocks are only removed once. Also prevents that behavior in the block's `remove!` method itself.