### PR TITLE
Metis client find

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -4,8 +4,6 @@ require 'singleton'
 require_relative '../../client'
 require_relative './models'
 
-require 'pry'
-
 module Etna
   module Clients
     class Metis

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -4,6 +4,8 @@ require 'singleton'
 require_relative '../../client'
 require_relative './models'
 
+require 'pry'
+
 module Etna
   module Clients
     class Metis
@@ -40,6 +42,12 @@ module Etna
       def create_folder(create_folder_request)
         FoldersResponse.new(
           @etna_client.folder_create(create_folder_request.to_h))
+      end
+
+      def find(find_request)
+        binding.pry
+        FoldersAndFilesResponse.new(
+          @etna_client.bucket_find(find_request.to_h))
       end
 
       def folder_exists?(create_folder_request)

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -45,7 +45,6 @@ module Etna
       end
 
       def find(find_request)
-        binding.pry
         FoldersAndFilesResponse.new(
           @etna_client.bucket_find(find_request.to_h))
       end

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -64,6 +64,30 @@ module Etna
         end
       end
 
+      class FindRequest < Struct.new(:project_name, :bucket_name, :params, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**args)
+          super({params: []}.update(args))
+        end
+
+        def add_param(param)
+          params << param
+        end
+
+        def to_h
+          binding.pry
+          super().map { |val| val.is_a?(Hash) ? val.to_h : val }
+        end
+      end
+
+      class FindParam < Struct.new(:attribute, :predicate, :value, :type, keyword_init: true)
+        include JsonSerializableStruct
+        def initialize(**args)
+          super({}.update(args))
+        end
+      end
+
       class FoldersResponse
         attr_reader :raw
 

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -76,8 +76,9 @@ module Etna
         end
 
         def to_h
-          binding.pry
-          super().map { |val| val.is_a?(Hash) ? val.to_h : val }
+          # The nested :params values don't get converted correctly with transform_values, so it's
+          #   easier to do from a JSON string
+          JSON.parse(to_json, :symbolize_names => true)
         end
       end
 

--- a/etna/spec/metis_client_spec.rb
+++ b/etna/spec/metis_client_spec.rb
@@ -158,4 +158,19 @@ describe 'Metis Client class' do
     expect(WebMock).to have_requested(:get, /#{METIS_HOST}\/#{PROJECT}\/list_all_folders\/#{RELEASE_BUCKET}/)
     expect(WebMock).to have_requested(:get, /#{METIS_HOST}\/#{PROJECT}\/list_all_folders\/#{RESTRICT_BUCKET}/)
   end
+
+  it 'can find folders and files' do
+    stub_find({bucket: RELEASE_BUCKET})
+
+    test_class.find(Etna::Clients::Metis::FindRequest.new(
+      bucket_name: RELEASE_BUCKET,
+      project_name: 'test',
+      params: [Etna::Clients::Metis::FindParam.new(
+        attribute: 'name',
+        predicate: 'glob',
+        value: 'folder/fo*'
+      )]))
+
+    expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{RELEASE_BUCKET}/)
+  end
 end

--- a/etna/spec/metis_client_spec.rb
+++ b/etna/spec/metis_client_spec.rb
@@ -194,7 +194,6 @@ describe 'Metis Client class' do
       value: 'folder/fo*'
     ))
 
-
     test_class.find(find_request)
 
     expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{RELEASE_BUCKET}/).

--- a/etna/spec/metis_client_spec.rb
+++ b/etna/spec/metis_client_spec.rb
@@ -171,6 +171,38 @@ describe 'Metis Client class' do
         value: 'folder/fo*'
       )]))
 
-    expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{RELEASE_BUCKET}/)
+    expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{RELEASE_BUCKET}/).
+      with(body: hash_including({
+      params: [{
+        attribute: 'name',
+        predicate: 'glob',
+        value: 'folder/fo*'
+    }]}))
+  end
+
+  it 'can add multiple find params' do
+    stub_find({bucket: RELEASE_BUCKET})
+
+    find_request = Etna::Clients::Metis::FindRequest.new(
+      bucket_name: RELEASE_BUCKET,
+      project_name: 'test',
+      params: [])
+
+    find_request.add_param(Etna::Clients::Metis::FindParam.new(
+      attribute: 'name',
+      predicate: 'glob',
+      value: 'folder/fo*'
+    ))
+
+
+    test_class.find(find_request)
+
+    expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{RELEASE_BUCKET}/).
+      with(body: hash_including({
+      params: [{
+        attribute: 'name',
+        predicate: 'glob',
+        value: 'folder/fo*'
+    }]}))
   end
 end

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -69,7 +69,8 @@ def stub_metis_setup
     {:method=>"GET", :route=>"/:project_name/list_all_folders/:bucket_name", :name=>"folder_list_all_folders", :params=>["project_name", "bucket_name"]},
     {:method=>"GET", :route=>"/:project_name/list/:bucket_name/*folder_path", :name=>"folder_list", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/rename/:bucket_name/*folder_path", :name=>"folder_rename", :params=>["project_name", "bucket_name", "folder_path"]},
-    {:method=>"POST", :route=>"/:project_name/folder/create/:bucket_name/*folder_path", :name=>"folder_create", :params=>["project_name", "bucket_name", "folder_path"]}
+    {:method=>"POST", :route=>"/:project_name/folder/create/:bucket_name/*folder_path", :name=>"folder_create", :params=>["project_name", "bucket_name", "folder_path"]},
+    {:method=>"POST", :route=>"/:project_name/find/:bucket_name", :name=>"bucket_find", :params=>["project_name", "bucket_name"]}
   ])
 
   stub_request(:options, METIS_HOST).
@@ -115,6 +116,13 @@ end
 
 def stub_rename_folder(params={})
   stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/folder\/rename\/#{params[:bucket] || RESTRICT_BUCKET}\//)
+  .to_return({
+    status: params[:status] || 200
+  })
+end
+
+def stub_find(params={})
+  stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{params[:bucket] || RESTRICT_BUCKET}\//)
   .to_return({
     status: params[:status] || 200
   })

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -122,7 +122,7 @@ def stub_rename_folder(params={})
 end
 
 def stub_find(params={})
-  stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{params[:bucket] || RESTRICT_BUCKET}\//)
+  stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{params[:bucket] || RESTRICT_BUCKET}/)
   .to_return({
     status: params[:status] || 200
   })

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -187,6 +187,34 @@ class Polyphemus
     end
   end
 
+  class FindIpiBulkRnaSeqFolders < Etna::Command
+    include WithEtnaClients
+
+    usage "Fetch a list of Metis BulkRNASeq folders for IPI, from integral_data"
+
+    def project
+      :mvir1
+    end
+
+    def execute
+      folders = metis_client.find(
+          Etna::Clients::Metis::FindRequest.new(
+            project_name: 'ipi',
+            bucket_name: 'integral_data',
+            params: [Etna::Clients::Metis::FindParam.new(
+              attribute: 'name',
+              predicate: 'glob',
+              value: 'BulkRNASeq/IPI*',
+              type: 'folder'
+            )])).folders.all
+      puts "Found a total of #{folders.length} BulkRNASeq folders in the IPI integral_data bucket"
+    end
+
+    def setup(config)
+      super
+    end
+  end
+
   class Console < Etna::Command
     usage 'Open a console with a connected Polyphemus instance.'
 

--- a/polyphemus/lib/metis/mvir1_waiver.rb
+++ b/polyphemus/lib/metis/mvir1_waiver.rb
@@ -7,7 +7,7 @@ class Mvir1Waiver
 
   def initialize(metis_client:, project_name: 'mvir1')
     @metis_client = metis_client
-    @project_name = project_name
+    @project_name = project_name.to_s
     @release_bucket_name = bucket_name(:release_bucket)
     @restrict_bucket_name = bucket_name(:restrict_bucket)
     @release_folders = @metis_client.folders(


### PR DESCRIPTION
This PR adds support for the `find` route on Metis, to the Etna gem's Metis client. There is also an example in Polyphemus commands on how to use it.