### PR TITLE
Graft/fix tsv download

### DIFF
--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    curb (0.9.10)
     database_cleaner (1.8.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
@@ -146,6 +147,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   debase
   etna!

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -224,8 +224,9 @@ class Magma
       bounds.map.with_index do |row, index|
         bound = {:lower => order_by_aliases.map { |c| row[c] }, :upper => nil}
 
+
         if bounds[index + 1]
-          bound[:upper] = bounds[index + 1].map { |c| row[c] }
+          bound[:upper] = order_by_aliases.map{ |c| bounds[index + 1][c] }
         end
 
         bound
@@ -288,8 +289,6 @@ class Magma
       if upper
         query = apply_multi_stage_ordering_bounds(query, upper: upper)
       end
-
-      p lower, upper
 
       query
     end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -292,6 +292,20 @@ describe RetrieveController do
       expect(table).to match_array(labor_list.map{|l| [ l.name, l.completed.to_s, l.number.to_s ] })
     end
 
+    it 'can retrieve the whole TSV' do
+      labor_list = create_list(:labor, 20000)
+      required_atts = ['name', 'completed', 'number']
+      retrieve(
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: required_atts,
+        format: 'tsv',
+        project_name: 'labors'
+      )
+      expect(last_response.status).to eq(200)
+      expect(last_response.body.count("\n")).to eq(20001)
+    end
+
     it 'can retrieve a TSV of data without an identifier' do
       prize_list = create_list(:prize, 12, worth: 5)
       retrieve(


### PR DESCRIPTION
I added the ability to paginate by multiple columns, but unfortunately we didn't have coverage over this one particular function.  Now we do.  

Fix is to ensure that each bounds maps to the order_by_aliases, which is dynamic and transforms bounds into the appropriate structure for consumption by bounds functions.