### PR TITLE
small fixes to make seed_databases working

### DIFF
--- a/bin/download_metis_dir
+++ b/bin/download_metis_dir
@@ -38,7 +38,7 @@ if [[ -e /dest ]]; then
     /app/bin/metis_client $metisPath get ./ /dest/
 else
   # Ensure images are created
-  make -C docker up
+  make -C docker build
   docker-compose -p monoetna run -e TOKEN="$TOKEN" -v $destPath:/dest -v $DIR:/root/bin metis_app /root/bin/download_metis_dir "$metisPath"
 fi
 

--- a/bin/download_metis_dir
+++ b/bin/download_metis_dir
@@ -13,7 +13,7 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" 
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
@@ -38,7 +38,7 @@ if [[ -e /dest ]]; then
     /app/bin/metis_client $metisPath get ./ /dest/
 else
   # Ensure images are created
-  make -C docker create
+  make -C docker up
   docker-compose -p monoetna run -e TOKEN="$TOKEN" -v $destPath:/dest -v $DIR:/root/bin metis_app /root/bin/download_metis_dir "$metisPath"
 fi
 

--- a/bin/seed_databases
+++ b/bin/seed_databases
@@ -13,7 +13,7 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" 
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
@@ -49,7 +49,7 @@ function startSeedInDocker() {
 }
 
 function runSeeds() {
-    make -C docker create
+    # make -C docker up
     startSeedInDocker timur
     startSeedInDocker magma
 }

--- a/bin/seed_databases
+++ b/bin/seed_databases
@@ -44,12 +44,15 @@ else
 
 function startSeedInDocker() {
     set -x
+    # Start database
+    docker-compose -p monoetna up $1_db -d
     docker-compose -p monoetna run -e TOKEN="$TOKEN" -v $DIR:/root/bin -v /tmp/local-seeds:/local-seeds $1_app /root/bin/seed_databases $1_db $1_development /local-seeds/$1_dev.bak
     set +x
 }
 
 function runSeeds() {
-    # make -C docker up
+    # Ensure docker-compose.yml ready
+    make -C docker docker-ready
     startSeedInDocker timur
     startSeedInDocker magma
 }


### PR DESCRIPTION
With the updated docker build, I was having issues getting `seed_databases` working. It seemed like the `create` Make command was changed (??), so seems like `up` is the replacement. I was getting this exception when running the command:

```
make: Entering directory 'monoetna/docker'
make: *** No rule to make target 'create'.  Stop.
make: Leaving directory 'monoetna/docker'
```

Also the actual seeding was failing when `up` was called beforehand, since the apps would be connected to the database and I would get an exception like:

```
dropdb: database removal failed: ERROR:  database "timur_development" is being accessed by other users
DETAIL:  There is 1 other session using the database.
++ error /root/bin/seed_databases 35
++ echo 'Whoops!  Looks like /root/bin/seed_databases:35 failed.'
Whoops!  Looks like /root/bin/seed_databases:35 failed.
++ echo 'Please try rerunning /root/bin/seed_databases again.'
Please try rerunning /root/bin/seed_databases again.
```

But not bringing up all the docker containers before seeding seems to fix the competing connection issue.