### PR TITLE
Account for no hmac in the environment in Metis bulk_copy route

### DIFF
--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -118,7 +118,7 @@ module Etna
 
     def hmac_authorized?(request)
       # either there is no hmac requirement, or we have a valid hmac
-      !@auth[:hmac] || request.env['etna.hmac'].valid?
+      !@auth[:hmac] || request.env['etna.hmac']&.valid?
     end
 
     def route_name(options)

--- a/etna/lib/etna/test_auth.rb
+++ b/etna/lib/etna/test_auth.rb
@@ -43,7 +43,9 @@ module Etna
     end
 
     def approve_hmac(request)
-      hmac_signature = etna_param(request, :signature) || 'invalid'
+      hmac_signature = etna_param(request, :signature)
+
+      return false unless hmac_signature
 
       headers = (etna_param(request, :headers)&.split(/,/) || []).map do |header|
         [ header.to_sym, etna_param(request, header) ]
@@ -63,7 +65,7 @@ module Etna
 
       hmac = Etna::TestHmac.new(application, hmac_params)
 
-      request.env['etna.hmac'] = hmac if hmac.valid?
+      request.env['etna.hmac'] = hmac
 
       return nil unless hmac.valid?
 

--- a/etna/lib/etna/test_auth.rb
+++ b/etna/lib/etna/test_auth.rb
@@ -63,7 +63,7 @@ module Etna
 
       hmac = Etna::TestHmac.new(application, hmac_params)
 
-      request.env['etna.hmac'] = hmac
+      request.env['etna.hmac'] = hmac if hmac.valid?
 
       return nil unless hmac.valid?
 

--- a/metis/lib/server/controllers/file_controller.rb
+++ b/metis/lib/server/controllers/file_controller.rb
@@ -138,7 +138,7 @@ class FileController < Metis::Controller
 
     user_authorized_buckets = Metis::Bucket.where(
       project_name: @params[:project_name],
-      owner: ['metis', hmac.id.to_s],
+      owner: ['metis', hmac&.id.to_s].reject {|o| o.empty?},
       name: revisions.map(&:bucket_names).flatten.uniq
     ).all.select{|b| b.allowed?(@user, hmac)}
 


### PR DESCRIPTION
So the reason this never came up during tests was because `Etna::TestAuth` automatically added an `hmac` element to the request environment, even if no signature or headers were supplied. With `Etna::Auth` though, `hmac` is not added to the request environment unless a signature and headers are provided. Hence in deployed environments I ran into `#<NoMethodError: undefined method 'id' for nil:NilClass>` when trying to call `bulk_copy`.

This PR updates `Etna::TestAuth` to more closely mimic the behavior of `Etna::Auth` in that it only adds a valid hmac element to the request environment when a signature is provided.

This also updates the `Etna::Route` to account for possible `nil` `hmac` elements in the environment, which can now happen with `TestAuth`. This is mainly a fix for testing, since it should have correctly failed in deployed environments when no `hmac` was provided but one was expected?

And the PR updates Metis's `bulk_copy` route to squash and remove empty owners when hmac is not provided.