### PR TITLE
return folder created instead of root folder; [close mountetna/metis#91]

### DIFF
--- a/metis/lib/server/controllers/folder_controller.rb
+++ b/metis/lib/server/controllers/folder_controller.rb
@@ -54,7 +54,7 @@ class FolderController < Metis::Controller
     raise Etna::BadRequest, 'Invalid path' unless Metis::File.valid_file_path?(@params[:folder_path])
 
     folders = mkdir_p(bucket, @params[:folder_path], @params[:project_name], Metis::File.author(@user))
-    success_json(folders: [ folders.first.to_hash ])
+    success_json(folders: [ folders.last.to_hash ])
   end
 
   def remove

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -378,7 +378,7 @@ describe FolderController do
       post_create_folder('blueprints/Helmet Blueprints')
 
       expect(last_response.status).to eq(200)
-      expect(json_body[:folders][0][:folder_name]).to eq('Helmet Blueprints')
+      expect(json_body[:folders].first[:folder_name]).to eq('Helmet Blueprints')
       folder = Metis::Folder.last
       expect(folder.folder_path).to eq([ 'blueprints', 'Helmet Blueprints'])
       expect(Metis::Folder.count).to eq(2)

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -378,6 +378,7 @@ describe FolderController do
       post_create_folder('blueprints/Helmet Blueprints')
 
       expect(last_response.status).to eq(200)
+      expect(json_body[:folders][0][:folder_name]).to eq('Helmet Blueprints')
       folder = Metis::Folder.last
       expect(folder.folder_path).to eq([ 'blueprints', 'Helmet Blueprints'])
       expect(Metis::Folder.count).to eq(2)


### PR DESCRIPTION
This PR addresses mountenta/metis#91. Currently when using the Metis UI, a newly created folder shows up as the same name as the "root" folder (first one after the bucket). However, it is saved correctly in the database. Refreshing the page verifies this.

This PR returns the newly created leaf folder instead of the root folder in the Metis controller, and adds a test to verify this. This results in the UI showing the correct folder name for newly created folders.