### PR TITLE
Recursive restriction

### DIFF
--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -96,6 +96,10 @@ class Magma
         @parent
       end
 
+      def parent_model
+        @parent ? Magma.instance.get_model(project_name, parent_model_name) : nil
+      end
+
       # suggests dictionary entries based on
       def dictionary(dictionary_json = {})
         return @dictionary unless dictionary_json[:dictionary_model]

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -31,11 +31,19 @@ class Magma
       @model = model
       @filters = []
 
-      if question.restrict? && @model.has_attribute?(:restricted)
-        # the model can be restricted, and we should withhold restricted data
-        query_args.unshift(
-          [ 'restricted', '::false' ]
-        )
+      if question.restrict?
+      # the model can be restricted, and we should withhold restricted data
+        restriction_model = model
+        ancestral_path = []
+        while restriction_model do
+          if restriction_model.has_attribute?(:restricted)
+            query_args.unshift(
+              ancestral_path + [ 'restricted', '::false' ]
+            )
+          end
+          ancestral_path << restriction_model.parent_model_name&.to_s
+          restriction_model = restriction_model.parent_model
+        end
       end
 
       # Since we are shifting off the the first elements on the query_args array

--- a/magma/spec/actions/add_attribute_actions_spec.rb
+++ b/magma/spec/actions/add_attribute_actions_spec.rb
@@ -19,20 +19,20 @@ describe Magma::AddAttributeAction do
   end
 
   let(:action) { Magma::AddAttributeAction.new(project_name, action_params) }
-  let(:model_name) { "monster" }
+  let(:model_name) { "labor" }
   let(:attribute_name) { "number_of_claws" }
 
   describe '#perform' do
     context "when it succeeds" do
       after do
         # Clear out new test attributes that are cached in memory
-        Labors::Monster.attributes.delete(attribute_name.to_sym)
+        Labors::Labor.attributes.delete(attribute_name.to_sym)
       end
 
       it 'adds a new attribute and returns no errors' do
         expect(action.perform).to eq(true)
         expect(action.errors).to be_empty
-        expect(Labors::Monster.attributes[attribute_name.to_sym].display_name).to eq("name")
+        expect(Labors::Labor.attributes[attribute_name.to_sym].display_name).to eq("name")
       end
     end
 
@@ -42,7 +42,7 @@ describe Magma::AddAttributeAction do
       it "captures the error and doesn't add the attribute" do
         expect(action.perform).to eq(false)
         expect(action.errors).not_to be_empty
-        expect(Labors::Monster.attributes[attribute_name.to_sym]).to be_nil
+        expect(Labors::Labor.attributes[attribute_name.to_sym]).to be_nil
       end
     end
   end
@@ -86,7 +86,7 @@ describe Magma::AddAttributeAction do
 
       it 'captures an attribute error' do
         expect(action.validate).to eq(false)
-        expect(action.errors.first[:message]).to eq("attribute_name already exists on Labors::Monster")
+        expect(action.errors.first[:message]).to eq("attribute_name already exists on Labors::Labor")
       end
     end
 

--- a/magma/spec/fixtures/labors_model_attributes.yml
+++ b/magma/spec/fixtures/labors_model_attributes.yml
@@ -63,6 +63,8 @@ monster:
     type: link
     link_model_name: monster
     column_name: reference_monster_id
+  restricted:
+    type: boolean
 prize:
   labor:
     type: parent

--- a/magma/spec/labors/migrations/16_add_restricted_to_monster.rb
+++ b/magma/spec/labors/migrations/16_add_restricted_to_monster.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(Sequel[:labors][:monsters]) do
+      add_column :restricted, TrueClass
+    end
+  end
+end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -508,9 +508,46 @@ describe RetrieveController do
       expect(json_body[:models][:victim][:documents].keys.sort).to eq(unrestricted_victim_list.map(&:identifier).map(&:to_sym))
     end
 
+    it 'hides the children of restricted records' do
+      lion = create(:monster, :lion, restricted: true)
+      hydra = create(:monster, :hydra, restricted: false)
+      restricted_victim_list = create_list(:victim, 9, monster: lion)
+      unrestricted_victim_list = create_list(:victim, 9, monster: hydra)
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'victim',
+        record_names: 'all',
+        attribute_names: 'all'
+      )
+      expect(json_body[:models][:victim][:documents].keys.sort).to eq(unrestricted_victim_list.map(&:identifier).map(&:to_sym))
+    end
+
     it 'shows restricted records to users with restricted permission' do
       restricted_victim_list = create_list(:victim, 9, restricted: true)
       unrestricted_victim_list = create_list(:victim, 9)
+
+      retrieve(
+        {
+          project_name: 'labors',
+          model_name: 'victim',
+          record_names: 'all',
+          attribute_names: 'all'
+        },
+        :editor
+      )
+      expect(json_body[:models][:victim][:documents].keys.sort).to eq(
+        (
+          unrestricted_victim_list + restricted_victim_list
+        ).map(&:identifier).map(&:to_sym).sort
+      )
+    end
+
+    it 'shows the children of restricted records to users with restricted permission' do
+      lion = create(:monster, :lion, restricted: true)
+      hydra = create(:monster, :hydra, restricted: false)
+      restricted_victim_list = create_list(:victim, 9, monster: lion)
+      unrestricted_victim_list = create_list(:victim, 9, monster: hydra)
 
       retrieve(
         {


### PR DESCRIPTION
This sets up recursive restriction on models, so that if a given record is restricted, all its children behave as restricted also, for both retrieval and update.