### PR TITLE
clarify ::false vs. ::untrue for restricted

### DIFF
--- a/magma/lib/magma/query/predicate/boolean.rb
+++ b/magma/lib/magma/query/predicate/boolean.rb
@@ -14,6 +14,13 @@ class Magma
     verb '::false' do
       child TrueClass
       constraint do
+        basic_constraint(@column_name, false)
+      end
+    end
+
+    verb '::untrue' do
+      child TrueClass
+      constraint do
         not_constraint(@column_name, true)
       end
     end

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -38,7 +38,7 @@ class Magma
         while restriction_model do
           if restriction_model.has_attribute?(:restricted)
             query_args.unshift(
-              ancestral_path + [ 'restricted', '::false' ]
+              ancestral_path + [ 'restricted', '::untrue' ]
             )
           end
           ancestral_path << restriction_model.parent_model_name&.to_s

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -341,19 +341,30 @@ describe QueryController do
   end
 
   context Magma::BooleanPredicate do
-    it 'checks truthiness' do
+    it 'checks ::true' do
       lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
-      hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false)
+      hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: nil)
       stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
-      query(
-        [ 'labor',
-          [ 'completed', '::false' ],
-          '::all',
-          'name'
-        ]
-      )
+      query([ 'labor', [ 'completed', '::true' ], '::all', 'name' ])
+      expect(json_body[:answer].map(&:last)).to eq([ 'Nemean Lion' ])
+      expect(json_body[:format]).to eq(['labors::labor#name', 'labors::labor#name'])
+    end
 
-      expect(json_body[:answer].map(&:last)).to eq([ 'Augean Stables', 'Lernean Hydra' ])
+    it 'checks ::false' do
+      lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+      hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: nil)
+      stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
+      query([ 'labor', [ 'completed', '::false' ], '::all', 'name' ])
+      expect(json_body[:answer].map(&:last)).to eq([ 'Augean Stables' ])
+      expect(json_body[:format]).to eq(['labors::labor#name', 'labors::labor#name'])
+    end
+
+    it 'checks ::untrue' do
+      lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true)
+      hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: nil)
+      stables = create(:labor, name: 'Augean Stables', number: 5, completed: false)
+      query([ 'labor', [ 'completed', '::untrue' ], '::all', 'name' ])
+      expect(json_body[:answer].map(&:last)).to match_array([ 'Lernean Hydra', 'Augean Stables' ])
       expect(json_body[:format]).to eq(['labors::labor#name', 'labors::labor#name'])
     end
   end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -523,6 +523,29 @@ describe RetrieveController do
       expect(json_body[:models][:victim][:documents].keys.sort).to eq(unrestricted_victim_list.map(&:identifier).map(&:to_sym))
     end
 
+    it 'conservatively hides if any ancestor is restricted' do
+      lion = create(:monster, :lion, restricted: true)
+      hydra = create(:monster, :hydra, restricted: false)
+
+      # some of the victims are not restricted
+      restricted_victim_list = create_list(:victim, 3, monster: lion, restricted: true)
+      unrestricted_victim_list = create_list(:victim, 3, monster: lion, restricted: false)
+      unrestricted_victim_list2 = create_list(:victim, 3, monster: lion, restricted: nil)
+
+      # some of the victims are not restricted
+      restricted_victim_list2 = create_list(:victim, 3, monster: hydra, restricted: true)
+      unrestricted_victim_list3 = create_list(:victim, 3, monster: hydra, restricted: false)
+      unrestricted_victim_list4 = create_list(:victim, 3, monster: hydra, restricted: nil)
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'victim',
+        record_names: 'all',
+        attribute_names: 'all'
+      )
+      expect(json_body[:models][:victim][:documents].keys.sort).to match_array((unrestricted_victim_list3 + unrestricted_victim_list4).map(&:identifier).map(&:to_sym))
+    end
+
     it 'shows restricted records to users with restricted permission' do
       restricted_victim_list = create_list(:victim, 9, restricted: true)
       unrestricted_victim_list = create_list(:victim, 9)


### PR DESCRIPTION
Missed getting this in by a hair's breadth before the recursive restriction stuff got merged, this just clarifies '::false' vs. '::untrue' (the latter including 'null', the former not) and indicates that unrestricted records are ones where restricted is '::untrue'.