### PR TITLE
Timur attribute ordering

### DIFF
--- a/timur/.gitignore
+++ b/timur/.gitignore
@@ -42,3 +42,6 @@ tmp
 /spec/examples.txt
 .npm-packages
 .npmrc
+
+view.rb
+*-view.json

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -38,7 +38,8 @@ const BrowserPane = ({ record, revision, pane, ...other_props}) => {
   const orderedViewAttributes = Object.values(pane.attributes)
     .sort((a, b) => a.index_order - b.index_order);
 
-  return console.log('rendering',  pane) || <div className='pane'>
+  console.log('rendering',  record);
+  return <div className='pane'>
     {
       pane.title && <div className='title' title={pane.name}>{pane.title}</div>
     }

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -27,27 +27,38 @@ const PaneAttribute = ({attribute, mode, value, revised_value, model_name, recor
   : null
 );
 
-const BrowserPane = ({ record, revision, pane, ...other_props}) =>
-  Object.keys(pane.attributes).length == 0
-  ? <div style={{'display': 'none'}} />
-  : console.log('rendering',  pane) || <div className='pane'>
+const BrowserPane = ({ record, revision, pane, ...other_props}) => {
+  if (Object.keys(pane.attributes).length === 0) {
+    return <div style={{'display': 'none'}} />
+  }
+
+  // We get an `index_order` from the server for defined views.
+  // We should verify that order is enforced, and not assume
+  //   that the pane.attributes are in the right order.
+  const orderedViewAttributes = Object.values(pane.attributes)
+    .sort((a, b) => a.index_order - b.index_order);
+
+  return console.log('rendering',  pane) || <div className='pane'>
     {
       pane.title && <div className='title' title={pane.name}>{pane.title}</div>
     }
     <div className='attributes'>
       {
-        Object.keys(pane.attributes).map(attribute_name=> {
+        orderedViewAttributes.map(attribute => {
+          let {attribute_name} = attribute;
+
           return <PaneAttribute
             key={attribute_name}
             record={record}
             value={ record[attribute_name] }
             revised_value={ (attribute_name in revision) ?  revision[attribute_name] : record[attribute_name] }
-            attribute={pane.attributes[attribute_name]}
+            attribute={attribute}
             {...other_props}
           />
         }).filter(_=>_)
       }
     </div>
   </div>;
+}
 
 export default BrowserPane

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 // Class imports.
 import AttributeViewer from '../attributes/attribute_viewer';
 
+import {sortAttributes} from '../../utils/attributes';
+
 const PaneAttribute = ({
   attribute,
   mode,
@@ -47,57 +49,39 @@ const getAttributeNamesByType = (attributes, type) => {
   });
 };
 
-const BrowserPane = ({record, revision, pane, ...other_props}) => {
-  const attribute_names = Object.keys(pane.attributes);
-
-  if (attribute_names.length === 0) {
-    return <div style={{display: 'none'}} />;
-  }
-
-  let sorted_attribute_names = new Set();
-
-  getAttributeNamesByType(pane.attributes, 'parent').forEach((attribute_name) =>
-    sorted_attribute_names.add(attribute_name)
-  );
-  getAttributeNamesByType(
-    pane.attributes,
-    'identifier'
-  ).forEach((attribute_name) => sorted_attribute_names.add(attribute_name));
-
-  attribute_names.forEach((attribute_name) =>
-    sorted_attribute_names.add(attribute_name)
-  );
-
-  console.log('rendering', record);
-  return (
-    <div className='pane'>
-      {pane.title && (
-        <div className='title' title={pane.name}>
-          {pane.title}
+const BrowserPane = ({record, revision, pane, ...other_props}) =>
+  Object.keys(pane.attributes).length === 0 ? (
+    <div style={{display: 'none'}} />
+  ) : (
+    console.log('rendering', record) || (
+      <div className='pane'>
+        {pane.title && (
+          <div className='title' title={pane.name}>
+            {pane.title}
+          </div>
+        )}
+        <div className='attributes'>
+          {sortAttributes(pane.attributes)
+            .map((attribute) => {
+              return (
+                <PaneAttribute
+                  key={attribute.name}
+                  record={record}
+                  value={record[attribute.name]}
+                  revised_value={
+                    attribute.name in revision
+                      ? revision[attribute.name]
+                      : record[attribute.name]
+                  }
+                  attribute={pane.attributes[attribute.name]}
+                  {...other_props}
+                />
+              );
+            })
+            .filter((_) => _)}
         </div>
-      )}
-      <div className='attributes'>
-        {Array.from(sorted_attribute_names)
-          .map((attribute_name) => {
-            return (
-              <PaneAttribute
-                key={attribute_name}
-                record={record}
-                value={record[attribute_name]}
-                revised_value={
-                  attribute_name in revision
-                    ? revision[attribute_name]
-                    : record[attribute_name]
-                }
-                attribute={pane.attributes[attribute_name]}
-                {...other_props}
-              />
-            );
-          })
-          .filter((_) => _)}
       </div>
-    </div>
+    )
   );
-};
 
 export default BrowserPane;

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -4,50 +4,100 @@ import * as React from 'react';
 // Class imports.
 import AttributeViewer from '../attributes/attribute_viewer';
 
-const PaneAttribute = ({attribute, mode, value, revised_value, model_name, record_name, template, record}) => (
-  (attribute.hidden !== true && (mode != 'edit' || attribute.editable)) ?
+const PaneAttribute = ({
+  attribute,
+  mode,
+  value,
+  revised_value,
+  model_name,
+  record_name,
+  template,
+  record
+}) =>
+  attribute.hidden !== true && (mode != 'edit' || attribute.editable) ? (
     <div className='attribute_row'>
-      <div className={ `attribute_name ${ (mode == 'edit' && value != revised_value) ? 'revised' : '' }` }
-        title={attribute.desc}>
-        {(attribute.display_name == null) ? attribute.title : attribute.display_name}
+      <div
+        className={`attribute_name ${
+          mode == 'edit' && value != revised_value ? 'revised' : ''
+        }`}
+        title={attribute.desc}
+      >
+        {attribute.display_name == null
+          ? attribute.title
+          : attribute.display_name}
       </div>
       <div className='attribute_value'>
         <AttributeViewer
-          model_name={ model_name }
-          record_name={ record_name }
+          model_name={model_name}
+          record_name={record_name}
           template={template}
           value={value}
           mode={mode}
-          attribute={ attribute }
+          attribute={attribute}
           document={record}
           revised_value={revised_value}
         />
       </div>
     </div>
-  : null
-);
+  ) : null;
 
-const BrowserPane = ({ record, revision, pane, ...other_props}) =>
-  Object.keys(pane.attributes).length == 0
-  ? <div style={{'display': 'none'}} />
-  : console.log('rendering',  record) || <div className='pane'>
-    {
-      pane.title && <div className='title' title={pane.name}>{pane.title}</div>
-    }
-    <div className='attributes'>
-      {
-        Object.keys(pane.attributes).map(attribute_name=> {
-          return <PaneAttribute
-            key={attribute_name}
-            record={record}
-            value={ record[attribute_name] }
-            revised_value={ (attribute_name in revision) ?  revision[attribute_name] : record[attribute_name] }
-            attribute={pane.attributes[attribute_name]}
-            {...other_props}
-          />
-        }).filter(_=>_)
-      }
+const getAttributeNamesByType = (attributes, type) => {
+  return Object.keys(attributes).filter((attribute_name) => {
+    return attributes[attribute_name].attribute_type === type;
+  });
+};
+
+const BrowserPane = ({record, revision, pane, ...other_props}) => {
+  const attribute_names = Object.keys(pane.attributes);
+
+  if (attribute_names.length === 0) {
+    return <div style={{display: 'none'}} />;
+  }
+
+  let sorted_attribute_names = new Set();
+
+  getAttributeNamesByType(pane.attributes, 'parent').forEach((attribute_name) =>
+    sorted_attribute_names.add(attribute_name)
+  );
+  getAttributeNamesByType(
+    pane.attributes,
+    'identifier'
+  ).forEach((attribute_name) => sorted_attribute_names.add(attribute_name));
+
+  attribute_names.forEach((attribute_name) =>
+    sorted_attribute_names.add(attribute_name)
+  );
+
+  console.log('rendering', record);
+  return (
+    <div className='pane'>
+      {pane.title && (
+        <div className='title' title={pane.name}>
+          {pane.title}
+        </div>
+      )}
+      <div className='attributes'>
+        {Array.from(sorted_attribute_names)
+          .map((attribute_name) => {
+            return (
+              <PaneAttribute
+                key={attribute_name}
+                record={record}
+                value={record[attribute_name]}
+                revised_value={
+                  attribute_name in revision
+                    ? revision[attribute_name]
+                    : record[attribute_name]
+                }
+                attribute={pane.attributes[attribute_name]}
+                {...other_props}
+              />
+            );
+          })
+          .filter((_) => _)}
+      </div>
     </div>
-  </div>;
+  );
+};
 
-export default BrowserPane
+export default BrowserPane;

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -4,78 +4,50 @@ import * as React from 'react';
 // Class imports.
 import AttributeViewer from '../attributes/attribute_viewer';
 
-import {sortAttributes} from '../../utils/attributes';
-
-const PaneAttribute = ({
-  attribute,
-  mode,
-  value,
-  revised_value,
-  model_name,
-  record_name,
-  template,
-  record
-}) =>
-  attribute.hidden !== true && (mode != 'edit' || attribute.editable) ? (
+const PaneAttribute = ({attribute, mode, value, revised_value, model_name, record_name, template, record}) => (
+  (attribute.hidden !== true && (mode != 'edit' || attribute.editable)) ?
     <div className='attribute_row'>
-      <div
-        className={`attribute_name ${
-          mode == 'edit' && value != revised_value ? 'revised' : ''
-        }`}
-        title={attribute.desc}
-      >
-        {attribute.display_name == null
-          ? attribute.title
-          : attribute.display_name}
+      <div className={ `attribute_name ${ (mode == 'edit' && value != revised_value) ? 'revised' : '' }` }
+        title={attribute.desc}>
+        {(attribute.display_name == null) ? attribute.title : attribute.display_name}
       </div>
       <div className='attribute_value'>
         <AttributeViewer
-          model_name={model_name}
-          record_name={record_name}
+          model_name={ model_name }
+          record_name={ record_name }
           template={template}
           value={value}
           mode={mode}
-          attribute={attribute}
+          attribute={ attribute }
           document={record}
           revised_value={revised_value}
         />
       </div>
     </div>
-  ) : null;
+  : null
+);
 
-const BrowserPane = ({record, revision, pane, ...other_props}) =>
-  Object.keys(pane.attributes).length === 0 ? (
-    <div style={{display: 'none'}} />
-  ) : (
-    console.log('rendering', record) || (
-      <div className='pane'>
-        {pane.title && (
-          <div className='title' title={pane.name}>
-            {pane.title}
-          </div>
-        )}
-        <div className='attributes'>
-          {sortAttributes(pane.attributes)
-            .map((attribute) => {
-              return (
-                <PaneAttribute
-                  key={attribute.name}
-                  record={record}
-                  value={record[attribute.name]}
-                  revised_value={
-                    attribute.name in revision
-                      ? revision[attribute.name]
-                      : record[attribute.name]
-                  }
-                  attribute={pane.attributes[attribute.name]}
-                  {...other_props}
-                />
-              );
-            })
-            .filter((_) => _)}
-        </div>
-      </div>
-    )
-  );
+const BrowserPane = ({ record, revision, pane, ...other_props}) =>
+  Object.keys(pane.attributes).length == 0
+  ? <div style={{'display': 'none'}} />
+  : console.log('rendering',  pane) || <div className='pane'>
+    {
+      pane.title && <div className='title' title={pane.name}>{pane.title}</div>
+    }
+    <div className='attributes'>
+      {
+        Object.keys(pane.attributes).map(attribute_name=> {
+          return <PaneAttribute
+            key={attribute_name}
+            record={record}
+            value={ record[attribute_name] }
+            revised_value={ (attribute_name in revision) ?  revision[attribute_name] : record[attribute_name] }
+            attribute={pane.attributes[attribute_name]}
+            {...other_props}
+          />
+        }).filter(_=>_)
+      }
+    </div>
+  </div>;
 
-export default BrowserPane;
+export default BrowserPane

--- a/timur/lib/client/jsx/components/browser/browser_pane.jsx
+++ b/timur/lib/client/jsx/components/browser/browser_pane.jsx
@@ -43,12 +43,6 @@ const PaneAttribute = ({
     </div>
   ) : null;
 
-const getAttributeNamesByType = (attributes, type) => {
-  return Object.keys(attributes).filter((attribute_name) => {
-    return attributes[attribute_name].attribute_type === type;
-  });
-};
-
 const BrowserPane = ({record, revision, pane, ...other_props}) =>
   Object.keys(pane.attributes).length === 0 ? (
     <div style={{display: 'none'}} />

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import { selectTemplate } from '../../selectors/magma';
+import { sortAttributes } from '../../utils/attributes';
 import AttributeReport from './attribute_report';
 
 const ModelAttribute = ({ attribute: { attribute_name, attribute_type, desc }, showAttribute }) => {
@@ -15,17 +16,6 @@ const ModelAttribute = ({ attribute: { attribute_name, attribute_type, desc }, s
   </div>
 }
 
-const order = ({attribute_type}) => ({
-  parent: 1,
-  identifier: 2,
-  collection: 3,
-  table: 4,
-  child: 5,
-  link: 6,
-  file: 7,
-  image: 8
-}[attribute_type] || 9)
-
 const ModelReport = ({ model_name, attribute_name, template, showAttribute }) =>
     (!template) ? <div/> :
     <div className="report">
@@ -37,9 +27,7 @@ const ModelReport = ({ model_name, attribute_name, template, showAttribute }) =>
           <span className="name">Attributes</span>
         </div>
         {
-          Object.values(template.attributes).sort(
-            (a,b) => (order(a)-order(b)) || a.attribute_name.localeCompare(b.attribute_name)
-          ).map( attribute =>
+          sortAttributes(template.attributes).map( attribute =>
             attribute.hidden
               ? null
               : <ModelAttribute key={attribute.attribute_name} showAttribute={ showAttribute } attribute={attribute} />

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -27,7 +27,7 @@ const ModelReport = ({ model_name, attribute_name, template, showAttribute }) =>
           <span className="name">Attributes</span>
         </div>
         {
-          sortAttributes(template.attributes).map( attribute =>
+          Object.values(sortAttributes(template.attributes)).map( attribute =>
             attribute.hidden
               ? null
               : <ModelAttribute key={attribute.attribute_name} showAttribute={ showAttribute } attribute={attribute} />

--- a/timur/lib/client/jsx/selectors/search.js
+++ b/timur/lib/client/jsx/selectors/search.js
@@ -1,5 +1,5 @@
 import {createSelector} from 'reselect';
-import {displayAttributes, selectTemplate} from "./magma";
+import {displayAttributes, selectTemplate} from './magma';
 import {sortAttributes} from '../utils/attributes';
 
 class SearchCache {
@@ -34,51 +34,52 @@ export const selectSearchAttributeNames = createSelector(
 
 export const selectSelectedModel = createSelector(
   selectSearchData,
-  ({ selected_model }) => selected_model,
-)
+  ({selected_model}) => selected_model
+);
 
 export const selectExpandedDisplayAttributeNames = createSelector(
   selectSelectedModel,
-  ({ magma }) => magma,
+  ({magma}) => magma,
   (selectedModel, magma) => {
     if (!selectedModel) return [];
 
     // Have to use the selector here instead of in connect()
     //   because the selectedModel is in component state instead
     //   of global state.
-    const template = selectTemplate({ magma }, selectedModel);
+    const template = selectTemplate({magma}, selectedModel);
     return displayAttributes(template);
   }
-)
+);
 
 export const selectDisplayAttributeNamesAndTypes = createSelector(
   selectExpandedDisplayAttributeNames,
   selectSelectedModel,
-  ({ magma }) => magma,
+  ({magma}) => magma,
   (displayAttributes, selectedModel, magma) => {
     if (!selectedModel) return [];
-    const template = selectTemplate({ magma }, selectedModel);
-    return displayAttributes
-      .map(name => [name, template.attributes[name].attribute_type]);
+    const template = selectTemplate({magma}, selectedModel);
+    return displayAttributes.map((name) => [
+      name,
+      template.attributes[name].attribute_type
+    ]);
   }
-)
+);
 
 export const selectSortedDisplayAttributeNames = createSelector(
   selectExpandedDisplayAttributeNames,
   selectSelectedModel,
-  ({ magma }) => magma,
+  ({magma}) => magma,
   (displayAttributes, selectedModel, magma) => {
     if (!selectedModel) return [];
-    const template = selectTemplate({ magma }, selectedModel);
-    
-    let attributes = {};
-    displayAttributes.forEach(name => {
-      attributes[name] = template.attributes[name]
-    });
-    attributes = sortAttributes({ ...attributes }, true);
+    const template = selectTemplate({magma}, selectedModel);
 
-    return attributes.map(
-      attribute => attribute.attribute_name);
+    let attributes = {};
+    displayAttributes.forEach((name) => {
+      attributes[name] = template.attributes[name];
+    });
+    attributes = Object.values(sortAttributes({...attributes}, true));
+
+    return attributes.map((attribute) => attribute.attribute_name);
   }
 );
 

--- a/timur/lib/client/jsx/selectors/search.js
+++ b/timur/lib/client/jsx/selectors/search.js
@@ -1,5 +1,6 @@
 import {createSelector} from 'reselect';
 import {displayAttributes, selectTemplate} from "./magma";
+import {sortAttributes} from '../utils/attributes';
 
 class SearchCache {
   constructor(search) {
@@ -62,30 +63,22 @@ export const selectDisplayAttributeNamesAndTypes = createSelector(
   }
 )
 
-const columnTypePriority = {
-  'identifier': 1,
-  'parent': 2,
-}
-
 export const selectSortedDisplayAttributeNames = createSelector(
-  selectDisplayAttributeNamesAndTypes,
-  (attributeNamesAndTypes) => {
-    // Shallow copy because the sort will mutate.  We don't want to mutate the shared instance
-    attributeNamesAndTypes = [ ...attributeNamesAndTypes ];
-    attributeNamesAndTypes = attributeNamesAndTypes
-      .map(([name, type]) => [name, columnTypePriority[type] || 100]);
+  selectExpandedDisplayAttributeNames,
+  selectSelectedModel,
+  ({ magma }) => magma,
+  (displayAttributes, selectedModel, magma) => {
+    if (!selectedModel) return [];
+    const template = selectTemplate({ magma }, selectedModel);
+    
+    let attributes = {};
+    displayAttributes.forEach(name => {
+      attributes[name] = template.attributes[name]
+    });
+    attributes = sortAttributes({ ...attributes }, true);
 
-    attributeNamesAndTypes.sort(
-      ([aname, atype], [bname, btype]) => {
-        if (atype === btype) {
-          if (aname < bname) return -1;
-          return 1;
-        }
-
-        return atype - btype;
-      })
-
-    return attributeNamesAndTypes.map(([name]) => name);
+    return attributes.map(
+      attribute => attribute.attribute_name);
   }
 );
 

--- a/timur/lib/client/jsx/selectors/tab_selector.jsx
+++ b/timur/lib/client/jsx/selectors/tab_selector.jsx
@@ -1,3 +1,5 @@
+import { sortAttributes } from '../utils/attributes';
+
 export const selectView = (state, model_name) => (
   state.views
   ? state.views[model_name]
@@ -61,13 +63,13 @@ export const interleaveAttributes = (tab, template)=>{
 
       // if there are no pane attributes show the whole template
       if (Object.keys(pane.attributes).length == 0) {
-        attributes = { ...Object.keys(template.attributes).reduce((attributes, att_name)=> {
+        attributes = sortAttributes({ ...Object.keys(template.attributes).reduce((attributes, att_name)=> {
           attributes[att_name] = {
             ...template.attributes[att_name],
             editable: true
           };
           return attributes;
-        },{})};
+        },{})});
       } else {
         // expand any attributes which are in the template
         Object.keys(pane.attributes).filter(attr_name=>attr_name in template.attributes).forEach(

--- a/timur/lib/client/jsx/utils/attributes.js
+++ b/timur/lib/client/jsx/utils/attributes.js
@@ -27,7 +27,6 @@ const order = (attribute, identifierFirst) => {
 };
 
 export const sortAttributes = (attributes, identifierFirst = false) => {
-  console.log('before sorting', attributes);
   const sortedAttributes = Object.values(attributes).sort(
     (a, b) =>
       order(a, identifierFirst) - order(b, identifierFirst) ||
@@ -41,6 +40,6 @@ export const sortAttributes = (attributes, identifierFirst = false) => {
       index_order: attribute.index_order ? attribute.index_order : index
     };
   });
-  console.log('done sorting', finalAttributes);
+
   return finalAttributes;
 };

--- a/timur/lib/client/jsx/utils/attributes.js
+++ b/timur/lib/client/jsx/utils/attributes.js
@@ -1,17 +1,27 @@
-const order = ({attribute_type}) =>
-  ({
-    parent: 1,
-    identifier: 2,
-    collection: 3,
-    table: 4,
-    child: 5,
-    link: 6,
-    file: 7,
-    image: 8
-  }[attribute_type] || 9);
+const order = (attribute, identifierFirst) => {
+  let { attribute_type } = attribute;
+  let map = identifierFirst ?
+    {
+        identifier: 1,
+        parent: 2
+    } : {
+        parent: 1,
+        identifier: 2
+    };
 
-export const sortAttributes = (attributes) =>
+    map = { ...map, ...{
+        collection: 3,
+        table: 4,
+        child: 5,
+        link: 6,
+        file: 7,
+        image: 8
+    }};
+  return (map[attribute_type] || 9);
+}
+
+export const sortAttributes = (attributes, identifierFirst = false) =>
   Object.values(attributes).sort(
     (a, b) =>
-      order(a) - order(b) || a.attribute_name.localeCompare(b.attribute_name)
+      order(a, identifierFirst) - order(b, identifierFirst) || a.attribute_name.localeCompare(b.attribute_name)
   );

--- a/timur/lib/client/jsx/utils/attributes.js
+++ b/timur/lib/client/jsx/utils/attributes.js
@@ -1,27 +1,46 @@
+import {sortedIndexOf} from 'lodash';
+
 const order = (attribute, identifierFirst) => {
-  let { attribute_type } = attribute;
-  let map = identifierFirst ?
-    {
+  let {attribute_type} = attribute;
+  let map = identifierFirst
+    ? {
         identifier: 1,
         parent: 2
-    } : {
+      }
+    : {
         parent: 1,
         identifier: 2
-    };
+      };
 
-    map = { ...map, ...{
-        collection: 3,
-        table: 4,
-        child: 5,
-        link: 6,
-        file: 7,
-        image: 8
-    }};
-  return (map[attribute_type] || 9);
-}
+  map = {
+    ...map,
+    ...{
+      collection: 3,
+      table: 4,
+      child: 5,
+      link: 6,
+      file: 7,
+      image: 8
+    }
+  };
+  return map[attribute_type] || 9;
+};
 
-export const sortAttributes = (attributes, identifierFirst = false) =>
-  Object.values(attributes).sort(
+export const sortAttributes = (attributes, identifierFirst = false) => {
+  console.log('before sorting', attributes);
+  const sortedAttributes = Object.values(attributes).sort(
     (a, b) =>
-      order(a, identifierFirst) - order(b, identifierFirst) || a.attribute_name.localeCompare(b.attribute_name)
+      order(a, identifierFirst) - order(b, identifierFirst) ||
+      a.attribute_name.localeCompare(b.attribute_name)
   );
+  let finalAttributes = {};
+  sortedAttributes.forEach((attribute, index) => {
+    // inject an index_order for default views
+    finalAttributes[attribute.attribute_name] = {
+      ...attribute,
+      index_order: attribute.index_order ? attribute.index_order : index
+    };
+  });
+  console.log('done sorting', finalAttributes);
+  return finalAttributes;
+};

--- a/timur/lib/client/jsx/utils/attributes.js
+++ b/timur/lib/client/jsx/utils/attributes.js
@@ -1,0 +1,17 @@
+const order = ({attribute_type}) =>
+  ({
+    parent: 1,
+    identifier: 2,
+    collection: 3,
+    table: 4,
+    child: 5,
+    link: 6,
+    file: 7,
+    image: 8
+  }[attribute_type] || 9);
+
+export const sortAttributes = (attributes) =>
+  Object.values(attributes).sort(
+    (a, b) =>
+      order(a) - order(b) || a.attribute_name.localeCompare(b.attribute_name)
+  );

--- a/timur/test/javascript/selectors/search.test.js
+++ b/timur/test/javascript/selectors/search.test.js
@@ -1,8 +1,15 @@
 import {
   selectSearchAttributeNames,
   selectSearchFilterParams,
-  selectSearchFilterString
+  selectSearchFilterString,
+  selectSortedDisplayAttributeNames
 } from '../../../lib/client/jsx/selectors/search';
+
+const models = {
+  monster: {template: require('../fixtures/template_monster.json')},
+  labor: {template: require('../fixtures/template_labor.json')},
+  project: {template: require('../fixtures/template_project.json')}
+};
 
 describe('selectSearchAttributeNames', () => {
   it('returns the attribute_names from the search state', () => {
@@ -51,3 +58,22 @@ describe('selectSearchFilterString', () => {
   });
 });
 
+describe('selectSortedDisplayAttributeNames', () => {
+  it('returns the sorted names of all attributes', () => {
+    let state = {
+      magma: {models},
+      search: {selected_model: 'monster'}
+    };
+
+    let attribute_names = selectSortedDisplayAttributeNames(state);
+
+    expect(attribute_names).toEqual([
+      'name',
+      'labor',
+      'aspect',
+      'victim',
+      'stats',
+      'species'
+    ]);
+  });
+});

--- a/timur/test/javascript/selectors/tab_selector.test.js
+++ b/timur/test/javascript/selectors/tab_selector.test.js
@@ -1,15 +1,36 @@
-import { interleaveAttributes } from '../../../lib/client/jsx/selectors/tab_selector';
+import {interleaveAttributes} from '../../../lib/client/jsx/selectors/tab_selector';
+
+import {sortAttributes} from '../../../lib/client/jsx/utils/attributes';
 
 describe('interleaveAttributes', () => {
   let monster = {
     attributes: {
-      name: { attribute_class: 'Magma::Attribute', type: 'String', name: 'name'},
-      height: { attribute_class: 'Magma::Attribute', type: 'Integer', name: 'height'},
-      cry: { attribute_class: 'Magma::Attribute', type: 'String', name: 'cry', options: [ 'scream', 'roar', 'hiss' ]}
+      name: {
+        attribute_class: 'Magma::Attribute',
+        type: 'String',
+        name: 'name',
+        attribute_name: 'name',
+        attribute_type: 'identifier'
+      },
+      height: {
+        attribute_class: 'Magma::Attribute',
+        type: 'Integer',
+        name: 'height',
+        attribute_name: 'height',
+        attribute_type: 'integer'
+      },
+      cry: {
+        attribute_class: 'Magma::Attribute',
+        type: 'String',
+        name: 'cry',
+        options: ['scream', 'roar', 'hiss'],
+        attribute_name: 'cry',
+        attribute_type: 'string'
+      }
     }
   };
 
-  it ('overwrites partial pane attributes with magma attributes', () => {
+  it('overwrites partial pane attributes with magma attributes', () => {
     let tab = {
       panes: {
         monster: {
@@ -18,7 +39,7 @@ describe('interleaveAttributes', () => {
             name: {},
             // here is some other attribute not present in the template
             victims: {
-              attribute_class: "VictimAttribute"
+              attribute_class: 'VictimAttribute'
             }
           }
         }
@@ -38,34 +59,36 @@ describe('interleaveAttributes', () => {
             },
             // the other is not
             victims: {
-              attribute_class: "VictimAttribute"
+              attribute_class: 'VictimAttribute'
             }
           }
         }
       }
     });
   });
-  it ('fills empty pane attributes information with the template attributes', () => {
+  it('fills empty pane attributes information with the template attributes', () => {
     // the pane attributes are undefined
     let tab = {
       panes: {
-        monster: { attributes: { } }
+        monster: {attributes: {}}
       }
     };
 
     let interleaved = interleaveAttributes(tab, monster);
 
-    // we get back the full list of template attributes
+    // we get back the full list of template attributes, sorted
     expect(interleaved).toEqual({
       panes: {
         monster: {
-          attributes: Object.keys(monster.attributes).reduce((attributes, att_name) => {
-            attributes[att_name] = {
-              ...monster.attributes[att_name],
-              editable: true
-            };
-            return attributes;
-          },{})
+          attributes: sortAttributes(
+            Object.keys(monster.attributes).reduce((attributes, att_name) => {
+              attributes[att_name] = {
+                ...monster.attributes[att_name],
+                editable: true
+              };
+              return attributes;
+            }, {})
+          )
         }
       }
     });


### PR DESCRIPTION
This PR addresses mountetna/timur#277. This enforces the same attribute ordering that we're using in the model map page, extracts that code and puts it into a shared utility that the Browser Pane uses ... @graft , this shouldn't override any manually defined views, right, but it will sort any attributes that are passed in from that view? Perhaps that is not desired before and the sorting needs to happen higher up in the component tree...I will do some more testing and play around with it.

This works currently for default views. Not sure how it interacts with manually defined views, and I need to test that further.