### PR TITLE
support attribute_group on attributes

### DIFF
--- a/etna/lib/etna/clients/magma/models.rb
+++ b/etna/lib/etna/clients/magma/models.rb
@@ -445,6 +445,7 @@ module Etna
           dest.format_hint = source.format_hint
           dest.hidden = source.hidden
           dest.link_model_name = source.link_model_name
+          dest.read_only = source.read_only
           dest.attribute_group = source.attribute_group
           dest.unique = source.unique
           dest.validation = source.validation

--- a/etna/lib/etna/clients/magma/models.rb
+++ b/etna/lib/etna/clients/magma/models.rb
@@ -64,7 +64,7 @@ module Etna
         end
       end
 
-      class AddAttributeAction < Struct.new(:action_name, :model_name, :attribute_name, :type, :description, :display_name, :format_hint, :hidden, :index, :link_model_name, :read_only, :restricted, :unique, :validation, keyword_init: true)
+      class AddAttributeAction < Struct.new(:action_name, :model_name, :attribute_name, :type, :description, :display_name, :format_hint, :hidden, :index, :link_model_name, :read_only, :attribute_group, :restricted, :unique, :validation, keyword_init: true)
         include JsonSerializableStruct
         def initialize(**args)
           super({action_name: 'add_attribute'}.update(args))
@@ -97,7 +97,7 @@ module Etna
         end
       end
 
-      class UpdateAttributeAction < Struct.new(:action_name, :model_name, :attribute_name, :type, :description, :display_name, :format_hint, :hidden, :index, :link_model_name, :read_only, :restricted, :unique, :validation, keyword_init: true)
+      class UpdateAttributeAction < Struct.new(:action_name, :model_name, :attribute_name, :type, :description, :display_name, :format_hint, :hidden, :index, :link_model_name, :read_only, :attribute_group, :restricted, :unique, :validation, keyword_init: true)
         include JsonSerializableStruct
         def initialize(**args)
           super({action_name: 'update_attribute'}.update(args))
@@ -410,6 +410,13 @@ module Etna
           raw['read_only'] = val
         end
 
+        def attribute_group
+          raw['attribute_group']
+        end
+
+        def attribute_group=(val)
+          raw['attribute_group'] = val
+        end
         def hidden
           raw['hidden']
         end
@@ -438,7 +445,7 @@ module Etna
           dest.format_hint = source.format_hint
           dest.hidden = source.hidden
           dest.link_model_name = source.link_model_name
-          dest.read_only = source.read_only
+          dest.attribute_group = source.attribute_group
           dest.unique = source.unique
           dest.validation = source.validation
           dest.restricted = source.restricted

--- a/etna/lib/etna/clients/magma/workflows/json_models.rb
+++ b/etna/lib/etna/clients/magma/workflows/json_models.rb
@@ -362,6 +362,10 @@ module Etna
           @raw['read_only']
         end
 
+        def attribute_group
+          @raw['attribute_group']
+        end
+
         def validation
           @raw['validation']
         end

--- a/magma/db/migrations/007_add_attribute_group_to_attributes.rb
+++ b/magma/db/migrations/007_add_attribute_group_to_attributes.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table(:attributes) do
+      add_column :attribute_group, String
+    end
+  end
+
+  down do
+    alter_table(:attributes) do
+      drop_column :attribute_group
+    end
+  end
+end

--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -206,7 +206,7 @@ class Magma
     end
 
     def validate_attribute_group_format
-      return if attribute_group =~ SNAKE_CASE_WORD
+      return if !attribute_group || attribute_group =~ SNAKE_CASE_WORD
       errors.add(:attribute_group, "must be snake_case with no spaces")
     end
 

--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -17,6 +17,7 @@ class Magma
       :display_name,
       :format_hint,
       :hidden,
+      :attribute_group,
       :index,
       :link_model_name,
       :read_only,
@@ -29,7 +30,7 @@ class Magma
 
     class << self
       def options
-        [:description, :display_name, :hidden, :read_only, :unique, :index, :validation,
+        [:description, :display_name, :hidden, :attribute_group, :read_only, :unique, :index, :validation,
 :format_hint, :loader, :link_model_name, :restricted]
       end
 
@@ -99,6 +100,7 @@ class Magma
         attribute_class: attribute_class_name,
         desc: description,
         display_name: display_name,
+        attribute_group: attribute_group,
         options: validation_object.options,
         match: validation_object.match,
         restricted: restricted,
@@ -185,6 +187,7 @@ class Magma
       validate_attribute_name_format
       validate_type
       validate_attribute_name_unique
+      validate_attribute_group_format
     end
 
     def validate_validation_json
@@ -195,9 +198,16 @@ class Magma
       errors.add(:validation, "is not properly formatted")
     end
 
+    SNAKE_CASE_WORD=/\A[a-z][a-z0-9]*(_[a-z0-9]+)*\Z/
+
     def validate_attribute_name_format
-      return if attribute_name =~ /\A[a-z][a-z0-9]*(_[a-z0-9]+)*\Z/
+      return if attribute_name =~ SNAKE_CASE_WORD
       errors.add(:attribute_name, "must be snake_case with no spaces")
+    end
+
+    def validate_attribute_group_format
+      return if attribute_group =~ SNAKE_CASE_WORD
+      errors.add(:attribute_group, "must be snake_case with no spaces")
     end
 
     def validate_type

--- a/magma/spec/actions/add_attribute_actions_spec.rb
+++ b/magma/spec/actions/add_attribute_actions_spec.rb
@@ -11,6 +11,7 @@ describe Magma::AddAttributeAction do
       format_hint: "incoming format hint",
       hidden: true,
       index: false,
+      attribute_group: attribute_group,
       read_only: true,
       restricted: false,
       unique: true,
@@ -21,6 +22,7 @@ describe Magma::AddAttributeAction do
   let(:action) { Magma::AddAttributeAction.new(project_name, action_params) }
   let(:model_name) { "labor" }
   let(:attribute_name) { "number_of_claws" }
+  let(:attribute_group) { "info" }
 
   describe '#perform' do
     context "when it succeeds" do
@@ -111,6 +113,17 @@ describe Magma::AddAttributeAction do
       end
     end
 
+    context "when attribute_group is not a snake_case word" do
+      let(:attribute_group) { @attribute_group }
+
+      it 'captures an attribute error' do
+        [ "infor\nmation", ' information', 'info_group	' , '1x_info'].each do |group|
+          @attribute_group = group
+          expect(action.validate).to eq(false)
+          expect(action.errors.first[:message]).to eq("attribute_group must be snake_case with no spaces")
+        end
+      end
+    end
     context "when adding a link attribute" do
       let(:action_params) do
         {

--- a/magma/spec/magma_attribute_spec.rb
+++ b/magma/spec/magma_attribute_spec.rb
@@ -68,6 +68,17 @@ describe Magma::Attribute do
 
       expect(json_validation_object.to_json).to eq("{\"type\":\"Regexp\",\"value\":\"(?-mix:^[a-zA-Z]{1}$)\"}")
     end
+
+    it "includes attribute groups" do
+      attribute = Magma::Attribute.new(
+        attribute_name: "stench",
+        attribute_group: "odors"
+      )
+
+      template = attribute.json_template
+
+      expect(template[:attribute_group]).to eq("odors")
+    end
   end
 
   describe "#revision_to_loader" do


### PR DESCRIPTION
Basic attribute groups support - in the end I decided to keep it simple and not have tags or weird format-based group hierarchies, the group is just a single snake_case word.

It's unclear to me how general the utility of this thing will be, we'll have to see. There is annotation penalty to be paid in maintaining this (that is, it must be filled in by someone), and it's not clear that this is the best place to put this work, but it's a starting point.