### PR TITLE
fix censoring for tables

### DIFF
--- a/magma/lib/magma/censor.rb
+++ b/magma/lib/magma/censor.rb
@@ -10,7 +10,7 @@ class Magma
       reasons = []
       return reasons unless restrict?
 
-      record_names = record_set.values.map(&:record_name)
+      record_names = record_set.values.map(&:record_name).reject {|name| name =~ Magma::Loader::TEMP_ID_MATCH }
 
       unrestricted_identifiers = Magma::Question.new(
         @project_name,

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -628,7 +628,7 @@ describe QueryController do
             [ '::identifier' ]
           ]
         ],
-        :editor
+        :privileged_editor
       )
       # the editor has a restricted permission
       expect(json_body[:answer].map(&:first).sort).to eq(
@@ -649,7 +649,7 @@ describe QueryController do
     it 'allows queries on restricted attributes to users with restricted permission' do
       victim_list = create_list(:victim, 9, country: 'thrace')
 
-      query([ 'victim', '::all', 'country' ], :editor)
+      query([ 'victim', '::all', 'country' ], :privileged_editor)
       expect(json_body[:answer].map(&:last).sort).to all(eq('thrace'))
     end
   end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -636,7 +636,7 @@ describe RetrieveController do
           record_names: 'all',
           attribute_names: 'all'
         },
-        :editor
+        :privileged_editor
       )
       expect(json_body[:models][:victim][:documents].keys.sort).to eq(
         (
@@ -658,7 +658,7 @@ describe RetrieveController do
           record_names: 'all',
           attribute_names: 'all'
         },
-        :editor
+        :privileged_editor
       )
       expect(json_body[:models][:victim][:documents].keys.sort).to eq(
         (
@@ -690,7 +690,7 @@ describe RetrieveController do
           record_names: 'all',
           attribute_names: [ 'country' ]
         },
-        :editor
+        :privileged_editor
       )
       countries = json_body[:models][:victim][:documents].values.map{|victim| victim[:country]}
       expect(countries).to all(eq('thrace'))

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -291,10 +291,10 @@ AUTH_USERS = {
     email: 'zeus@twelve-labors.org', first: 'Zeus', perm: 'a:administration'
   },
   editor: {
-    email: 'eurystheus@twelve-labors.org', first: 'Eurystheus', perm: 'E:labors'
+    email: 'eurystheus@twelve-labors.org', first: 'Eurystheus', perm: 'e:labors'
   },
-  restricted_editor: {
-    email: 'copreus@twelve-labors.org', first: 'Copreus', perm: 'e:labors'
+  privileged_editor: {
+    email: 'copreus@twelve-labors.org', first: 'Copreus', perm: 'E:labors'
   },
   viewer: {
     email: 'hercules@twelve-labors.org', first: 'Hercules', perm: 'v:labors'

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -909,7 +909,7 @@ describe UpdateController do
             }
           }
         },
-        :restricted_editor
+        :editor
       )
       expect(last_response.status).to eq(422)
       expect(json_body[:errors]).to eq(["Cannot revise restricted victim '#{orig_name}'"])
@@ -932,7 +932,7 @@ describe UpdateController do
             }
           }
         },
-        :restricted_editor
+        :editor
       )
       expect(last_response.status).to eq(422)
       expect(json_body[:errors]).to eq(["Cannot revise restricted victim '#{orig_name}'"])
@@ -954,7 +954,7 @@ describe UpdateController do
             }
           }
         },
-        :editor
+        :privileged_editor
       )
       expect(last_response.status).to eq(200)
       expect(json_document(:victim,new_name)).to eq(name: new_name)
@@ -978,7 +978,7 @@ describe UpdateController do
             }
           }
         },
-        :editor
+        :privileged_editor
       )
       expect(last_response.status).to eq(200)
       expect(json_document(:victim,new_name)).to eq(name: new_name)
@@ -999,7 +999,7 @@ describe UpdateController do
             }
           }
         },
-        :restricted_editor
+        :editor
       )
       expect(last_response.status).to eq(422)
       expect(json_body[:errors]).to eq(["Cannot revise restricted attribute :country on victim 'Outis Koutsonadis'"])
@@ -1019,7 +1019,7 @@ describe UpdateController do
                   }
               }
           },
-          :restricted_editor
+          :editor
       )
       expect(last_response.status).to eq(422)
       expect(json_body[:errors]).to eq(["Cannot revise restricted attribute :restricted on victim 'Outis Koutsonadis'"])
@@ -1038,7 +1038,7 @@ describe UpdateController do
             }
           }
         },
-        :editor
+        :privileged_editor
       )
       expect(last_response.status).to eq(200)
       expect(json_document(:victim,'Outis Koutsonadis')).to include(country: 'thrace')
@@ -1058,7 +1058,7 @@ describe UpdateController do
                   }
               }
           },
-          :editor
+          :privileged_editor
       )
       expect(last_response.status).to eq(200)
 


### PR DESCRIPTION
Another bug-fix coming off @corps's repair of the censor, affecting tables. I also flipped the restricted bit on most of the specs by default, so now they're being tested as a non-privileged user, which I think is better as the restriction is always being exercised.