### PR TITLE
Modify create project / schema syntax for our postgres version

### DIFF
--- a/magma/lib/magma/actions/add_project.rb
+++ b/magma/lib/magma/actions/add_project.rb
@@ -2,7 +2,11 @@ class Magma
 
   class AddProjectAction < ComposedAction
     def perform
-      Magma.instance.db.run "CREATE SCHEMA IF NOT EXISTS #{@project_name}"
+      begin
+        Magma.instance.db.run "CREATE SCHEMA #{@project_name}"
+      rescue Sequel::Error => e
+        raise unless e.message.start_with?('PG::DuplicateSchema: ERROR:')
+      end
       super
     end
 


### PR DESCRIPTION
Turns out "create schema if not exists" was added in Postgres 9.3, so we don't have access to that syntax on deployed servers. When I tried using the add_project API on staging this morning, I received an exception:

```
[{"message":"Unexpected error","source":null,"reason":"PG::SyntaxError: ERROR:  syntax error at or near \"NOT\"\nLINE 1: CREATE SCHEMA IF NOT EXISTS test1\n                         ^\n"}] (Etna::Error)
```

This PR reverts to just `create schema`, and swallows any DuplicateSchema exceptions to mimic the behavior of `create schema if not exists`.