### PR TITLE
add call to timur create_routes in entrypoint

### DIFF
--- a/docker/etna-base/entrypoints/build.sh
+++ b/docker/etna-base/entrypoints/build.sh
@@ -70,3 +70,7 @@ fi
 if [ -n "$RUN_NPM_INSTALL" ]; then
   if [ -e ../etna ]; then npm link ../etna/packages/etna-js; fi
 fi
+
+if [ "$APP_NAME" = "timur" ]; then
+  ./bin/timur create_routes
+fi


### PR DESCRIPTION
The Timur UI requires a call to `./bin/timur create_routes` to update the JS routes used in the front-end. This puts that call into the base `entrypoint.sh`.

Without this line, the Timur UI loads with the list of projects, but then fails to a blank screen if you try to navigate to a specific project.