### PR TITLE
accept ranges header on downloads

### DIFF
--- a/metis/lib/server/controllers/download_controller.rb
+++ b/metis/lib/server/controllers/download_controller.rb
@@ -13,7 +13,7 @@ class DownloadController < Metis::Controller
 
     return [
       200,
-      { 'X-Sendfile' => file.data_block.location },
+      { 'X-Sendfile' => file.data_block.location, 'Accept-Ranges' => 'bytes' },
       [ '' ]
     ]
   end


### PR DESCRIPTION
Very simple, just adds "Accept-Ranges: bytes" header to responses from download_url. The result is you can, e.g., scrub back and forth in a video without having to download the whole thing. But also, maybe later, scrub back and forth in an fcs file.