### PR TITLE
add some tsv specs, fix file attribute bug in query_to_tsv

### DIFF
--- a/magma/lib/magma/attributes/file.rb
+++ b/magma/lib/magma/attributes/file.rb
@@ -64,8 +64,7 @@ class Magma
       end
     end
 
-    def query_to_tsv(value)
-      file = query_to_payload(value)
+    def query_to_tsv(file)
       file ? file[:url] : nil
     end
 

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -303,7 +303,7 @@ describe RetrieveController do
       )
       header, *table = CSV.parse(last_response.body, col_sep: "\t")
 
-      expect(table).to match_array(prize_list.map{|l| [ l.labor, l.name, l.worth.to_s ] })
+      expect(table).to match_array(prize_list.map{|l| header.map{|h| l.send(h)&.to_s} })
     end
 
     it 'can retrieve a TSV of collection attribute' do

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -319,7 +319,7 @@ describe RetrieveController do
       )
 
       header, *table = CSV.parse(last_response.body, col_sep: "\t")
-      expect(table).to eq([ [ "The Twelve Labors of Hercules", "labor1, labor2, labor3"] ])
+      expect(table).to eq([ [ "The Twelve Labors of Hercules", labors.map(&:identifier).join(', ') ] ])
     end
 
     it 'retrieves a TSV with file attributes as urls' do


### PR DESCRIPTION
A bug was introduced at some point during our various file attribute munges which prevented the url from appearing in TSV downloads; since TSV downloads are pretty useful tools in the Timur context this is unfortunate.

I'm repairing this here for expediency; however, these issues are all due to the rather intrusive way that the TSVWriter class reaches into the Magma::Payload class to determine its output; that class is as a result something of a paper tiger, which appears as if it should abstract away a coherent payload format but in fact provides very little other to the TSV output. A separate overhaul of this class is required. The test coverage for TSV format is also abysmal, there should be tests covering each attribute type, but there are only a few (and pretty impoverished tests at that). These concerns should be addressed separately.