### PR TITLE
Etna logger does not automatically log warnings, polyphemus always tr…

### DIFF
--- a/etna/lib/etna/logger.rb
+++ b/etna/lib/etna/logger.rb
@@ -16,7 +16,6 @@ module Etna
 
     def warn(msg, &block)
       super
-      Rollbar.warn(msg)
     end
 
     def error(msg, &block)

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'logger'
+require 'rollbar'
 
 class Polyphemus
   class Help < Etna::Command
@@ -268,7 +269,7 @@ class Polyphemus
           # Magma does not support delete right now, so we restrict the models, but we can unlink and
           # delete the files in metis
           restrict!(patient, delete_metis_files: true)
-        elsif should_be_restricted && ! patient['restricted']
+        elsif should_be_restricted
           restrict!(patient)
         elsif ! should_be_restricted && patient['restricted']
           unrestrict!(patient)
@@ -312,11 +313,6 @@ class Polyphemus
 
     def restrict!(patient, delete_metis_files: false)
       name = patient['name']
-      logger.warn("Attempting to restrict access to #{name}")
-
-      # This code path should be --eventually consistent--  That is to say, we should ensure each operation
-      # is idempotent (may need to be repeated), and that the patient is not marked restricted until all other
-      # related tasks are complete and the state is consistent.
 
       if delete_metis_files
         # do metis movement attempt for now -- no auto-delete
@@ -326,19 +322,20 @@ class Polyphemus
         restrict_patient_data(name)
       end
 
-
-      update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: project)
-      update_request.update_revision('patient', name, restricted: true)
-      magma_client.update(update_request)
+      unless patient['restricted']
+        logger.warn("Attempting to restrict access to #{name}")
+        Rollbar.warn("Attempting to restrict access to #{name}")
+        update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: project)
+        update_request.update_revision('patient', name, restricted: true)
+        magma_client.update(update_request)
+      end
     end
 
     def unrestrict!(patient)
       name = patient['name']
       logger.warn("Attempting to unrestrict access to #{name}")
+      Rollbar.warn("Attempting to unrestrict access to #{name}")
 
-      # This code path should be --eventually consistent--  That is to say, we should ensure each operation
-      # is idempotent (may need to be repeated), and that the patient is not marked restricted until all other
-      # related tasks are complete and the state is consistent.
       release_patient_data(name)
 
       update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: project)

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -324,7 +324,7 @@ class Polyphemus
 
       unless patient['restricted']
         logger.warn("Attempting to restrict access to #{name}")
-        Rollbar.warn("Attempting to restrict access to #{name}")
+        Rollbar.info("Attempting to restrict access to #{name}")
         update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: project)
         update_request.update_revision('patient', name, restricted: true)
         magma_client.update(update_request)
@@ -334,7 +334,7 @@ class Polyphemus
     def unrestrict!(patient)
       name = patient['name']
       logger.warn("Attempting to unrestrict access to #{name}")
-      Rollbar.warn("Attempting to unrestrict access to #{name}")
+      Rollbar.info("Attempting to unrestrict access to #{name}")
 
       release_patient_data(name)
 

--- a/polyphemus/spec/examples.txt
+++ b/polyphemus/spec/examples.txt
@@ -1,16 +1,16 @@
 example_id                                    | status | run_time        |
 --------------------------------------------- | ------ | --------------- |
-./spec/cascade_mvir_restricted_spec.rb[1:1:1] | passed | 0.07517 seconds |
-./spec/cascade_mvir_restricted_spec.rb[1:1:2] | passed | 0.06381 seconds |
-./spec/cascade_mvir_restricted_spec.rb[1:2:1] | passed | 0.04603 seconds |
-./spec/cascade_mvir_restricted_spec.rb[1:2:2] | passed | 0.04327 seconds |
-./spec/metis_waiver_helper_spec.rb[1:1]       | passed | 0.00617 seconds |
-./spec/metis_waiver_helper_spec.rb[1:2]       | passed | 0.00352 seconds |
-./spec/metis_waiver_helper_spec.rb[1:3]       | passed | 0.02485 seconds |
-./spec/metis_waiver_helper_spec.rb[1:4]       | passed | 0.00431 seconds |
-./spec/metis_waiver_helper_spec.rb[1:5]       | passed | 0.0255 seconds  |
-./spec/metis_waiver_helper_spec.rb[1:6]       | passed | 0.00337 seconds |
-./spec/metis_waiver_helper_spec.rb[1:7]       | passed | 0.01387 seconds |
-./spec/metis_waiver_helper_spec.rb[1:8]       | passed | 0.00359 seconds |
-./spec/metis_waiver_helper_spec.rb[1:9]       | passed | 0.01605 seconds |
-./spec/metis_waiver_helper_spec.rb[1:10]      | passed | 0.00634 seconds |
+./spec/cascade_mvir_restricted_spec.rb[1:1:1] | passed | 0.10258 seconds |
+./spec/cascade_mvir_restricted_spec.rb[1:1:2] | passed | 0.07667 seconds |
+./spec/cascade_mvir_restricted_spec.rb[1:2:1] | passed | 0.05795 seconds |
+./spec/cascade_mvir_restricted_spec.rb[1:2:2] | passed | 0.05605 seconds |
+./spec/metis_waiver_helper_spec.rb[1:1]       | passed | 0.00791 seconds |
+./spec/metis_waiver_helper_spec.rb[1:2]       | passed | 0.003 seconds   |
+./spec/metis_waiver_helper_spec.rb[1:3]       | passed | 0.02496 seconds |
+./spec/metis_waiver_helper_spec.rb[1:4]       | passed | 0.003 seconds   |
+./spec/metis_waiver_helper_spec.rb[1:5]       | passed | 0.0268 seconds  |
+./spec/metis_waiver_helper_spec.rb[1:6]       | passed | 0.00497 seconds |
+./spec/metis_waiver_helper_spec.rb[1:7]       | passed | 0.01476 seconds |
+./spec/metis_waiver_helper_spec.rb[1:8]       | passed | 0.00275 seconds |
+./spec/metis_waiver_helper_spec.rb[1:9]       | passed | 0.01422 seconds |
+./spec/metis_waiver_helper_spec.rb[1:10]      | passed | 0.0052 seconds  |


### PR DESCRIPTION
…ies to move patient files

This was actually simpler than expected.

1.  Always try to restrict patient files for all restricted patients.  Even if they have already been restricted.  This means @graft you can set the restricted bit freely, this script will still handle the files.  This seems like a lot of extra work but it's actually not; we cache the entire bucket's folder set in one query anyways, which is a fixed cost.

2.  Reduce rollbar logger messages by not implicitly logging every warn.