### PR TITLE
Simple Metis client

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.15'
+  spec.version           = '0.1.16'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/etna/clients/metis.rb
+++ b/etna/lib/etna/clients/metis.rb
@@ -1,0 +1,2 @@
+require_relative './metis/client'
+require_relative './metis/models'

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -14,8 +14,23 @@ module Etna
       end
 
       def folder_list_all_folders(list_all_folders_request)
-        ListFoldersResponse.new(
+        FoldersResponse.new(
           @etna_client.folder_list_all_folders(list_all_folders_request.to_h))
+      end
+
+      def folder_list(list_folder_request)
+        FoldersAndFilesResponse.new(
+          @etna_client.folder_list(list_folder_request.to_h))
+      end
+
+      def folder_rename(rename_folder_request)
+        FoldersResponse.new(
+          @etna_client.folder_rename(rename_folder_request.to_h))
+      end
+
+      def folder_create(create_folder_request)
+        FoldersResponse.new(
+          @etna_client.folder_create(create_folder_request.to_h))
       end
     end
   end

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -1,0 +1,22 @@
+require 'net/http/persistent'
+require 'net/http/post/multipart'
+require 'singleton'
+require_relative '../../client'
+require_relative './models'
+
+module Etna
+  module Clients
+    class Metis
+      def initialize(host:, token:)
+        raise 'Metis client configuration is missing host.' unless host
+        raise 'Metis client configuration is missing token.' unless token
+        @etna_client = ::Etna::Client.new(host, token)
+      end
+
+      def folder_list_all_folders(list_all_folders_request)
+        ListFoldersResponse.new(
+          @etna_client.folder_list_all_folders(list_all_folders_request.to_h))
+      end
+    end
+  end
+end

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -1,0 +1,56 @@
+require_relative '../../json_serializable_struct'
+
+
+module Etna
+  module Clients
+    class Metis
+      class ListFoldersRequest < Struct.new(:project_name, :bucket_name, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+      end
+
+      class ListFoldersResponse
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def folders
+          Folders.new(raw[:folders])
+        end
+      end
+
+      class Folders
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def all
+          raw.map { |folder| Folder.new(folder) }
+        end
+      end
+
+      class Folder
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def folder_path
+          raw[:folder_path]
+        end
+
+        def bucket_name
+          raw[:bucket_name]
+        end
+      end
+    end
+  end
+end

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -12,7 +12,31 @@ module Etna
         end
       end
 
-      class ListFoldersResponse
+      class RenameFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, :new_bucket_name, :new_folder_path, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+      end
+
+      class ListFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+      end
+
+      class CreateFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+      end
+
+      class FoldersResponse
         attr_reader :raw
 
         def initialize(raw = {})
@@ -21,6 +45,24 @@ module Etna
 
         def folders
           Folders.new(raw[:folders])
+        end
+      end
+
+      class FoldersAndFilesResponse < FoldersResponse
+        def files
+          Files.new(raw[:files])
+        end
+      end
+
+      class Files
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def all
+          raw.map { |file| File.new(file) }
         end
       end
 
@@ -33,6 +75,22 @@ module Etna
 
         def all
           raw.map { |folder| Folder.new(folder) }
+        end
+      end
+
+      class File
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def file_path
+          raw[:file_path]
+        end
+
+        def file_name
+          raw[:file_name]
         end
       end
 

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -4,7 +4,7 @@ require_relative '../../json_serializable_struct'
 module Etna
   module Clients
     class Metis
-      class ListFoldersRequest < Struct.new(:project_name, :bucket_name, keyword_init: true)
+      class ListFoldersRequest < Struct.new(:project_name, :bucket_name, :offset, :limit, keyword_init: true)
         include JsonSerializableStruct
 
         def initialize(**params)

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -27,6 +27,21 @@ class Polyphemus
     end
   end
 
+  class GetMetisFolders < Etna::Command
+    usage "Fetch a list of Metis folders from a bucket"
+
+    def execute
+      client = Polyphemus.instance.metis_client
+      folders = client.folder_list_all_folders(
+        Etna::Clients::Metis::ListFoldersRequest.new(project_name: 'mvir1', bucket_name: 'data')).folders
+      folders.all.each { |f| p f.folder_path }
+    end
+
+    def setup(config)
+      super
+    end
+  end
+
   class Console < Etna::Command
     usage 'Open a console with a connected Polyphemus instance.'
 

--- a/polyphemus/lib/polyphemus.rb
+++ b/polyphemus/lib/polyphemus.rb
@@ -1,10 +1,15 @@
 require_relative 'commands'
 require 'etna/clients/magma'
+require 'etna/clients/metis'
 
 class Polyphemus
   include Etna::Application
 
   def magma_client
     @magma_client ||= Etna::Clients::Magma.new({ token: ENV['TOKEN'] }.update(config(:magma)))
+  end
+
+  def metis_client
+    @metis_client ||= Etna::Clients::Metis.new({ token: ENV['TOKEN'] }.update(config(:metis)))
   end
 end


### PR DESCRIPTION
This PR adds a simple Metis client to the Etna gem and bumps the version so it gets published.

The methods supported in the Metis client are the ones required for the waiver behavior:

1) Listing contents of a single folder
2) Listing all folders of a bucket
3) Creating a folder
4) Renaming a folder