### PR TITLE
add relative require to get load project working

### DIFF
--- a/magma/lib/magma/commands.rb
+++ b/magma/lib/magma/commands.rb
@@ -59,6 +59,7 @@ class Magma
     end
 
     def options
+      require_relative './attribute'
       @options ||= Magma::Attribute.options - [:loader] + [:created_at, :updated_at, :attribute_name]
     end
   end
@@ -76,7 +77,7 @@ class Magma
 
   class Migrate < Etna::Command
     usage '[<version_number>] # Run migrations for the current environment.'
-    
+
     def execute(version=nil)
       Sequel.extension(:migration)
       db = Magma.instance.db
@@ -123,8 +124,8 @@ class Magma
 
   # When building migrations from scratch this command does not output
   # an order that respects foreign key constraints. i.e. The order in which the
-  # migration creates tries to create the tables is out of whack and causes 
-  # error messages that tables are required but do not exist. Most of the time 
+  # migration creates tries to create the tables is out of whack and causes
+  # error messages that tables are required but do not exist. Most of the time
   # this is not an issue (because we are only doing slight modifications), but
   # when we do a new migration of an established database errors do arise.
   # Presently we are manually reorgaizing the initial migration (putting the


### PR DESCRIPTION
Small fix to Magma's `load_project` command. I was trying to update a project and getting this exception:

```
Traceback (most recent call last):
	8: from ./bin/magma:11:in `<main>'
	7: from /app/vendor/bundle/2.5.7/ruby/2.5.0/gems/etna-0.1.13/lib/etna/application.rb:75:in `run_command'
	6: from /app/lib/magma/commands.rb:12:in `execute'
	5: from /app/lib/magma/commands.rb:12:in `each'
	4: from /app/lib/magma/commands.rb:18:in `block in execute'
	3: from /app/lib/magma/commands.rb:18:in `each'
	2: from /app/lib/magma/commands.rb:19:in `block (2 levels) in execute'
	1: from /app/lib/magma/commands.rb:49:in `load_attribute'
/app/lib/magma/commands.rb:63:in `options': uninitialized constant Magma::Attribute (NameError)
```

This PR just imports `Magma::Attribute` into the method, so it can be available.