### PR TITLE
Sort flow files into integral dataset

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -23,15 +23,21 @@ module Etna
           @etna_client.folder_list(list_folder_request.to_h))
       end
 
+      def ensure_parent_folder_exists(project_name:, bucket_name:, path:)
+        create_folder_request = CreateFolderRequest.new(
+          project_name: project_name,
+          bucket_name: bucket_name,
+          folder_path: parent_folder_path(path)
+        )
+        create_folder(create_folder_request) if !folder_exists?(create_folder_request)
+      end
+
       def rename_folder(rename_folder_request)
-        if rename_folder_request.create_parent
-          create_parent_request = CreateFolderRequest.new(
-            project_name: rename_folder_request.project_name,
-            bucket_name: rename_folder_request.new_bucket_name,
-            folder_path: parent_folder_path(rename_folder_request.new_folder_path)
-          )
-          create_folder(create_parent_request) if !folder_exists?(create_parent_request)
-        end
+        ensure_parent_folder_exists(
+          project_name: rename_folder_request.project_name,
+          bucket_name: rename_folder_request.new_bucket_name,
+          path: rename_folder_request.new_folder_path
+        ) if rename_folder_request.create_parent
 
         FoldersResponse.new(
           @etna_client.folder_rename(rename_folder_request.to_h))

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -3,6 +3,7 @@ require 'net/http/post/multipart'
 require 'singleton'
 require_relative '../../client'
 require_relative './models'
+require_relative './workflows'
 
 module Etna
   module Clients
@@ -45,6 +46,11 @@ module Etna
       def find(find_request)
         FoldersAndFilesResponse.new(
           @etna_client.bucket_find(find_request.to_h))
+      end
+
+      def copy_files(copy_files_request)
+        FilesResponse.new(
+          @etna_client.file_bulk_copy(copy_files_request.to_h))
       end
 
       def folder_exists?(create_folder_request)

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -3,7 +3,6 @@ require 'net/http/post/multipart'
 require 'singleton'
 require_relative '../../client'
 require_relative './models'
-require_relative './workflows'
 
 module Etna
   module Clients

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -89,6 +89,31 @@ module Etna
         end
       end
 
+      class CopyFilesRequest < Struct.new(:project_name, :revisions, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**args)
+          super({revisions: []}.update(args))
+        end
+
+        def add_revision(revision)
+          revisions << revision
+        end
+
+        def to_h
+          # The nested :revisions values don't get converted correctly with transform_values, so it's
+          #   easier to do from a JSON string
+          JSON.parse(to_json, :symbolize_names => true)
+        end
+      end
+
+      class CopyRevision < Struct.new(:source, :dest, keyword_init: true)
+        include JsonSerializableStruct
+        def initialize(**args)
+          super({}.update(args))
+        end
+      end
+
       class FoldersResponse
         attr_reader :raw
 
@@ -98,6 +123,18 @@ module Etna
 
         def folders
           Folders.new(raw[:folders])
+        end
+      end
+
+      class FilesResponse
+        attr_reader :raw
+
+        def initialize(raw = {})
+          @raw = raw
+        end
+
+        def files
+          Files.new(raw[:files])
         end
       end
 

--- a/etna/lib/etna/clients/metis/workflows.rb
+++ b/etna/lib/etna/clients/metis/workflows.rb
@@ -1,0 +1,1 @@
+require_relative './workflows/flow_integral_data_workflow'

--- a/etna/lib/etna/clients/metis/workflows.rb
+++ b/etna/lib/etna/clients/metis/workflows.rb
@@ -1,1 +1,0 @@
-require_relative './workflows/flow_integral_data_workflow'

--- a/etna/spec/metis_client_spec.rb
+++ b/etna/spec/metis_client_spec.rb
@@ -204,4 +204,26 @@ describe 'Metis Client class' do
         value: 'folder/fo*'
     }]}))
   end
+
+  it 'can copy files' do
+    stub_copy
+
+    copy_request = Etna::Clients::Metis::CopyFilesRequest.new(
+      project_name: 'test',
+      revisions: [])
+
+    copy_request.add_revision(Etna::Clients::Metis::CopyRevision.new(
+      source: 'metis://foo',
+      dest: 'metis://bar'
+    ))
+
+    test_class.copy_files(copy_request)
+
+    expect(WebMock).to have_requested(:post, /#{METIS_HOST}\/#{PROJECT}\/files\/copy/).
+      with(body: hash_including({
+      revisions: [{
+        source: 'metis://foo',
+        dest: 'metis://bar'
+    }]}))
+  end
 end

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -128,7 +128,8 @@ def stub_metis_setup
     {:method=>"GET", :route=>"/:project_name/list/:bucket_name/*folder_path", :name=>"folder_list", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/rename/:bucket_name/*folder_path", :name=>"folder_rename", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/create/:bucket_name/*folder_path", :name=>"folder_create", :params=>["project_name", "bucket_name", "folder_path"]},
-    {:method=>"POST", :route=>"/:project_name/find/:bucket_name", :name=>"bucket_find", :params=>["project_name", "bucket_name"]}
+    {:method=>"POST", :route=>"/:project_name/find/:bucket_name", :name=>"bucket_find", :params=>["project_name", "bucket_name"]},
+    {:method=>"POST", :route=>"/:project_name/files/copy", :name=>"file_bulk_copy", :params=>["project_name"]}
   ])
 
   stub_request(:options, METIS_HOST).
@@ -181,6 +182,13 @@ end
 
 def stub_find(params={})
   stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/find\/#{params[:bucket] || RESTRICT_BUCKET}/)
+  .to_return({
+    status: params[:status] || 200
+  })
+end
+
+def stub_copy(params={})
+  stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/files\/copy/)
   .to_return({
     status: params[:status] || 200
   })

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -482,6 +482,24 @@ class Polyphemus
     end
   end
 
+  class IpiCopyFlowToIntegralDataset < Etna::Command
+    include WithEtnaClientsByEnvironment
+    include WithLogger
+    usage 'ipi_copy_flow_to_integral_dataset <environment> <source_bucket> <source_folder>'
+
+    def execute(env, source_bucket, source_folder)
+      require_relative './ipi/flow_populate_integral_data'
+      metis_client = environment(env).metis_client
+
+      integral_flow = IpiFlowPopulateIntegralData.new(
+        metis_client: metis_client,
+        source_bucket_name: source_bucket,
+        source_folder_name: source_folder
+        )
+      integral_flow.copy_files
+    end
+  end
+
   class Console < Etna::Command
     usage 'Open a console with a connected Polyphemus instance.'
 

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -482,7 +482,6 @@ class Polyphemus
     end
   end
 
-<<<<<<< HEAD
   class IpiCopyFlowToIntegralDataset < Etna::Command
     include WithEtnaClientsByEnvironment
     include WithLogger
@@ -498,7 +497,9 @@ class Polyphemus
         source_folder_name: source_folder
         )
       integral_flow.copy_files
-=======
+    end
+  end
+
   class SetFileAttributesToBlank < Etna::Command
     include WithEtnaClientsByEnvironment
     include WithLogger
@@ -519,7 +520,6 @@ class Polyphemus
         model_names: model_names,
         project_name: project_name)
       blanker.set_file_attrs_blank
->>>>>>> master
     end
   end
 

--- a/polyphemus/lib/ipi/flow_fcs_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_fcs_file_linker.rb
@@ -5,11 +5,12 @@ require_relative './ipi_helper'
 class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
   def initialize(**opts)
     super(**{bucket_name: 'integral_data', model_name: 'flow'}.update(opts))
+    @helper = IpiHelper.new
   end
 
   def find_matches
     {}.tap do |all_matches|
-      IpiHelper::find_files_by_extension(
+      @helper.find_files_by_extension(
         metis_client: metis_client,
         project_name: project_name,
         bucket_name: bucket_name,
@@ -18,48 +19,12 @@ class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
         file_path = fcs_file.file_path
         key = [{
           fcs_file: file_path,
-          stain: stain_from_fcs(file_path),
-          stain_name: stain_name_from_fcs(file_path)
+          stain: @helper.stain_from_fcs(file_path),
+          stain_name: @helper.stain_name_from_fcs(file_path)
         }, :fcs_file]
         all_matches[key] = [file_path]
       end
     end
-  end
-
-  def stain_from_fcs(fcs_file_path)
-    # File name should be: IPICRC024_T3_flow_dc.fcs
-    # We need to return dc
-    file_name = IpiHelper::file_name_from_path(fcs_file_path).sub('.fcs', '')
-    regex_results = fcs_regex(file_name)
-    regex_results[:stain].downcase
-  end
-
-  def stain_name_from_fcs(fcs_file_path)
-    # File name should be: IPICRC024_T3_flow_dc.fcs
-    # We need to return IPICRC024.T3.flow.dc
-    IpiHelper::file_name_from_path(
-      fcs_file_path).sub('.fcs', '').gsub('_', '.')
-  end
-
-  def sample_name_from_fcs(fcs_file_path)
-    # File name should be: IPICRC024_T3_flow_dc.fcs
-    # We need to return IPICRC024.T3
-    file_name = IpiHelper::file_name_from_path(fcs_file_path).sub('.fcs', '')
-    regex_results = fcs_regex(file_name)
-    regex_results[:sample_name].sub('_', '.')
-  end
-
-  def patient_name_from_fcs(fcs_file_path)
-    # File name should be: IPICRC024_T3_flow_dc.fcs
-    # We need to return IPICRC024
-    sample_name = sample_name_from_fcs(fcs_file_path)
-    sample_name.split('.').first
-  end
-
-  def fcs_regex(file_name)
-    regex = Regexp.new('(?<sample_name>IPI\w+\d+_\w+\d)_(?:flow_)?(?<stain>dc|innate|nktb|sort|treg)', Regexp::IGNORECASE)
-    raise "FCS filename #{file_name} does not match expected regex" unless regex.match(file_name)
-    regex.match(file_name)
   end
 
   # Subclasses should override this to implement custom logic for how regex matches should match to linking.
@@ -68,9 +33,9 @@ class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
       identifiers.update(match_data)
       # Below data is to get_or_create the parent records
       identifiers['flow'] = match_data[:stain_name]
-      identifiers['sample'] = sample_name_from_fcs(match_data[:fcs_file])
-      identifiers['patient'] = patient_name_from_fcs(match_data[:fcs_file])
-      identifiers['experiment'] = IpiHelper::experiment_from_patient_number(identifiers['patient'])
+      identifiers['sample'] = @helper.sample_name_from_fcs(match_data[:fcs_file])
+      identifiers['patient'] = @helper.patient_name_from_fcs(match_data[:fcs_file])
+      identifiers['experiment'] = @helper.experiment_from_patient_number(identifiers['patient'])
     end
   end
 

--- a/polyphemus/lib/ipi/flow_populate_integral_data.rb
+++ b/polyphemus/lib/ipi/flow_populate_integral_data.rb
@@ -1,0 +1,93 @@
+# This class copies data from a Metis bucket and organizes it into the integral dataset.
+# This assumes the WSP and FCS files in the source Metis bucket
+#   have gone through Lenny's pipeline and are consistently named,
+#   following our naming convention.
+require 'ostruct'
+require_relative './ipi_helper'
+
+class IpiFlowPopulateIntegralData < Struct.new(:metis_client, :project_name, :source_bucket_name, :source_folder_name, :dest_bucket_name, keyword_init: true)
+  attr_reader :helper
+
+  def initialize(**opts)
+    super(**{dest_bucket_name: 'integral_data', project_name: 'ipi'}.update(opts))
+    @helper = IpiHelper.new
+  end
+
+  def find_files(extension)
+    helper.find_files_in_folder_by_extension(
+      metis_client: metis_client,
+      project_name: project_name,
+      bucket_name: source_bucket_name,
+      folder_name: source_folder_name,
+      extension: extension
+    )
+  end
+
+  def source_metis_path(file)
+    "metis://#{project_name}/#{source_bucket_name}/#{file.file_path}"
+  end
+
+  def dest_path(file)
+    # Return the full metis path for the file
+    #
+    # WSP are associated with the patient
+    #
+    # IPIGYN001/
+    #     IPIGYN001.wsp
+    #
+    # FCS are associated with the sample / tube, i.e. FlowCytometry/ would be
+    #     a new directory under IPIGYN001.T1/
+    # Then each stain has a subdirectory?
+    #
+    # IPIGYN001.T1/
+    #     FlowCytometry/
+    #         IPIGYN001.T1.flow.dc/
+    #             IPIGYN001_T1_flow_dc.fcs
+
+    patient_name = is_wsp(file) ?
+      helper.patient_name_from_wsp(file.file_path) :
+      helper.patient_name_from_fcs(file.file_path)
+    experiment = helper.experiment_from_patient_number(patient_name)
+
+    return "#{experiment}/#{patient_name}/#{file.file_name}" if is_wsp(file)
+
+    sample_name = helper.sample_name_from_fcs(file.file_path)
+    stain_name = helper.stain_name_from_fcs(file.file_path)
+
+    return "#{experiment}/#{patient_name}/#{sample_name}/FlowCytometry/#{stain_name}/#{file.file_name}"
+  end
+
+  def dest_metis_path(file)
+    return "metis://#{project_name}/#{dest_bucket_name}/#{dest_path(file)}"
+  end
+
+  def is_wsp(file)
+      return file.file_name.downcase.end_with?('wsp')
+  end
+
+  def copy_files_to_dest(ext)
+    copy_files_request = Etna::Clients::Metis::CopyFilesRequest.new(project_name: project_name)
+
+    find_files(ext).each do |file|
+      metis_client.ensure_parent_folder_exists(
+        project_name: project_name,
+        bucket_name: dest_bucket_name,
+        path: dest_path(file))
+
+      copy_files_request.add_revision(
+        Etna::Clients::Metis::CopyRevision.new(
+          source: source_metis_path(file),
+          dest: dest_metis_path(file)
+        )
+      )
+    end
+    puts copy_files_request
+    # metis_client.copy_files(copy_files_request)
+  end
+
+  def copy_files
+    ['wsp', 'fcs'].each do |ext|
+      copy_files_to_dest(ext)
+    end
+  end
+end

--- a/polyphemus/lib/ipi/flow_wsp_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_wsp_file_linker.rb
@@ -5,11 +5,12 @@ require_relative './ipi_helper'
 class IpiFlowWspLinker < Etna::Clients::Magma::FileLinkingWorkflow
   def initialize(**opts)
     super(**{bucket_name: 'integral_data', model_name: 'patient'}.update(opts))
+    @helper = IpiHelper.new
   end
 
   def find_matches
     {}.tap do |all_matches|
-      IpiHelper::find_files_by_extension(
+      @helper.find_files_by_extension(
         metis_client: metis_client,
         project_name: project_name,
         bucket_name: bucket_name,
@@ -17,16 +18,12 @@ class IpiFlowWspLinker < Etna::Clients::Magma::FileLinkingWorkflow
       ).each do |wsp_file|
         file_path = wsp_file.file_path
         key = [{
-          ipi_number: patient_name_from_wsp(file_path),
+          ipi_number: @helper.patient_name_from_wsp(file_path),
           flojo_file: file_path
         }, :flojo_file]
         all_matches[key] = [file_path]
       end
     end
-  end
-
-  def patient_name_from_wsp(wsp_file_path)
-    IpiHelper::file_name_from_path(wsp_file_path).sub('.wsp', '')
   end
 
   # Subclasses should override this to implement custom logic for how regex matches should match to linking.
@@ -35,7 +32,7 @@ class IpiFlowWspLinker < Etna::Clients::Magma::FileLinkingWorkflow
       identifiers.update(match_data)
       # Below data is to get_or_create the parent records
       identifiers['patient'] = match_data[:ipi_number]
-      identifiers['experiment'] = IpiHelper::experiment_from_patient_number(match_data[:ipi_number])
+      identifiers['experiment'] = @helper.experiment_from_patient_number(match_data[:ipi_number])
     end
   end
 

--- a/polyphemus/lib/ipi/ipi_helper.rb
+++ b/polyphemus/lib/ipi/ipi_helper.rb
@@ -1,5 +1,8 @@
 class IpiHelper
-  def self.find_files_by_extension(metis_client:, project_name:, bucket_name:, extension:)
+  def initialize
+  end
+
+  def find_files_by_extension(metis_client:, project_name:, bucket_name:, extension:)
     metis_client.find(
       Etna::Clients::Metis::FindRequest.new(
         project_name: project_name,
@@ -13,14 +16,54 @@ class IpiHelper
     )).files.all
   end
 
-  def self.experiment_from_patient_number(patient_number)
+  def experiment_from_patient_number(patient_number)
     experiments = JSON.parse(File.read('./lib/ipi/ipi_experiment_map.json'))
     exp_codes = experiments.keys
     reg = Regexp.new("(?<exp>#{exp_codes.join('|')})")
     experiments[reg.match(patient_number)[:exp]]
   end
 
-  def self.file_name_from_path(path)
+  def file_name_from_path(path)
     path.split('/').last
+  end
+
+  def patient_name_from_wsp(wsp_file_path)
+    file_name_from_path(wsp_file_path).sub('.wsp', '')
+  end
+
+  def stain_from_fcs(fcs_file_path)
+    # File name should be: IPICRC024_T3_flow_dc.fcs
+    # We need to return dc
+    file_name = file_name_from_path(fcs_file_path).sub('.fcs', '')
+    regex_results = fcs_regex(file_name)
+    regex_results[:stain].downcase
+  end
+
+  def stain_name_from_fcs(fcs_file_path)
+    # File name should be: IPICRC024_T3_flow_dc.fcs
+    # We need to return IPICRC024.T3.flow.dc
+    file_name_from_path(
+      fcs_file_path).sub('.fcs', '').gsub('_', '.')
+  end
+
+  def sample_name_from_fcs(fcs_file_path)
+    # File name should be: IPICRC024_T3_flow_dc.fcs
+    # We need to return IPICRC024.T3
+    file_name = file_name_from_path(fcs_file_path).sub('.fcs', '')
+    regex_results = fcs_regex(file_name)
+    regex_results[:sample_name].sub('_', '.')
+  end
+
+  def patient_name_from_fcs(fcs_file_path)
+    # File name should be: IPICRC024_T3_flow_dc.fcs
+    # We need to return IPICRC024
+    sample_name = sample_name_from_fcs(fcs_file_path)
+    sample_name.split('.').first
+  end
+
+  def fcs_regex(file_name)
+    regex = Regexp.new('(?<sample_name>IPI\w+\d+_\w+\d)_(?:flow_)?(?<stain>dc|innate|nktb|sort|treg)', Regexp::IGNORECASE)
+    raise "FCS filename #{file_name} does not match expected regex" unless regex.match(file_name)
+    regex.match(file_name)
   end
 end

--- a/polyphemus/lib/ipi/ipi_helper.rb
+++ b/polyphemus/lib/ipi/ipi_helper.rb
@@ -16,6 +16,20 @@ class IpiHelper
     )).files.all
   end
 
+  def find_files_in_folder_by_extension(metis_client:, project_name:, bucket_name:, extension:, folder_name:)
+    metis_client.find(
+      Etna::Clients::Metis::FindRequest.new(
+        project_name: project_name,
+        bucket_name: bucket_name,
+        params: [Etna::Clients::Metis::FindParam.new(
+          attribute: 'name',
+          predicate: 'glob',
+          value: "#{folder_name}/**/*.#{extension}",
+          type: 'file'
+        )]
+    )).files.all
+  end
+
   def experiment_from_patient_number(patient_number)
     experiments = JSON.parse(File.read('./lib/ipi/ipi_experiment_map.json'))
     exp_codes = experiments.keys


### PR DESCRIPTION
This PR adds the bulk_copy files action to the metis_client, and builds on that to copy Flow files from one Metis bucket to the another (default the integral dataset). 

This assumes that Flow filenames are well-formed and have all been run through Lenny's pipeline.