### PR TITLE
add validation to flow stain flag attribute, to match rna_seq model

### DIFF
--- a/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
+++ b/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
@@ -60,9 +60,13 @@ class IpiAddFlowModelMigration
       ), Etna::Clients::Magma::AddAttributeAction.new(
         model_name: 'flow',
         type: 'string',
-        attribute_name: 'quality_flag',
-        description: 'Quality flag for the stain.',
-        display_name: 'Qualify flag'
+        attribute_name: 'flag',
+        description: 'Quality flag for this Flow stain.',
+        display_name: 'Flag',
+        validation: {
+          type: 'Array',
+          value: ['good', 'bad', 'critical']
+        }
       ), Etna::Clients::Magma::AddAttributeAction.new(
         model_name: 'flow',
         type: 'string',


### PR DESCRIPTION
Small change to the new flow model, to make the `flag` attribute more consistent with the `rna_seq` model.