### PR TITLE
Cs/make file attrs blank

### DIFF
--- a/etna/lib/etna/clients/magma/workflows.rb
+++ b/etna/lib/etna/clients/magma/workflows.rb
@@ -1,3 +1,4 @@
 require_relative './workflows/crud_workflow'
 require_relative './workflows/file_linking_workflow'
 require_relative './workflows/model_synchronization_workflow'
+require_relative './workflows/file_attributes_blank_workflow'

--- a/etna/lib/etna/clients/magma/workflows/file_attributes_blank_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/file_attributes_blank_workflow.rb
@@ -1,0 +1,69 @@
+require 'ostruct'
+require 'pry'
+require_relative './crud_workflow'
+
+module Etna
+  module Clients
+    class Magma
+      class FileAttributesBlankWorkflow < Struct.new(:magma_crud, :model_names, :project_name, keyword_init: true)
+
+        def initialize(opts)
+          super(**{}.update(opts))
+        end
+
+        def magma_client
+          magma_crud.magma_client
+        end
+
+        def find_file_and_image_attributes
+          {}.tap do |all_matches|
+            model_names.each do |model_name|
+              attribute_names = models.model(model_name).template.attributes.all.select {|a|
+                a.attribute_type == Etna::Clients::Magma::AttributeType::FILE ||
+                a.attribute_type == Etna::Clients::Magma::AttributeType::IMAGE}.map { |a|
+                a.attribute_name}
+              all_matches[model_name] = attribute_names
+            end
+          end
+        end
+
+        def each_revision
+          find_file_and_image_attributes.each do |model_name, attribute_names|
+            # Query all records in this model
+            request = Etna::Clients::Magma::RetrievalRequest.new(project_name: project_name)
+            request.model_name = model_name
+            request.attribute_names = attribute_names
+            request.record_names = 'all'
+            documents = magma_client.retrieve(request).models.model(model_name).documents
+
+            documents.document_keys.each do |record_name|
+              document = documents.document(record_name)
+              attribute_names.each do |attribute_name|
+                yield [model_name, record_name, attribute_name] if !document[attribute_name]
+              end
+            end
+          end
+        end
+
+        def set_file_attrs_blank
+          magma_crud.update_records do |update_request|
+            each_revision do |model_name, record_name, attribute_name|
+              update_request.update_revision(model_name, record_name, revision_for(attribute_name))
+            end
+          end
+        end
+
+        def revision_for(attribute_name)
+          {attribute_name => {path: "::blank"}}
+        end
+
+        def models
+          @models ||= begin
+            magma_client.retrieve(RetrievalRequest.new(project_name: self.project_name, model_name: 'all')).models
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/etna/lib/etna/clients/magma/workflows/file_attributes_blank_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/file_attributes_blank_workflow.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'pry'
 require_relative './crud_workflow'
 
 module Etna

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -482,6 +482,29 @@ class Polyphemus
     end
   end
 
+  class SetFileAttributesToBlank < Etna::Command
+    include WithEtnaClientsByEnvironment
+    include WithLogger
+    usage 'set_file_attributes_to_blank <environment> <project_name> <model_names>'
+
+    def magma_crud
+      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(
+        magma_client: @environ.magma_client,
+        project_name: @project_name)
+    end
+
+    def execute(env, project_name, *model_names)
+      @environ = environment(env)
+      @project_name = project_name
+
+      blanker = Etna::Clients::Magma::FileAttributesBlankWorkflow.new(
+        magma_crud: magma_crud,
+        model_names: model_names,
+        project_name: project_name)
+      blanker.set_file_attrs_blank
+    end
+  end
+
   class Console < Etna::Command
     usage 'Open a console with a connected Polyphemus instance.'
 


### PR DESCRIPTION
This PR adds a polyphemus command and Etna workflow to help mark all `nil` File and Image attributes as `::blank`, for all records in a model -- so basically we know that any record without a file assigned in a File / Image attribute won't have one in the future.

For now, this will only be used for IPI Flow model, but could conceivably also be used for Patient or any other model that we know won't have new Files / Images added. Only really useful at the end of a project, when we're "closing it out".