### PR TITLE
Updates to flow integral data linker

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -9,7 +9,7 @@ require_relative './models'
 module Etna
   module Clients
     class Metis
-      attr_reader :token, :host
+      attr_reader :token
       def initialize(host:, token:, persistent: true, ignore_ssl: false)
         raise 'Metis client configuration is missing host.' unless host
         raise 'Metis client configuration is missing token.' unless token
@@ -20,7 +20,6 @@ module Etna
           ignore_ssl: ignore_ssl)
 
         @token = token
-        @host = host
       end
 
       def list_all_folders(list_all_folders_request = ListFoldersRequest.new)

--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -2,13 +2,14 @@ require 'net/http/persistent'
 require 'net/http/post/multipart'
 require 'singleton'
 require 'cgi'
+require 'json'
 require_relative '../../client'
 require_relative './models'
 
 module Etna
   module Clients
     class Metis
-      attr_reader :token
+      attr_reader :token, :host
       def initialize(host:, token:, persistent: true, ignore_ssl: false)
         raise 'Metis client configuration is missing host.' unless host
         raise 'Metis client configuration is missing token.' unless token
@@ -19,6 +20,7 @@ module Etna
           ignore_ssl: ignore_ssl)
 
         @token = token
+        @host = host
       end
 
       def list_all_folders(list_all_folders_request = ListFoldersRequest.new)
@@ -103,6 +105,52 @@ module Etna
       def copy_files(copy_files_request)
         FilesResponse.new(
           @etna_client.file_bulk_copy(copy_files_request.to_h))
+      end
+
+      def signed_copy_files(copy_files_request, application, hmac_id)
+        bulk_copy_route = @etna_client.routes.find { |r| r[:name] == 'file_bulk_copy' }
+
+        return nil unless bulk_copy_route
+
+        # At some point, when Metis supports changing project names,
+        # this parameter should be the old file project name (metis_file_location_parts[2]))
+        # and the new project name in the HMAC headers should
+        # be project_name
+
+        path = @etna_client.route_path(
+          bulk_copy_route,
+          project_name: copy_files_request.project_name
+        )
+
+        bulk_copy_params = {
+          revisions: copy_files_request.revisions.map { |rev|
+            JSON.parse(rev.to_json, symbolize_names: true) }
+        }
+
+        # Now populate the standard headers
+        hmac_params = {
+          method: 'POST',
+          host: host,
+          path: path,
+
+          expiration: (DateTime.now + 10).iso8601,
+          id: hmac_id,
+          nonce: SecureRandom.hex,
+          headers: bulk_copy_params,
+        }
+
+        hmac = Etna::Hmac.new(application, hmac_params)
+
+        cgi_hash = CGI.parse(hmac.url_params[:query])
+        cgi_hash.delete('X-Etna-Revisions') # this could be too long for URI
+
+        hmac_params_hash = Hash[cgi_hash.map {|key,values| [key.to_sym, values[0]||true]}]
+
+        FilesResponse.new(@etna_client.send(
+          'body_request',
+          Net::HTTP::Post,
+          hmac.url_params[:path] + '?' + URI.encode_www_form(cgi_hash),
+          bulk_copy_params))
       end
 
       def folder_exists?(create_folder_request)

--- a/polyphemus/lib/ipi/flow_populate_integral_data.rb
+++ b/polyphemus/lib/ipi/flow_populate_integral_data.rb
@@ -66,23 +66,25 @@ class IpiFlowPopulateIntegralData < Struct.new(:metis_client, :project_name, :so
   end
 
   def copy_files_to_dest(ext)
-    copy_files_request = Etna::Clients::Metis::CopyFilesRequest.new(project_name: project_name)
-
     find_files(ext).each do |file|
+      copy_files_request = Etna::Clients::Metis::CopyFilesRequest.new(project_name: project_name)
+
+      puts "Ensuring parent folder exists for #{file.file_name}."
       metis_client.ensure_parent_folder_exists(
         project_name: project_name,
         bucket_name: dest_bucket_name,
         path: dest_path(file))
 
+      puts "Creating copy request."
       copy_files_request.add_revision(
         Etna::Clients::Metis::CopyRevision.new(
           source: source_metis_path(file),
           dest: dest_metis_path(file)
         )
       )
+
+      metis_client.signed_copy_files(copy_files_request, Polyphemus.instance, 'metis')
     end
-    puts copy_files_request
-    # metis_client.copy_files(copy_files_request)
   end
 
   def copy_files


### PR DESCRIPTION
This PR adds an HMAC-signed bulk-copy request to the metis client, and reconfigures the IPI flow-to-integral-dataset command in Polyphemus to use that method instead of the vanilla `copy_files`. The command also now makes a copy request for every file, because unfortunately the FCS file set is very "branchy" and causes the Metis proxy connection to Apache to time out.