### PR TITLE
delete data block archives on Glacier

### DIFF
--- a/metis/lib/archiver.rb
+++ b/metis/lib/archiver.rb
@@ -31,7 +31,7 @@ class Metis
 
     def delete(data_block)
       raise ArgumentError, "No vault defined!" unless @config
-      raise ArgumentError, "Data block not archived!" unless data_block.archive_id
+      return unless data_block.archive_id
 
       archive = vault.archives.get(data_block.archive_id)
       archive.destroy

--- a/metis/lib/archiver.rb
+++ b/metis/lib/archiver.rb
@@ -29,6 +29,14 @@ class Metis
       data_block.save
     end
 
+    def delete(data_block)
+      raise ArgumentError, "No vault defined!" unless @config
+      raise ArgumentError, "Data block not archived!" unless data_block.archive_id
+
+      archive = vault.archives.get(data_block.archive_id)
+      archive.destroy
+    end
+
     private
 
     def vault

--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -102,6 +102,7 @@ class Metis
       if !removed
         delete_block!
         update(removed: true, updated_at: DateTime.now)
+        Metis.instance.archiver.delete(self) if archive_id
       end
     end
 

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -33,6 +33,8 @@ describe 'Metis Commands' do
     end
 
     it "removes orphaned data blocks" do
+      glacier_stub('metis-test-athena')
+
       @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
 
@@ -45,6 +47,7 @@ describe 'Metis Commands' do
       wisdom_block_md5_hash = @wisdom_file.data_block.md5_hash
       wisdom_file_block_location = @wisdom_file.data_block.location
       helmet_file_block_location = @helmet_file.data_block.location
+      @wisdom_file.data_block.update(archive_id: 'archive_id')
 
       expect(::File.exists?(wisdom_file_block_location)).to eq(true)
       expect(::File.exists?(helmet_file_block_location)).to eq(true)

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -173,6 +173,12 @@ def glacier_stub(vault_name)
       'Content-Type': 'application/json',
     }
   )
+  stub_glacier_method(:delete, "/#{vault_name}/archives/archive_id",
+    status: 204,
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  )
 end
 
 def stub_glacier_method(method, path, response={})


### PR DESCRIPTION
This PR won't remove the archives associated with the orphaned data blocks that I removed earlier this week, but should take care of cleaning up the archives in the future.

When a data_block is removed, the corresponding archive on Glacier should also be scheduled for removal.