### PR TITLE
Updates to linking flow files from integral_data

### DIFF
--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -481,49 +481,51 @@ class Polyphemus
   end
 
   class LinkIpiFlowWsp < Etna::Command
-    include WithEtnaClients
+    include WithEtnaClientsByEnvironment
     include WithLogger
-    usage 'link_ipi_flow_wsp [environment]'
-
-    attr_reader :environment
+    usage 'link_ipi_flow_wsp <environment>'
 
     def project_name
       :ipi
     end
 
     def magma_crud
-      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: magma_client, project_name: project_name)
+      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: @environ.magma_client, project_name: project_name)
     end
 
-    def execute(env = Polyphemus.instance.environment)
+    def execute(env)
       require_relative './ipi/flow_wsp_file_linker'
-      @environment = env
+      @environ = environment(env)
 
-      linker = IpiFlowWspLinker.new(magma_crud: magma_crud, metis_client: metis_client, project_name: project_name)
+      linker = IpiFlowWspLinker.new(
+        magma_crud: magma_crud,
+        metis_client: @environ.metis_client,
+        project_name: project_name)
       linker.link_files
     end
   end
 
   class LinkIpiFlowFcs < Etna::Command
-    include WithEtnaClients
+    include WithEtnaClientsByEnvironment
     include WithLogger
-    usage 'link_ipi_flow_fcs [environment]'
-
-    attr_reader :environment
+    usage 'link_ipi_flow_fcs <environment>'
 
     def project_name
       :ipi
     end
 
     def magma_crud
-      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: magma_client, project_name: project_name)
+      @magma_crud ||= Etna::Clients::Magma::MagmaCrudWorkflow.new(magma_client: @environ.magma_client, project_name: project_name)
     end
 
-    def execute(env = Polyphemus.instance.environment)
+    def execute(env)
       require_relative './ipi/flow_fcs_file_linker'
-      @environment = env
+      @environ = environment(env)
 
-      linker = IpiFlowFcsLinker.new(magma_crud: magma_crud, metis_client: metis_client, project_name: project_name)
+      linker = IpiFlowFcsLinker.new(
+        magma_crud: magma_crud,
+        metis_client: @environ.metis_client,
+        project_name: project_name)
       linker.link_files
     end
   end

--- a/polyphemus/lib/ipi/flow_fcs_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_fcs_file_linker.rb
@@ -58,6 +58,7 @@ class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
       # Have to inject project_name into the update request.
       update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: 'ipi')
       update_request.update_revision(model_name, id, revision)
+      puts "Updating #{model_name}, record #{id}."
       magma_crud.magma_client.update(update_request)
     end
   end

--- a/polyphemus/lib/ipi/flow_wsp_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_wsp_file_linker.rb
@@ -40,6 +40,7 @@ class IpiFlowWspLinker < Etna::Clients::Magma::FileLinkingWorkflow
     magma_crud.update_records do |update_request|
       each_revision do |id, revision|
         update_request.update_revision(model_name, id, revision)
+        puts "Updating #{model_name}, record #{id}."
       end
     end
   end

--- a/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
+++ b/polyphemus/lib/ipi/migrations/01_flow_model_migration.rb
@@ -175,6 +175,10 @@ class IpiAddFlowModelMigration
     #   path or file name, we can still create a copy of the
     #   Magma copy of the file.
     return {
+      path: "::blank"
+    } if value&.dig('path') && value['path'] == '::blank'
+
+    return {
       path: "metis://#{@project_name}/magma/#{value['path']}"
     } if value&.dig('path')
 
@@ -193,7 +197,8 @@ class IpiAddFlowModelMigration
 
   def execute
     create_flow_model
-    copy_flow_data
+    # copy_flow_data # Don't copy old, bad data. Let's start from a clean slate
+    #                   so that all data in the new model is good!
     hide_sample_columns
     create_population_model
   end


### PR DESCRIPTION
This PR updates the flow FCS and WSP file linking workflows to use the new `environment` handling.

At some point these should probably be transitioned to the ETL workflow, too.