### PR TITLE
use match_array instead of eq

### DIFF
--- a/etna/lib/etna/templates/create_project_template.json
+++ b/etna/lib/etna/templates/create_project_template.json
@@ -122,6 +122,7 @@
       "attributes": {}
     },
     "status": {
+      // Table relationships do not need the "identifier" attribute defined.
       "parent_model_name": "patient",
       "parent_link_type": "table"
     },

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -260,7 +260,7 @@ describe UpdateController do
         hydra_monster.refresh
         habitat.refresh
         expect(hydra_monster.habitat).to eq(habitat)
-        expect(habitat.monster).to eq([lion_monster, hydra_monster])
+        expect(habitat.monster).to match_array([lion_monster, hydra_monster])
       end
     end
 
@@ -494,7 +494,7 @@ describe UpdateController do
         habitat.refresh
         expect(lion_monster.habitat).to eq(habitat)
         expect(hydra_monster.habitat).to eq(habitat)
-        expect(habitat.monster).to eq([ lion_monster, hydra_monster ])
+        expect(habitat.monster).to match_array([ lion_monster, hydra_monster ])
       end
     end
 
@@ -846,7 +846,7 @@ describe UpdateController do
         project.refresh
         expect(lion.project).to eq(project)
         expect(hydra.project).to eq(project)
-        expect(project.labor).to eq([ hydra, lion ])
+        expect(project.labor).to match_array([ hydra, lion ])
       end
 
       it 'via a parent in parent-collection' do
@@ -881,7 +881,7 @@ describe UpdateController do
         project.refresh
         expect(lion.project).to eq(project)
         expect(hydra.project).to eq(project)
-        expect(project.labor).to eq([ hydra, lion ])
+        expect(project.labor).to match_array([ hydra, lion ])
       end
 
       it 'via the child of a link model' do


### PR DESCRIPTION
Sorry, differently-ordered Array results caused #123 to fail. Changing the new specs for orphaning and linking to use `match_array` instead of `eq` for the Collection specs.