### PR TITLE
Account for change in permission format for Timur home page

### DIFF
--- a/timur/lib/client/jsx/components/home_page.jsx
+++ b/timur/lib/client/jsx/components/home_page.jsx
@@ -1,24 +1,31 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
+import * as _ from 'lodash';
+
 // Module imports.
 import { selectUserPermissions } from '../selectors/user_selector';
 
-export class HomePage extends React.Component{
+export default class HomePage extends React.Component{
   renderProjects(){
     let { permissions } = this.props;
-    if(permissions.length <= 0){
+
+    if(_.keys(permissions).length <= 0){
       return <span>{'No available projects.'}</span>;
     }
 
-    return permissions.map(({project_name,role})=>
-        <a className='home-page-project-link'
-          key={project_name}
-          href={`/${project_name}`}>
-          {project_name} &nbsp;
-          <span className='home-page-project-role'>({role})</span>
-        </a>
-    );
+    return <React.Fragment>
+      {_.keys(permissions).map( key => {
+          let {project_name, role} = permissions[key];
+          return <a className='home-page-project-link'
+            key={project_name}
+            href={`/${project_name}`}>
+            {project_name} &nbsp;
+            <span className='home-page-project-role'>({role})</span>
+          </a>
+      })}
+    </React.Fragment>
+
   }
 
   render(){

--- a/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HomePage renders 1`] = `
+<div
+  className="browser project"
+>
+  <div
+    className="home-page-header-group"
+  >
+    <div
+      className="page-detail-group"
+    >
+      Available Projects
+    </div>
+  </div>
+  <div
+    className="browser-tab"
+  />
+</div>
+`;

--- a/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
@@ -15,6 +15,35 @@ exports[`HomePage renders 1`] = `
   </div>
   <div
     className="browser-tab"
-  />
+  >
+    <a
+      className="home-page-project-link"
+      href="/labors"
+    >
+      labors
+        
+      <span
+        className="home-page-project-role"
+      >
+        (
+        viewer
+        )
+      </span>
+    </a>
+    <a
+      className="home-page-project-link"
+      href="/wisdom"
+    >
+      wisdom
+        
+      <span
+        className="home-page-project-role"
+      >
+        (
+        viewer
+        )
+      </span>
+    </a>
+  </div>
 </div>
 `;

--- a/timur/test/javascript/components/home_page.test.js
+++ b/timur/test/javascript/components/home_page.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import {mount, shallow} from 'enzyme';
+import renderer from 'react-test-renderer';
+import {mockStore} from '../helpers';
+import HomePage from '../../../lib/client/jsx/components/home_page';
+
+const permissions = require('../fixtures/home_page_permissions.json');
+
+describe('HomePage', () => {
+  it('renders', () => {
+    const tree = renderer
+      .create(<HomePage permissions={permissions} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/timur/test/javascript/fixtures/home_page_permissions.json
+++ b/timur/test/javascript/fixtures/home_page_permissions.json
@@ -1,7 +1,7 @@
 {
   "labors": {
-    "role": "administrator",
-    "privileged": true,
+    "role": "viewer",
+    "privileged": false,
     "project_name": "labors"
   },
   "wisdom": {

--- a/timur/test/javascript/fixtures/home_page_permissions.json
+++ b/timur/test/javascript/fixtures/home_page_permissions.json
@@ -1,0 +1,12 @@
+{
+  "labors": {
+    "role": "administrator",
+    "privileged": true,
+    "project_name": "labors"
+  },
+  "wisdom": {
+    "role": "viewer",
+    "privileged": false,
+    "project_name": "wisdom"
+  }
+}


### PR DESCRIPTION
It seems like the `permissions` format changed from an Array to an Object when it was consolidated into `etna-js`. This breaks the Timur home page, where a user's projects are listed. I was getting the following errors in the console and just a blank screen at the root URL:

```
TypeError: permissions.map is not a function
    renderProjects https://timur.development.local/js/timur.bundle.js:83512
    render https://timur.development.local/js/timur.bundle.js:83535
    gi https://timur.development.local/js/timur.bundle.js:47484
    fi https://timur.development.local/js/timur.bundle.js:47483
    Rj https://timur.development.local/js/timur.bundle.js:47565
    Qj https://timur.development.local/js/timur.bundle.js:47548
    Kj https://timur.development.local/js/timur.bundle.js:47548
    yj https://timur.development.local/js/timur.bundle.js:47541
    Ig https://timur.development.local/js/timur.bundle.js:47532
    bk https://timur.development.local/js/timur.bundle.js:47583
    ik https://timur.development.local/js/timur.bundle.js:47586
    Nj https://timur.development.local/js/timur.bundle.js:47542
    ik https://timur.development.local/js/timur.bundle.js:47586
    render https://timur.development.local/js/timur.bundle.js:47592
    createUI https://timur.development.local/js/timur.bundle.js:47252
    TimurApplication https://timur.development.local/js/timur.bundle.js:47240
    <anonymous> https://timur.development.local/:17
timur.bundle.js:47511:195
```

Other pages in Timur would work fine, if you went directly to a project for example.

This PR adjusts the code in the `home_page` component to treat it as an Object instead of an Array.