### PR TITLE
Bin to add etna gem locally during development

### DIFF
--- a/bin/reinstall-etna-gem
+++ b/bin/reinstall-etna-gem
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+set -e
+
+prog=$0
+error() {
+   echo "Whoops!  Looks like $1:$2 failed."
+   echo "Please try rerunning $prog again."
+   exit 1
+}
+trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+cd $DIR/../etna
+
+set -x
+gem uninstall etna
+gem build etna.gemspec
+gem install etna-*.gem
+
+set +x
+echo
+echo
+echo "To ensure the etna gem is on your path, try running the following:"
+echo
+echo "export PATH=\$(gem env path):\$PATH"


### PR DESCRIPTION
Just a convenience bin that uninstalls and reinstalls the etna gem from sources.

In general it is better to test the etna gem _outside the docker container_ so you don't have issues with the home directory and so that we can test its behaviors in a vanilla ruby environment.