### PR TITLE
Add view update endpoint to timur

### DIFF
--- a/timur/lib/server.rb
+++ b/timur/lib/server.rb
@@ -16,6 +16,8 @@ class Timur
       erb_view(:client)
     end
 
+    post 'api/view/:project_name/:model_name', action: 'browse#update', as: :update_view, auth: { user: { is_admin?: :project_name } }
+
     with auth: { user: { can_view?: :project_name } } do
       # browse_controller.rb
       get 'api/view/:project_name/:model_name', action: 'browse#view', as: :view

--- a/timur/lib/server/controllers/browse_controller.rb
+++ b/timur/lib/server/controllers/browse_controller.rb
@@ -1,9 +1,22 @@
+require_relative '../view_update'
+
 class BrowseController < Timur::Controller
   def view
-    view = ViewTab.retrieve_view(
-      @params[:project_name],
-      @params[:model_name]
+    success_json(
+      ViewTab.retrieve_view(@params[:project_name], @params[:model_name])
     )
-    success(view.to_json, 'application/json')
+  end
+
+  def update
+    require_params :project_name, :model_name, :tabs
+
+    ViewUpdate.new(
+      @params[:project_name], @params[:model_name], @params[:tabs]
+    ).run
+
+    success_json(
+      ViewTab.retrieve_view(@params[:project_name], @params[:model_name])
+    )
   end
 end
+

--- a/timur/lib/server/view_update.rb
+++ b/timur/lib/server/view_update.rb
@@ -1,0 +1,69 @@
+class ViewUpdate
+  def initialize(project_name, model_name, tabs)
+    @project_name = project_name
+    @model_name = model_name
+    @tabs = tabs
+  end
+
+  def run
+    destroy_old_views
+
+    @tabs.each.with_index do |tab,i|
+      create_tab(tab, i)
+    end
+  end
+
+  private
+
+  def destroy_old_views
+    tabs = ViewTab.where(project: @project_name, model: @model_name).all
+    panes = ViewPane.where(view_tab_id: tabs.map(&:id)).all
+    attributes = ViewAttribute.where(view_pane_id: panes.map(&:id)).all
+
+    ViewAttribute.where(id: attributes.map(&:id)).destroy
+    ViewPane.where(id: panes.map(&:id)).destroy
+    ViewTab.where(id: tabs.map(&:id)).destroy
+  end
+
+  def create_tab(tab_config, index_order)
+    tab = ViewTab.create(
+      tab_config.slice(:name, :title, :description).merge(
+        project: @project_name,
+        model: @model_name,
+        index_order: index_order,
+        created_at: Time.now,
+        updated_at: Time.now
+      )
+    )
+
+    tab_config[:panes].each.with_index do |pane_config,i|
+      create_pane(pane_config, tab, i)
+    end
+  end
+
+  def create_pane(pane_config, tab, index_order)
+    pane = ViewPane.create(
+      pane_config.slice(:name, :title).merge(
+        view_tab: tab,
+        index_order: index_order,
+        created_at: Time.now,
+        updated_at: Time.now
+      )
+    )
+
+    pane_config[:attributes].each.with_index do |att_config,i|
+      create_attribute(att_config, pane, i)
+    end
+  end
+
+  def create_attribute(att_config, pane, index_order)
+    att = ViewAttribute.create(
+      att_config.slice(:name, :attribute_class).merge(
+        view_pane: pane,
+        index_order: index_order,
+        created_at: Time.now,
+        updated_at: Time.now
+      )
+    )
+  end
+end

--- a/timur/spec/browse_spec.rb
+++ b/timur/spec/browse_spec.rb
@@ -63,9 +63,13 @@ describe BrowseController do
 
       expect(last_response.status).to eq(200)
 
+      # the new panes are in place
       panes = json_body[:view][:tabs][:statistics][:panes]
       expect(panes[:appearance][:attributes].keys).to eq([:height, :mass])
       expect(panes[:mien][:attributes].keys).to eq([:odor])
+
+      # the old pane is gone
+      expect(panes[:default]).to be_nil
     end
   end
 end

--- a/timur/spec/browse_spec.rb
+++ b/timur/spec/browse_spec.rb
@@ -28,4 +28,44 @@ describe BrowseController do
       ).to eq([:weight, :size, :odor])
     end
   end
+
+  context '#update' do
+    it 'updates the view' do
+      view_tab = create(:view_tab, project: 'labors', model: 'monster', index_order: 1, name: 'stats')
+      view_pane = create(:view_pane, view_tab: view_tab, name: 'default')
+      size = create(:view_attribute, view_pane: view_pane, index_order: 2, name: 'size')
+      weight = create(:view_attribute, view_pane: view_pane, index_order: 1, name: 'weight')
+      odor = create(:view_attribute, view_pane: view_pane, index_order: 3, name: 'odor')
+
+      tabs = [
+        {
+          name: 'statistics',
+          panes: [
+            {
+              name: 'appearance',
+              attributes: [
+                { name: 'height' },
+                { name: 'mass' },
+              ]
+            },
+            {
+              name: 'mien',
+              attributes: [
+                { name: 'odor' }
+              ]
+            }
+          ]
+        }
+      ]
+
+      auth_header(:admin)
+      post('/api/view/labors/monster', tabs: tabs)
+
+      expect(last_response.status).to eq(200)
+
+      panes = json_body[:view][:tabs][:statistics][:panes]
+      expect(panes[:appearance][:attributes].keys).to eq([:height, :mass])
+      expect(panes[:mien][:attributes].keys).to eq([:odor])
+    end
+  end
 end


### PR DESCRIPTION
This is a piece of code I have had lying around for a while which lets you update a Timur view using a piece of JSON, here I am just exposing this via API, which should be sufficient basis to later build a basic view editing interface. Also much easier than hacking things into the database from the console.