### PR TITLE
Add the population and mfi models via API so link attributes are cleaner

### DIFF
--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -456,20 +456,19 @@ class Polyphemus
   end
 
   class IpiAddFlowModel < Etna::Command
-    include WithEtnaClients
+    include WithEtnaClientsByEnvironment
     include WithLogger
 
-    usage "Add the Flow model to IPI, and migrate data from Sample model to Flow"
+    usage "ipi_add_flow_model <environment>; Add the Flow model to IPI, and migrate data from Sample model to Flow"
 
     def project_name
       :ipi
     end
 
-    def magma_crud
-      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: magma_client, project_name: project_name)
-    end
+    def execute(env)
+      magma_client = environment(env).magma_client
+      magma_crud = Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: magma_client, project_name: project_name)
 
-    def execute
       require_relative './ipi/migrations/01_flow_model_migration'
       migration = IpiAddFlowModelMigration.new(magma_client: magma_client, magma_crud: magma_crud)
       migration.execute

--- a/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
+++ b/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
@@ -75,6 +75,74 @@ class IpiAddFlowModelMigration
     @magma_client.update_model(add_attributes_request)
   end
 
+  def create_population_model
+    create_population_request = Etna::Clients::Magma::UpdateModelRequest.new(
+      project_name: @project_name,
+      actions: [Etna::Clients::Magma::AddModelAction.new(
+        model_name: 'population',
+        parent_model_name: 'flow',
+        parent_link_type: 'table'
+      )]
+    )
+    @magma_client.update_model(create_population_request)
+
+    add_attributes_request = Etna::Clients::Magma::UpdateModelRequest.new(
+      project_name: @project_name,
+      actions: [Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'population',
+        type: 'string',
+        attribute_name: 'name',
+        description: 'Name of this population.'
+      ), Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'population',
+        type: 'integer',
+        attribute_name: 'count',
+        description: 'Number of cells.'
+      ), Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'population',
+        type: 'string',
+        attribute_name: 'ancestry',
+        description: 'Chain of parent populations.'
+      )]
+    )
+
+    @magma_client.update_model(add_attributes_request)
+  end
+
+  def create_mfi_model
+    create_mfi_request = Etna::Clients::Magma::UpdateModelRequest.new(
+      project_name: @project_name,
+      actions: [Etna::Clients::Magma::AddModelAction.new(
+        model_name: 'mfi',
+        parent_model_name: 'population',
+        parent_link_type: 'table'
+      )]
+    )
+    @magma_client.update_model(create_mfi_request)
+
+    add_attributes_request = Etna::Clients::Magma::UpdateModelRequest.new(
+      project_name: @project_name,
+      actions: [Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'mfi',
+        type: 'string',
+        attribute_name: 'name',
+        description: 'Name of antibody.'
+      ), Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'mfi',
+        type: 'string',
+        attribute_name: 'fluor',
+        description: 'Color of this channel.'
+      ), Etna::Clients::Magma::AddAttributeAction.new(
+        model_name: 'mfi',
+        type: 'float',
+        attribute_name: 'value',
+        description: 'Mean fluorescence intensity.'
+      )]
+    )
+
+    @magma_client.update_model(add_attributes_request)
+  end
+
   def copy_flow_data
     # Copy the existing file, quality_flag, and notes for each stain
     #   from the Sample model to the new Flow model
@@ -157,5 +225,7 @@ class IpiAddFlowModelMigration
     create_flow_model
     copy_flow_data
     hide_sample_columns
+    create_population_model
+    create_mfi_model
   end
 end


### PR DESCRIPTION
While doing additional testing on the Flow migration, I realized that trying to create the right parent / table links when mixing Ruby class-based models with API-created models is very difficult. So it'll be cleaner just to re-create the population and mfi models via the API from scratch. This PR adds those model definitions to the same flow migration that will create the flow model. 