### PR TITLE
Cs/rename folders across buckets

### DIFF
--- a/metis/lib/folder_rename_revision.rb
+++ b/metis/lib/folder_rename_revision.rb
@@ -1,0 +1,26 @@
+require_relative 'folder_revision'
+
+class Metis
+  class FolderRenameRevision < FolderRevision
+    def revise!
+      raise 'Invalid revision, cannot revise!' unless valid?
+      raise 'Cannot revise without a user' unless @user
+
+      # Have to fetch the actual source folder. What gets
+      #   set in the revision's source.folder attribute
+      #   is the parent folder, which
+      #   we don't need at this point.
+      source_folder = Metis::Folder.from_path(
+        @source.bucket, full_folder_path(@source)).last
+
+      if @source.mpath.bucket_name == @dest.mpath.bucket_name
+        source_folder.rename!(@dest.folder, @dest.mpath.file_name)
+      else
+        source_folder.update_bucket_and_rename!(
+          @dest.folder, @dest.mpath.file_name, @dest.bucket)
+      end
+
+      return source_folder
+    end
+  end
+end

--- a/metis/lib/folder_revision.rb
+++ b/metis/lib/folder_revision.rb
@@ -1,0 +1,98 @@
+require_relative 'revision'
+
+class Metis
+  class FolderRevision < Revision
+    def validate
+      @errors = []
+      validate_source(@source)
+      validate_dest(@dest)
+    end
+
+    def bucket_names
+      # This is kind of weird, but we need the ability to grab
+      #   all relevant bucket names, even before validation of
+      #   the CopyRevision.
+      # So, if @dest doesn't exist, we don't return it
+      source_bucket_names = super
+      if @dest.mpath.valid?
+        return source_bucket_names.push(@dest.mpath.bucket_name)
+      end
+      return source_bucket_names
+    end
+
+    def mpaths
+      source_mpaths = super
+      source_mpaths.push(@dest.mpath) if @dest.mpath.valid?
+      return source_mpaths
+    end
+
+    def to_hash
+      {
+        dest: @dest.mpath.path,
+        source: @source.mpath.path,
+        errors: @errors
+      }
+    end
+
+    private
+
+    def full_folder_path(mpath_w_objs)
+      mpath_w_objs.mpath.folder_path ?
+        "#{mpath_w_objs.mpath.folder_path}/#{mpath_w_objs.mpath.file_name}" :
+        mpath_w_objs.mpath.file_name
+    end
+
+    def validate_target_folder(mpath_w_objs, folder_check_type='source')
+      # NOTE: the "mpath_w_objs.folder" is the parent folder, not the
+      #   actual folder, so we have to account for that in the validations.
+      errors_found = false
+
+      target_folder = Metis::Folder.from_path(
+        mpath_w_objs.bucket,
+        full_folder_path(mpath_w_objs)).last
+
+      if !target_folder
+        @errors.push("Folder not found: \"#{mpath_w_objs.mpath.path}\"")
+        errors_found = true
+      end
+
+      if target_folder&.read_only? && folder_check_type == 'source'
+        @errors.push("Folder \"#{mpath_w_objs.mpath.path}\" is read-only")
+        errors_found = true
+      end
+
+      return errors_found
+    end
+
+    def validate_dest_file(mpath_w_objs)
+      # Because we don't want users overwriting files with a folder
+      errors_found = false
+
+      file = Metis::File.from_folder(
+        mpath_w_objs.bucket,
+        mpath_w_objs.folder,
+        mpath_w_objs.mpath.file_name)
+
+      if file&.has_data?
+        @errors.push("Cannot overwrite existing file: \"#{mpath_w_objs.mpath.path}\"")
+        errors_found = true
+      end
+
+      return errors_found
+    end
+
+    def validate_source (source_mpath_w_objs)
+      return unless validate_mpath(source_mpath_w_objs.mpath)
+      return unless validate_bucket(source_mpath_w_objs)
+      return unless validate_target_folder(source_mpath_w_objs, 'source')
+      return unless validate_folder(source_mpath_w_objs, 'source')
+    end
+
+    def validate_dest (dest_mpath_w_objs)
+      return unless validate_mpath(dest_mpath_w_objs.mpath)
+      return unless validate_bucket(dest_mpath_w_objs)
+      return unless validate_folder(dest_mpath_w_objs, 'dest')
+      return unless validate_dest_file(dest_mpath_w_objs)
+    end
+  end
+end

--- a/metis/lib/folder_revision.rb
+++ b/metis/lib/folder_revision.rb
@@ -37,14 +37,19 @@ class Metis
     private
 
     def full_folder_path(mpath_w_objs)
+      # Because of how the MetisPath regex works, the actual
+      #   folder name gets returned as the mpath.file_name, so
+      #   here we have to reconstruct the entire path by concatenating
+      #   mpath.folder_path + mpath.file_name.
       mpath_w_objs.mpath.folder_path ?
         "#{mpath_w_objs.mpath.folder_path}/#{mpath_w_objs.mpath.file_name}" :
         mpath_w_objs.mpath.file_name
     end
 
-    def validate_target_folder(mpath_w_objs, folder_check_type='source')
+    def validate_source_folder(mpath_w_objs)
       # NOTE: the "mpath_w_objs.folder" is the parent folder, not the
-      #   actual folder, so we have to account for that in the validations.
+      #   actual folder, so we have to account for that in the validations and
+      #   can't use the superclass #validate_folder()
       errors_found = false
 
       target_folder = Metis::Folder.from_path(
@@ -56,7 +61,7 @@ class Metis
         errors_found = true
       end
 
-      if target_folder&.read_only? && folder_check_type == 'source'
+      if target_folder&.read_only?
         @errors.push("Folder \"#{mpath_w_objs.mpath.path}\" is read-only")
         errors_found = true
       end
@@ -64,8 +69,11 @@ class Metis
       return errors_found
     end
 
-    def validate_dest_file(mpath_w_objs)
-      # Because we don't want users overwriting files with a folder
+    def validate_dest_is_not_file(mpath_w_objs)
+      # Because we don't want users overwriting files with a folder.
+      # Since we just need to check for file existence and don't
+      #   care about the file.read_only? flag, we can't use
+      #   the superclass #validate_file() method.
       errors_found = false
 
       file = Metis::File.from_folder(
@@ -84,7 +92,7 @@ class Metis
     def validate_source (source_mpath_w_objs)
       return unless validate_mpath(source_mpath_w_objs.mpath)
       return unless validate_bucket(source_mpath_w_objs)
-      return unless validate_target_folder(source_mpath_w_objs, 'source')
+      return unless validate_source_folder(source_mpath_w_objs)
       return unless validate_folder(source_mpath_w_objs, 'source')
     end
 
@@ -92,7 +100,7 @@ class Metis
       return unless validate_mpath(dest_mpath_w_objs.mpath)
       return unless validate_bucket(dest_mpath_w_objs)
       return unless validate_folder(dest_mpath_w_objs, 'dest')
-      return unless validate_dest_file(dest_mpath_w_objs)
+      return unless validate_dest_is_not_file(dest_mpath_w_objs)
     end
   end
 end

--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -220,6 +220,7 @@ class Metis
     def update_bucket!(new_bucket)
       raise 'Bucket does not match folder bucket' if folder != nil and folder.bucket_id != new_bucket.id
       update(bucket: new_bucket)
+      refresh
     end
   end
 end

--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -216,5 +216,10 @@ class Metis
         folder_id: new_folder ? new_folder.id : nil
       )
     end
+
+    def update_bucket!(new_bucket)
+      raise 'Bucket does not match folder bucket' if folder != nil and folder.bucket_id != new_bucket.id
+      update(bucket: new_bucket)
+    end
   end
 end

--- a/metis/lib/models/folder.rb
+++ b/metis/lib/models/folder.rb
@@ -97,25 +97,17 @@ class Metis
       refresh
     end
 
-    def update_bucket!(new_bucket)
-      update(bucket: new_bucket)
+    def update_bucket_and_rename!(new_folder, new_folder_name, new_bucket)
+      update(folder: new_folder, folder_name: new_folder_name, bucket: new_bucket)
 
       # Need to recursively update all sub-folders and files
       files.each { |file|
         file.update_bucket!(new_bucket)
       }
       folders.each { |folder|
-        folder.update_bucket!(new_bucket)
+        folder.update_bucket_and_rename!(self, folder.folder_name, new_bucket)
       }
 
-      refresh
-    end
-
-    def update_bucket_and_rename!(new_folder, new_folder_name, new_bucket)
-      # rename first to avoid any potential collisions with folder names
-      #    in the new bucket
-      rename!(new_folder, new_folder_name)
-      update_bucket!(new_bucket)
       refresh
     end
 

--- a/metis/lib/models/folder.rb
+++ b/metis/lib/models/folder.rb
@@ -97,18 +97,25 @@ class Metis
       refresh
     end
 
-    def update_bucket_and_rename!(new_folder, new_folder_name, new_bucket)
+    def update_bucket!(new_bucket)
       update(bucket: new_bucket)
-      rename!(new_folder, new_folder_name)
 
       # Need to recursively update all sub-folders and files
       files.each { |file|
         file.update_bucket!(new_bucket)
       }
       folders.each { |folder|
-        folder.update_bucket_and_rename!(self, folder.folder_name, new_bucket)
+        folder.update_bucket!(new_bucket)
       }
 
+      refresh
+    end
+
+    def update_bucket_and_rename!(new_folder, new_folder_name, new_bucket)
+      # rename first to avoid any potential collisions with folder names
+      #    in the new bucket
+      rename!(new_folder, new_folder_name)
+      update_bucket!(new_bucket)
       refresh
     end
 

--- a/metis/lib/models/folder.rb
+++ b/metis/lib/models/folder.rb
@@ -97,6 +97,21 @@ class Metis
       refresh
     end
 
+    def update_bucket_and_rename!(new_folder, new_folder_name, new_bucket)
+      update(bucket: new_bucket)
+      rename!(new_folder, new_folder_name)
+
+      # Need to recursively update all sub-folders and files
+      files.each { |file|
+        file.update_bucket!(new_bucket)
+      }
+      folders.each { |folder|
+        folder.update_bucket_and_rename!(self, folder.folder_name, new_bucket)
+      }
+
+      refresh
+    end
+
     def remove!
       delete
     end

--- a/metis/lib/revision.rb
+++ b/metis/lib/revision.rb
@@ -94,13 +94,13 @@ class Metis
       return errors_found
     end
 
-    def validate_folder(mpath_w_objs)
+    def validate_folder(mpath_w_objs, folder_check_type='source')
       errors_found = false
 
-      if Metis::Folder.exists?(
+      if (Metis::Folder.exists?(
           mpath_w_objs.mpath.file_name,
           mpath_w_objs.bucket,
-          mpath_w_objs.folder)
+          mpath_w_objs.folder) && folder_check_type == 'dest')
 
           @errors.push(
             "Cannot copy over existing folder: \"#{mpath_w_objs.mpath.path}\""
@@ -135,7 +135,7 @@ class Metis
     def validate_dest (dest_mpath_w_objs)
       return unless validate_mpath(dest_mpath_w_objs.mpath)
       return unless validate_bucket(dest_mpath_w_objs)
-      return unless validate_folder(dest_mpath_w_objs)
+      return unless validate_folder(dest_mpath_w_objs, 'dest')
       return unless validate_file(dest_mpath_w_objs, 'dest')
     end
   end

--- a/metis/lib/server.rb
+++ b/metis/lib/server.rb
@@ -37,6 +37,7 @@ class Metis
     post '/:project_name/folder/protect/:bucket_name/*folder_path', action: 'folder#protect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/unprotect/:bucket_name/*folder_path', action: 'folder#unprotect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/rename/:bucket_name/*folder_path', action: 'folder#rename', auth: { user: { can_edit?: :project_name } }
+    post '/:project_name/folder/move/:bucket_name/*folder_path', action: 'folder#move', auth: { user: { can_edit?: :project_name } }
 
     # file operations
     delete '/:project_name/file/remove/:bucket_name/*file_path', action: 'file#remove', auth: { user: { can_edit?: :project_name } }

--- a/metis/lib/server.rb
+++ b/metis/lib/server.rb
@@ -37,7 +37,6 @@ class Metis
     post '/:project_name/folder/protect/:bucket_name/*folder_path', action: 'folder#protect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/unprotect/:bucket_name/*folder_path', action: 'folder#unprotect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/rename/:bucket_name/*folder_path', action: 'folder#rename', auth: { user: { can_edit?: :project_name } }
-    post '/:project_name/folder/move/:bucket_name/*folder_path', action: 'folder#move', auth: { user: { can_edit?: :project_name } }
 
     # file operations
     delete '/:project_name/file/remove/:bucket_name/*file_path', action: 'file#remove', auth: { user: { can_edit?: :project_name } }

--- a/metis/lib/server/controllers/folder_controller.rb
+++ b/metis/lib/server/controllers/folder_controller.rb
@@ -116,32 +116,6 @@ class FolderController < Metis::Controller
     return failure(422, errors: revision.errors) unless revision.valid?
 
     return success_json(folders: [ revision.revise!.to_hash ])
-    # require_param(:new_folder_path)
-    # bucket = require_bucket
-    # folder = Metis::Folder.from_path(bucket, @params[:folder_path]).last
-
-    # metis_path, new_folder_path, new_bucket = new_folder_path_components(bucket)
-
-    # raise Etna::Error.new('Folder not found', 404) unless folder
-
-    # raise Etna::Forbidden, 'Folder is read-only' if folder.read_only?
-
-    # raise Etna::BadRequest, 'Invalid path' unless Metis::File.valid_file_path?(new_folder_path)
-
-    # new_parent_folder_path, new_folder_name = Metis::File.path_parts(new_folder_path)
-
-    # new_parent_folder = require_folder(new_bucket, new_parent_folder_path)
-
-    # raise Etna::Forbidden, 'Folder is read-only' if new_parent_folder && new_parent_folder.read_only?
-
-    # raise Etna::BadRequest, 'Cannot overwrite existing folder' if Metis::Folder.exists?(new_folder_name, new_bucket, new_parent_folder)
-
-    # raise Etna::BadRequest, 'Cannot overwrite existing file' if Metis::File.exists?(new_folder_name, new_bucket, new_parent_folder)
-
-    # folder.rename!(new_parent_folder, new_folder_name) if !metis_path.valid?
-    # folder.update_bucket_and_rename!(new_parent_folder, new_folder_name, new_bucket) if metis_path.valid?
-
-    # success_json(folders: [ folder.to_hash ])
   end
 
   protected

--- a/metis/lib/server/controllers/folder_controller.rb
+++ b/metis/lib/server/controllers/folder_controller.rb
@@ -109,7 +109,6 @@ class FolderController < Metis::Controller
 
     # Accept a Metis path as :new_folder_path to allow users to specify
     #   a new bucket (and in the future, a new project?)
-    binding.pry
     new_folder_path = @params[:new_folder_path]
     metis_path = Metis::Path.new(new_folder_path)
     raise Etna::BadRequest, 'Invalid path' unless metis_path.valid?
@@ -122,9 +121,9 @@ class FolderController < Metis::Controller
 
     raise Etna::Forbidden, 'Folder is read-only' if new_parent_folder && new_parent_folder.read_only?
 
-    raise Etna::BadRequest, 'Cannot overwrite existing folder' if Metis::Folder.exists?(new_folder_name, bucket, new_parent_folder)
+    raise Etna::BadRequest, 'Cannot overwrite existing folder' if Metis::Folder.exists?(new_folder_name, new_bucket, new_parent_folder)
 
-    raise Etna::BadRequest, 'Cannot overwrite existing file' if Metis::File.exists?(new_folder_name, bucket, new_parent_folder)
+    raise Etna::BadRequest, 'Cannot overwrite existing file' if Metis::File.exists?(new_folder_name, new_bucket, new_parent_folder)
 
     folder.update_bucket_and_rename!(new_parent_folder, new_folder_name, new_bucket)
 

--- a/metis/spec/file_spec.rb
+++ b/metis/spec/file_spec.rb
@@ -1284,26 +1284,24 @@ describe FileController do
 
   context '#update_bucket!' do
     before(:each) do
-      @default_bucket = default_bucket('athena')
+      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup_files', owner: 'metis', access: 'viewer')
+      stubs.create_bucket('athena', 'backup_files')
 
-      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup-files', owner: 'metis', access: 'viewer')
-      stubs.create_bucket('athena', 'backup-files')
-
-      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM, bucket: @default_bucket)
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
 
-      @blueprints_folder = create_folder('athena', 'blueprints', bucket: @default_bucket)
+      @blueprints_folder = create_folder('athena', 'blueprints')
       stubs.create_folder('athena', 'files', 'blueprints')
 
-      @helmet_folder = create_folder('athena', 'helmet', bucket: @default_bucket, folder: @blueprints_folder)
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
       stubs.create_folder('athena', 'files', 'blueprints/helmet')
 
-      @helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: @default_bucket, folder: @helmet_folder)
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET, folder: @helmet_folder)
       stubs.create_file('athena', 'files', 'blueprints/helmet/helmet.jpg', HELMET)
     end
 
     it 'moves a file to the new bucket when does not have a parent folder' do
-      expect(@wisdom_file.bucket).to eq(@default_bucket)
+      expect(@wisdom_file.bucket).not_to eq(@backup_files_bucket)
 
       @wisdom_file.update_bucket!(@backup_files_bucket)
 
@@ -1312,9 +1310,9 @@ describe FileController do
 
     it 'moves a file to the new bucket when does have a parent folder' do
       backup_blueprints_folder = create_folder('athena', 'blueprints', bucket: @backup_files_bucket)
-      stubs.create_folder('athena', 'backup-files', 'blueprints')
+      stubs.create_folder('athena', 'backup_files', 'blueprints')
 
-      expect(@helmet_file.bucket).to eq(@default_bucket)
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
       @helmet_file.folder = backup_blueprints_folder
 
       @helmet_file.update_bucket!(@backup_files_bucket)
@@ -1323,13 +1321,13 @@ describe FileController do
     end
 
     it 'cannot move a file to a different bucket than its folder\'s bucket' do
-      expect(@helmet_file.bucket).to eq(@default_bucket)
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
 
       expect {
         @helmet_file.update_bucket!(@backup_files_bucket)
       }.to raise_error(StandardError)
 
-      expect(@helmet_file.bucket).to eq(@default_bucket)
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
     end
   end
 end

--- a/metis/spec/file_spec.rb
+++ b/metis/spec/file_spec.rb
@@ -1281,4 +1281,55 @@ describe FileController do
       expect(::File.exists?(location)).to be_truthy
     end
   end
+
+  context '#update_bucket!' do
+    before(:each) do
+      @default_bucket = default_bucket('athena')
+
+      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup-files', owner: 'metis', access: 'viewer')
+      stubs.create_bucket('athena', 'backup-files')
+
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM, bucket: @default_bucket)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      @blueprints_folder = create_folder('athena', 'blueprints', bucket: @default_bucket)
+      stubs.create_folder('athena', 'files', 'blueprints')
+
+      @helmet_folder = create_folder('athena', 'helmet', bucket: @default_bucket, folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: @default_bucket, folder: @helmet_folder)
+      stubs.create_file('athena', 'files', 'blueprints/helmet/helmet.jpg', HELMET)
+    end
+
+    it 'moves a file to the new bucket when does not have a parent folder' do
+      expect(@wisdom_file.bucket).to eq(@default_bucket)
+
+      @wisdom_file.update_bucket!(@backup_files_bucket)
+
+      expect(@wisdom_file.bucket).to eq(@backup_files_bucket)
+    end
+
+    it 'moves a file to the new bucket when does have a parent folder' do
+      backup_blueprints_folder = create_folder('athena', 'blueprints', bucket: @backup_files_bucket)
+      stubs.create_folder('athena', 'backup-files', 'blueprints')
+
+      expect(@helmet_file.bucket).to eq(@default_bucket)
+      @helmet_file.folder = backup_blueprints_folder
+
+      @helmet_file.update_bucket!(@backup_files_bucket)
+
+      expect(@helmet_file.bucket).to eq(@backup_files_bucket)
+    end
+
+    it 'cannot move a file to a different bucket than its folder\'s bucket' do
+      expect(@helmet_file.bucket).to eq(@default_bucket)
+
+      expect {
+        @helmet_file.update_bucket!(@backup_files_bucket)
+      }.to raise_error(StandardError)
+
+      expect(@helmet_file.bucket).to eq(@default_bucket)
+    end
+  end
 end

--- a/metis/spec/folder_rename_revision_spec.rb
+++ b/metis/spec/folder_rename_revision_spec.rb
@@ -1,0 +1,449 @@
+describe Metis::FolderRenameRevision do
+
+    def app
+      OUTER_APP
+    end
+
+    before(:each) do
+      default_bucket('athena')
+
+      @user = Etna::User.new({
+        first: 'Athena',
+        last: 'Pallas',
+        email: 'athena@olympus.org',
+        perm: 'a:athena'
+      })
+
+      @wisdom_folder = create_folder('athena', 'wisdom')
+      stubs.create_folder('athena', 'files', 'wisdom')
+    end
+
+    after(:each) do
+      stubs.clear
+
+      expect(stubs.contents(:athena)).to be_empty
+    end
+
+    it 'creates a Metis::PathWithObjects as the dest parameter' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/wisdom',
+            user: @user
+        })
+        expect(revision.dest.instance_of? Metis::PathWithObjects).to eq(true)
+    end
+
+    it 'adds error message if user cannot access the dest bucket' do
+        sundry_bucket = create( :bucket, project_name: 'athena', name: 'sundry', access: 'viewer', owner: 'metis' )
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/sundry/wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Invalid bucket: \"sundry\""
+        )
+    end
+
+    it 'does not add error message if user can access the dest bucket' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/wisdom_2',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors).to eq([])
+    end
+
+    it 'adds error message if the dest path is invalid' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: "metis://athena/files/learn\nwisdom",
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Invalid path: \"metis://athena/files/learn\nwisdom\""
+        )
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: nil,
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Invalid path: \"\""
+        )
+    end
+
+    it 'does not add error message if the dest path is valid' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/learn-wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors).to eq([])
+
+        blueprints_folder = create_folder('athena', 'blueprints')
+        stubs.create_folder('athena', 'files', 'blueprints')
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/blueprints/drawing_wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        revision.dest.folder = blueprints_folder
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors).to eq([])
+    end
+
+    it 'returns the source and dest bucket_names in an array' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/helmet',
+            dest: 'metis://athena/files/wisdom',
+            user: @user
+        })
+        expect(revision.bucket_names).
+            to eq(['files', 'files'])
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/helmet',
+            dest: nil,
+            user: @user
+        })
+        expect(revision.bucket_names).
+            to eq(['files'])
+    end
+
+    it 'adds error message if dest bucket is read-only' do
+        contents_folder = create_folder('athena', 'contents', read_only: true)
+        stubs.create_folder('athena', 'files', 'contents')
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/contents/wisdom',
+            user: @user
+        })
+
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        revision.dest.folder = contents_folder
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Folder \"contents\" is read-only"
+        )
+    end
+
+    it 'adds error message if dest file exists' do
+        @wisdom2_file = create_file('athena', 'wisdom2.txt', WISDOM*2)
+        stubs.create_file('athena', 'files', 'wisdom2.txt', WISDOM*2)
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/wisdom2.txt',
+            user: @user
+        })
+
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Cannot overwrite existing file: \"metis://athena/files/wisdom2.txt\""
+        )
+    end
+
+    it 'reports multiple errors from validation' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/helmet',
+            dest: nil,
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+
+        expect(revision.errors.length).to eq(2)
+
+        expect(revision.errors[0]).to eq(
+            "Folder not found: \"metis://athena/files/helmet\""
+        )
+        expect(revision.errors[1]).to eq(
+            "Invalid path: \"\""
+        )
+    end
+
+    it 'adds error message if trying to copy over an existing folder' do
+        wisdom_folder = create_folder('athena', 'wisdom_jr')
+        stubs.create_folder('athena', 'files', 'wisdom_jr')
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/wisdom_jr',
+            user: @user
+        })
+
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Cannot copy over existing folder: \"metis://athena/files/wisdom_jr\""
+        )
+    end
+
+    it 'executes the revision' do
+        expect(Metis::Folder.count).to eq(1)
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/learn-wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        revision.validate
+        learn_wisdom = revision.revise!
+        expect(Metis::Folder.count).to eq(1)
+        expect(learn_wisdom.id).to eq(@wisdom_folder.id)
+    end
+
+    it 'throws exception if you try to revise without setting user' do
+        expect(Metis::Folder.count).to eq(1)
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/learn-wisdom'
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        revision.validate
+        expect {
+            revision.revise!
+        }.to raise_error(StandardError)
+
+        expect(Metis::Folder.count).to eq(1)
+    end
+
+    it 'adds error message if source bucket is invalid' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/war/helmet',
+            dest: 'metis://athena/files/wisdom',
+            user: @user
+        })
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(2)
+        expect(revision.errors).to eq([
+            "Invalid bucket: \"war\"",
+            "Cannot copy over existing folder: \"metis://athena/files/wisdom\""
+        ])
+    end
+
+    it 'adds error message if source folder does not exist' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom_jr',
+            dest: 'metis://athena/files/wisdom_sr',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Folder not found: \"metis://athena/files/wisdom_jr\""
+        )
+    end
+
+    it 'adds error message if the source path is invalid' do
+        revision = Metis::FolderRenameRevision.new({
+            source: "metis://athena/files/build\nhelmet",
+            dest: "metis://athena/magma/instructables",
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect(revision.errors[0]).to eq(
+            "Invalid path: \"metis://athena/files/build\nhelmet\""
+        )
+
+        revision = Metis::FolderRenameRevision.new({
+            source: nil,
+            dest: nil,
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(2)
+        expect(revision.errors[0]).to eq(
+            "Invalid path: \"\""
+        )
+        expect(revision.errors[1]).to eq(
+            "Invalid path: \"\""
+        )
+    end
+
+    it 'does not add error message if the source path is valid' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/backup_wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors).to eq([])
+    end
+
+    it 'adds error message if user cannot access the source bucket' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/magma/wisdom',
+            dest: 'metis://athena/files/wisdom',
+            user: @user
+        })
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(2)
+        expect(revision.errors[0]).to eq(
+            "Invalid bucket: \"magma\""
+        )
+    end
+
+    it 'does not add error message if user can access the source bucket' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/wisdom_jr',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors).to eq([])
+    end
+
+    it 'will not execute the revision if not valid' do
+        expect(Metis::Folder.count).to eq(1)
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: nil,
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        revision.validate
+        expect(revision.errors.length).to eq(1)
+        expect {
+            revision.revise!
+        }.to raise_error(StandardError)
+
+        expect(Metis::Folder.count).to eq(1)
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/files/backup_wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        expect {
+            revision.revise!
+        }.to raise_error(StandardError)
+
+        expect(Metis::Folder.count).to eq(1)
+    end
+
+    it 'is invalid if validate not run' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/wisdom',
+            dest: 'metis://athena/backup_files/wisdom',
+            user: @user
+        })
+        revision.source.bucket = default_bucket('athena')
+        revision.dest.bucket = default_bucket('athena')
+        expect(revision.errors).to eq(nil)
+        expect(revision.valid?).to eq(false)
+    end
+
+    it 'returns the dest and source paths in an array' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/helmet',
+            dest: 'metis://athena/magma/wisdom'
+        })
+        expect(revision.mpaths.length).to eq(2)
+        expect(revision.mpaths[0].path).
+            to eq('metis://athena/files/helmet')
+        expect(revision.mpaths[1].path).
+            to eq('metis://athena/magma/wisdom')
+
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/files/helmet',
+            dest: nil
+        })
+        expect(revision.mpaths.length).to eq(1)
+        expect(revision.mpaths[0].path).
+            to eq('metis://athena/files/helmet')
+    end
+
+    it 'returns a hash representation' do
+        revision = Metis::FolderRenameRevision.new({
+            source: 'metis://athena/magma/wisdom',
+            dest: 'metis://athena/files/wisdom',
+            user: @user
+        })
+        revision.dest.bucket = default_bucket('athena')
+
+        expect(revision.to_hash).to eq({
+            source: 'metis://athena/magma/wisdom',
+            dest: 'metis://athena/files/wisdom',
+            errors: nil
+        })
+
+        revision.validate
+
+        expect(revision.to_hash).to eq({
+            source: 'metis://athena/magma/wisdom',
+            dest: 'metis://athena/files/wisdom',
+            errors: [
+                "Invalid bucket: \"magma\"",
+                "Cannot copy over existing folder: \"metis://athena/files/wisdom\""],
+        })
+    end
+end

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 describe FolderController do
   include Rack::Test::Methods
 
@@ -790,6 +789,9 @@ describe FolderController do
 
       @sketches_folder = create_folder('athena', 'sketches', folder: @helmet_folder)
       stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches')
+
+      @backup_blueprints_folder = create_folder('athena', 'blueprints', bucket: @backup_files_bucket)
+      stubs.create_folder('athena', 'backup_files', 'blueprints')
 
       token_header(:editor)
       move_folder('blueprints/helmet/sketches', 'metis://athena/backup_files/blueprints/drawings')

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 describe FolderController do
   include Rack::Test::Methods
 
@@ -617,6 +618,280 @@ describe FolderController do
       @blueprints_folder.refresh
       expect(@blueprints_folder.folder_path).to eq(['blueprints'])
       expect(@blueprints_folder.folder).to be_nil
+    end
+  end
+
+  context '#update_bucket_and_rename!' do
+    before(:each) do
+      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup_files', owner: 'metis', access: 'viewer')
+      stubs.create_bucket('athena', 'backup_files')
+
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      @blueprints_folder = create_folder('athena', 'blueprints')
+      stubs.create_folder('athena', 'files', 'blueprints')
+
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET, folder: @helmet_folder)
+      stubs.create_file('athena', 'files', 'blueprints/helmet/helmet.jpg', HELMET)
+    end
+
+    it 'recursively updates file and sub-folder buckets' do
+      expect(@helmet_folder.bucket).not_to eq(@backup_files_bucket)
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@helmet_folder.folder).to eq(@blueprints_folder)
+      expect(@helmet_file.folder).to eq(@helmet_folder)
+
+      @blueprints_folder.update_bucket_and_rename!(
+        nil, 'backup-blueprints', @backup_files_bucket)
+
+      @helmet_file.refresh
+      @helmet_folder.refresh
+      @blueprints_folder.refresh
+
+      expect(@helmet_folder.bucket).to eq(@backup_files_bucket)
+      expect(@helmet_file.bucket).to eq(@backup_files_bucket)
+      expect(@blueprints_folder.bucket).to eq(@backup_files_bucket)
+      expect(@blueprints_folder.folder_name).to eq('backup-blueprints')
+      expect(@helmet_folder.folder).to eq(@blueprints_folder)
+      expect(@helmet_file.folder).to eq(@helmet_folder)
+    end
+  end
+
+  context '#move' do
+    before(:each) do
+      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup_files', owner: 'metis', access: 'viewer')
+      stubs.create_bucket('athena', 'backup_files')
+
+      @blueprints_folder = create_folder('athena', 'blueprints')
+      stubs.create_folder('athena', 'files', 'blueprints')
+    end
+
+    def move_folder path, new_path
+      json_post("/athena/folder/move/files/#{path}", new_folder_path: new_path)
+    end
+
+    it 'moves a folder' do
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/blue-prints')
+
+      stubs.add_folder('athena', 'backup_files', 'blue-prints')
+
+      @blueprints_folder.refresh
+      expect(last_response.status).to eq(200)
+      expect(@blueprints_folder.folder_name).to eq('blue-prints')
+      expect(@blueprints_folder.bucket).to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move a folder to an invalid name' do
+      token_header(:editor)
+      move_folder('blueprints', "blue\nprints")
+
+      @blueprints_folder.refresh
+      expect(last_response.status).to eq(422)
+      expect(json_body[:error]).to eq('Invalid path')
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move a folder without permissions' do
+      token_header(:viewer)
+      move_folder('blueprints', 'metis://athena/backup_files/blue-prints')
+
+      @blueprints_folder.refresh
+      expect(last_response.status).to eq(403)
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move a non-existent folder' do
+      # we attempt to rename a folder that does not exist
+      token_header(:editor)
+      move_folder('redprints', 'metis://athena/backup_files/red-prints')
+
+      expect(last_response.status).to eq(404)
+      expect(json_body[:error]).to eq('Folder not found')
+
+      # the actual folder is untouched
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move over an existing folder' do
+      helmet_folder = create_folder('athena', 'helmet', bucket: @backup_files_bucket)
+      stubs.create_folder('athena', 'backup_files', 'helmet')
+
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/helmet')
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:error]).to eq('Cannot overwrite existing folder')
+
+      # the actual folder is untouched
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move over an existing file' do
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: @backup_files_bucket)
+      stubs.create_file('athena', 'backup_files', 'helmet.jpg', HELMET)
+
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/helmet.jpg')
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:error]).to eq('Cannot overwrite existing file')
+
+      # the actual folder is untouched
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_name).to eq('blueprints')
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move a read-only folder' do
+      @blueprints_folder.read_only = true
+      @blueprints_folder.save
+
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/blue-prints')
+
+      expect(last_response.status).to eq(403)
+      expect(json_body[:error]).to eq('Folder is read-only')
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_path).to eq(['blueprints'])
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'can move a folder to a new folder' do
+      contents_folder = create_folder('athena', 'contents', bucket: @backup_files_bucket)
+      stubs.create_folder('athena', 'backup_files', 'contents')
+
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/contents/blueprints')
+      stubs.add_folder('athena', 'backup_files', 'contents/blueprints')
+
+      expect(last_response.status).to eq(200)
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_path).to eq(['contents', 'blueprints'])
+      expect(@blueprints_folder.folder).to eq(contents_folder)
+      expect(@blueprints_folder.bucket).to eq(@backup_files_bucket)
+    end
+
+    it 'can move a sub-folder to a different folder' do
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @sketches_folder = create_folder('athena', 'sketches', folder: @helmet_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches')
+
+      token_header(:editor)
+      move_folder('blueprints/helmet/sketches', 'metis://athena/backup_files/blueprints/drawings')
+      stubs.add_folder('athena', 'backup_files', 'blueprints/drawings')
+
+      expect(last_response.status).to eq(200)
+      @sketches_folder.refresh
+      expect(@sketches_folder.folder_path).to eq(['blueprints', 'drawings'])
+      expect(@sketches_folder.bucket).to eq(@backup_files_bucket)
+
+      @helmet_folder.refresh
+      expect(@helmet_folder.folders).to eq([])
+      expect(@helmet_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'refuses to move a sub-folder to a non-existent tree' do
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @sketches_folder = create_folder('athena', 'sketches', folder: @helmet_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches')
+
+      token_header(:editor)
+      move_folder('blueprints/helmet/sketches', 'metis://athena/backup_files/sketches/blueprints/helmet')
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:error]).to eq('Invalid folder: "sketches/blueprints"')
+
+      # folders and buckets are unchanged
+      @sketches_folder.refresh
+      expect(@sketches_folder.folder_path).to eq(['blueprints', 'helmet', 'sketches'])
+      expect(@sketches_folder.bucket).not_to eq(@backup_files_bucket)
+
+      @helmet_folder.refresh
+      expect(@helmet_folder.folders).to eq([@sketches_folder])
+      expect(@helmet_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'moves the contents of folders' do
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @sketches_folder = create_folder('athena', 'sketches', folder: @helmet_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches')
+
+      @helmet_file = create_file('athena', 'helmet-sketch.jpg', HELMET, folder: @sketches_folder)
+      stubs.create_file('athena', 'files', 'blueprints/helmet/sketches/helmet-sketch.jpg', HELMET)
+
+      @failed_sketches_folder = create_folder('athena', 'failed-sketches', folder: @sketches_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches/failed-sketches')
+
+      token_header(:editor)
+      move_folder('blueprints/helmet/sketches', 'metis://athena/backup_files/sketches')
+      stubs.add_folder('athena', 'backup_files', 'sketches')
+
+      expect(last_response.status).to eq(200)
+      @sketches_folder.refresh
+      expect(@sketches_folder.folder_path).to eq(['sketches'])
+      expect(@sketches_folder.bucket).to eq(@backup_files_bucket)
+
+      @failed_sketches_folder.refresh
+      expect(@failed_sketches_folder.folder_path).to eq(['sketches', 'failed-sketches'])
+      expect(@failed_sketches_folder.bucket).to eq(@backup_files_bucket)
+
+      @helmet_file.refresh
+      expect(@helmet_file.file_path).to eq('sketches/helmet-sketch.jpg')
+      expect(@helmet_file).to be_has_data
+      expect(@helmet_file.bucket).to eq(@backup_files_bucket)
+
+      @helmet_folder.refresh
+      expect(@helmet_folder.folders).to eq([])
+      expect(@helmet_folder.bucket).not_to eq(@backup_files_bucket)
+
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'will not move a folder to a read-only folder' do
+      contents_folder = create_folder('athena', 'contents', bucket: @backup_files_bucket, read_only: true)
+      stubs.create_folder('athena', 'backup_files', 'contents')
+
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/contents/blueprints')
+
+      expect(last_response.status).to eq(403)
+      expect(json_body[:error]).to eq('Folder is read-only')
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_path).to eq(['blueprints'])
+      expect(@blueprints_folder.folder).to be_nil
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
+    end
+
+    it 'will not move a folder to a non-existent folder' do
+      token_header(:editor)
+      move_folder('blueprints', 'metis://athena/backup_files/contents/blueprints')
+
+      expect(last_response.status).to eq(422)
+      expect(json_body[:error]).to eq('Invalid folder: "contents"')
+      @blueprints_folder.refresh
+      expect(@blueprints_folder.folder_path).to eq(['blueprints'])
+      expect(@blueprints_folder.folder).to be_nil
+      expect(@blueprints_folder.bucket).not_to eq(@backup_files_bucket)
     end
   end
 end


### PR DESCRIPTION
This PR adds the ability to rename a folder into a different bucket (same project), using the `folder_rename` route. It does not extend that ability to the Metis UI yet -- we can add that functionality later, if needed. Since our main use case currently is an internal scripting tool, this is just an API change.

Much of the changes are related to building off of the `Revision` and validations that were used for the updated `File#copy` and `File#bulk_copy` routes, so that the validation schemes are shared.

To test in a running instance, you have to make a request outside of the UI, via a tool like `curl` or Postman. You need to include two new parameters in the payload, `new_folder_path` and `new_bucket_name`. For example, if you have a bucket called `published` with a folder `stories` in the project 'legends', you would POST to `https://<Metis host>/legends/folder/rename/published/stories` a payload of

```
{"new_folder_path":"story_ideas", "new_bucket_name": "drafts"}
```

And that would move `stories` plus all children folders and files to the `drafts` bucket while also renaming the folder to `story_ideas`. So the Metis "view" URLs would go from `/legends/published/stories` => `/legends/drafts/story_ideas`.

Renaming folders in the Metis UI should behave the same as before.