### PR TITLE
Metis rename file across buckets

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -56,7 +56,7 @@ module Etna
         ensure_parent_folder_exists(
           project_name: rename_file_request.project_name,
           bucket_name: rename_file_request.new_bucket_name,
-          path: parent_folder_path(rename_file_request.new_file_path)
+          path: rename_file_request.new_file_path # ensure_parent_folder_exists() parses this for the parent path
         ) if rename_file_request.create_parent
 
         FilesResponse.new(
@@ -70,7 +70,7 @@ module Etna
 
       def delete_folder(delete_folder_request)
         FoldersResponse.new(
-          @etna_client.folder_delete(delete_folder_request.to_h))
+          @etna_client.folder_remove(delete_folder_request.to_h))
       end
 
       def find(find_request)

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -34,6 +34,21 @@ module Etna
         end
       end
 
+      class RenameFileRequest < Struct.new(:project_name, :bucket_name, :file_path, :new_bucket_name, :new_file_path, :create_parent, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({create_parent: false}.update(params))
+        end
+
+        def to_h
+          # The :project_name comes in from Polyphemus as a symbol value,
+          #   we need to make sure it's a string because it's going
+          #   in the URL.
+          super().compact.transform_values(&:to_s)
+        end
+      end
+
       class ListFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, keyword_init: true)
         include JsonSerializableStruct
 
@@ -50,6 +65,21 @@ module Etna
       end
 
       class CreateFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+
+        def to_h
+          # The :project_name comes in from Polyphemus as a symbol value,
+          #   we need to make sure it's a string because it's going
+          #   in the URL.
+          super().compact.transform_values(&:to_s)
+        end
+      end
+
+      class DeleteFolderRequest < Struct.new(:project_name, :bucket_name, :folder_path, keyword_init: true)
         include JsonSerializableStruct
 
         def initialize(**params)

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -77,7 +77,7 @@ def stub_metis_setup
     {:method=>"GET", :route=>"/:project_name/list/:bucket_name/*folder_path", :name=>"folder_list", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/rename/:bucket_name/*folder_path", :name=>"folder_rename", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/create/:bucket_name/*folder_path", :name=>"folder_create", :params=>["project_name", "bucket_name", "folder_path"]},
-    {:method=>"DELETE", :route=>"/:project_name/folder/remove/:bucket_name/*folder_path", :name=>"folder_delete", :params=>["project_name", "bucket_name", "folder_path"]},
+    {:method=>"DELETE", :route=>"/:project_name/folder/remove/:bucket_name/*folder_path", :name=>"folder_remove", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/find/:bucket_name", :name=>"bucket_find", :params=>["project_name", "bucket_name"]},
     {:method=>"POST", :route=>"/:project_name/files/copy", :name=>"file_bulk_copy", :params=>["project_name"]},
     {:method=>"POST", :route=>"/:project_name/file/rename/:bucket_name/*file_path", :name=>"file_rename", :params=>["project_name", "bucket_name", "file_path"]}

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -77,8 +77,10 @@ def stub_metis_setup
     {:method=>"GET", :route=>"/:project_name/list/:bucket_name/*folder_path", :name=>"folder_list", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/rename/:bucket_name/*folder_path", :name=>"folder_rename", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/folder/create/:bucket_name/*folder_path", :name=>"folder_create", :params=>["project_name", "bucket_name", "folder_path"]},
+    {:method=>"DELETE", :route=>"/:project_name/folder/remove/:bucket_name/*folder_path", :name=>"folder_delete", :params=>["project_name", "bucket_name", "folder_path"]},
     {:method=>"POST", :route=>"/:project_name/find/:bucket_name", :name=>"bucket_find", :params=>["project_name", "bucket_name"]},
-    {:method=>"POST", :route=>"/:project_name/files/copy", :name=>"file_bulk_copy", :params=>["project_name"]}
+    {:method=>"POST", :route=>"/:project_name/files/copy", :name=>"file_bulk_copy", :params=>["project_name"]},
+    {:method=>"POST", :route=>"/:project_name/file/rename/:bucket_name/*file_path", :name=>"file_rename", :params=>["project_name", "bucket_name", "file_path"]}
   ])
 
   stub_request(:options, METIS_HOST).
@@ -108,7 +110,7 @@ def stub_metis_setup
     })
 end
 
-def stub_parent_exists(params={})
+def stub_list_bucket(params={})
   stub_request(:get, /#{METIS_HOST}\/#{PROJECT}\/list\/#{params[:bucket] || RESTRICT_BUCKET}\//)
   .to_return({
     status: params[:status] || 200
@@ -124,6 +126,20 @@ end
 
 def stub_rename_folder(params={})
   stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/folder\/rename\/#{params[:bucket] || RESTRICT_BUCKET}\//)
+  .to_return({
+    status: params[:status] || 200
+  })
+end
+
+def stub_rename_file(params={})
+  stub_request(:post, /#{METIS_HOST}\/#{PROJECT}\/file\/rename\/#{params[:bucket] || RESTRICT_BUCKET}\//)
+  .to_return({
+    status: params[:status] || 200
+  })
+end
+
+def stub_delete_folder(params={})
+  stub_request(:delete, /#{METIS_HOST}\/#{PROJECT}\/folder\/remove\/#{params[:bucket] || RESTRICT_BUCKET}\//)
   .to_return({
     status: params[:status] || 200
   })

--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -8,6 +8,7 @@ gem 'pg'
 gem 'sequel'
 gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/c140d60d78c368df7d56e71112eed1c4ecd6d431'
 gem 'jwt'
+gem 'puma', '5.0.2'
 
 group :test do
   gem 'rspec'

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -36,12 +36,15 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
+    nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -84,6 +87,7 @@ DEPENDENCIES
   nokogiri
   pg
   pry
+  puma (= 5.0.2)
   rack
   rack-test
   rack-throttle

--- a/magma/Gemfile
+++ b/magma/Gemfile
@@ -11,6 +11,7 @@ gem 'carrierwave-sequel'
 gem 'carrierwave'
 gem 'activesupport', '>= 4.2.6'
 gem 'spreadsheet'
+gem 'puma', '5.0.2'
 
 group :test do
   gem 'simplecov'

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    curb (0.9.11)
     database_cleaner (1.8.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
@@ -88,6 +89,7 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
+    nio4r (2.5.4)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     pg (1.2.2)
@@ -98,6 +100,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (4.0.3)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -146,6 +150,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   debase
   etna!
@@ -157,6 +162,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
+  puma (= 5.0.2)
   rack-test
   rspec
   ruby-debug-ide

--- a/metis/Gemfile
+++ b/metis/Gemfile
@@ -7,6 +7,7 @@ gem 'pg'
 gem 'sequel'
 gem 'fog-aws'
 gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/c140d60d78c368df7d56e71112eed1c4ecd6d431'
+gem 'puma', '5.0.2'
 
 group :test do
   gem 'rspec'

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
+    nio4r (2.5.4)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
@@ -79,6 +80,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.5)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -127,6 +130,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
+  puma (= 5.0.2)
   rack
   rack-test
   rspec

--- a/metis/lib/copy_revision.rb
+++ b/metis/lib/copy_revision.rb
@@ -2,30 +2,6 @@ require_relative 'revision'
 
 class Metis
   class CopyRevision < Revision
-    def validate
-      @errors = []
-      validate_source(@source)
-      validate_dest(@dest)
-    end
-
-    def bucket_names
-      # This is kind of weird, but we need the ability to grab
-      #   all relevant bucket names, even before validation of
-      #   the CopyRevision.
-      # So, if @dest doesn't exist, we don't return it
-      source_bucket_names = super
-      if @dest.mpath.valid?
-        return source_bucket_names.push(@dest.mpath.bucket_name)
-      end
-      return source_bucket_names
-    end
-
-    def mpaths
-      source_mpaths = super
-      source_mpaths.push(@dest.mpath) if @dest.mpath.valid?
-      return source_mpaths
-    end
-
     def revise!
       raise 'Invalid revision, cannot revise!' unless valid?
       raise 'Cannot revise without a user' unless @user
@@ -37,14 +13,6 @@ class Metis
         dest_bucket_name: @dest.mpath.bucket_name,
         user: @user
       })
-    end
-
-    def to_hash
-      {
-        dest: @dest.mpath.path,
-        source: @source.mpath.path,
-        errors: @errors
-      }
     end
   end
 end

--- a/metis/lib/file_rename_revision.rb
+++ b/metis/lib/file_rename_revision.rb
@@ -1,0 +1,72 @@
+require_relative 'revision'
+
+class Metis
+  class FileRenameRevision < Revision
+    def validate
+      @errors = []
+      validate_source(@source)
+      validate_dest(@dest)
+    end
+
+    def bucket_names
+      # This is kind of weird, but we need the ability to grab
+      #   all relevant bucket names, even before validation of
+      #   the CopyRevision.
+      # So, if @dest doesn't exist, we don't return it
+      source_bucket_names = super
+      if @dest.mpath.valid?
+        return source_bucket_names.push(@dest.mpath.bucket_name)
+      end
+      return source_bucket_names
+    end
+
+    def mpaths
+      source_mpaths = super
+      source_mpaths.push(@dest.mpath) if @dest.mpath.valid?
+      return source_mpaths
+    end
+
+    def revise!
+      raise 'Invalid revision, cannot revise!' unless valid?
+      raise 'Cannot revise without a user' unless @user
+
+      @source.file.update_bucket_and_rename!(
+        @dest.folder,
+        @dest.mpath.file_name,
+        @dest.bucket)
+    end
+
+    def to_hash
+      {
+        dest: @dest.mpath.path,
+        source: @source.mpath.path,
+        errors: @errors
+      }
+    end
+
+    def validate_file(mpath_w_objs, file_check_type='source')
+      errors_found = super
+
+      # Do not let users clobber files by default
+      file = Metis::File.from_folder(
+        mpath_w_objs.bucket,
+        mpath_w_objs.folder,
+        mpath_w_objs.mpath.file_name)
+
+      if file&.has_data? && file_check_type == 'dest'
+        @errors.push("File \"#{mpath_w_objs.mpath.path}\" already exists")
+        errors_found = true
+      end
+
+      if file&.read_only? && file_check_type == 'source'
+        @errors.push("File \"#{mpath_w_objs.mpath.path}\" is read-only")
+        errors_found = true
+      end
+
+      # Set this to use in revise!
+      mpath_w_objs.file = file unless errors_found
+
+      return errors_found
+    end
+  end
+end

--- a/metis/lib/file_rename_revision.rb
+++ b/metis/lib/file_rename_revision.rb
@@ -2,30 +2,6 @@ require_relative 'revision'
 
 class Metis
   class FileRenameRevision < Revision
-    def validate
-      @errors = []
-      validate_source(@source)
-      validate_dest(@dest)
-    end
-
-    def bucket_names
-      # This is kind of weird, but we need the ability to grab
-      #   all relevant bucket names, even before validation of
-      #   the CopyRevision.
-      # So, if @dest doesn't exist, we don't return it
-      source_bucket_names = super
-      if @dest.mpath.valid?
-        return source_bucket_names.push(@dest.mpath.bucket_name)
-      end
-      return source_bucket_names
-    end
-
-    def mpaths
-      source_mpaths = super
-      source_mpaths.push(@dest.mpath) if @dest.mpath.valid?
-      return source_mpaths
-    end
-
     def revise!
       raise 'Invalid revision, cannot revise!' unless valid?
       raise 'Cannot revise without a user' unless @user
@@ -34,14 +10,6 @@ class Metis
         @dest.folder,
         @dest.mpath.file_name,
         @dest.bucket)
-    end
-
-    def to_hash
-      {
-        dest: @dest.mpath.path,
-        source: @source.mpath.path,
-        errors: @errors
-      }
     end
 
     def validate_file(mpath_w_objs, file_check_type='source')

--- a/metis/lib/folder_revision.rb
+++ b/metis/lib/folder_revision.rb
@@ -2,38 +2,6 @@ require_relative 'revision'
 
 class Metis
   class FolderRevision < Revision
-    def validate
-      @errors = []
-      validate_source(@source)
-      validate_dest(@dest)
-    end
-
-    def bucket_names
-      # This is kind of weird, but we need the ability to grab
-      #   all relevant bucket names, even before validation of
-      #   the CopyRevision.
-      # So, if @dest doesn't exist, we don't return it
-      source_bucket_names = super
-      if @dest.mpath.valid?
-        return source_bucket_names.push(@dest.mpath.bucket_name)
-      end
-      return source_bucket_names
-    end
-
-    def mpaths
-      source_mpaths = super
-      source_mpaths.push(@dest.mpath) if @dest.mpath.valid?
-      return source_mpaths
-    end
-
-    def to_hash
-      {
-        dest: @dest.mpath.path,
-        source: @source.mpath.path,
-        errors: @errors
-      }
-    end
-
     private
 
     def full_folder_path(mpath_w_objs)

--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -220,8 +220,17 @@ class Metis
     end
 
     def update_bucket!(new_bucket)
-      raise 'Bucket does not match folder bucket' if folder != nil and folder.bucket_id != new_bucket.id
+      raise 'Bucket does not match folder bucket' if folder != nil && folder.bucket_id != new_bucket.id
       update(bucket: new_bucket)
+      refresh
+    end
+
+    def update_bucket_and_rename!(folder, new_file_name, new_bucket)
+      raise 'Bucket does not match folder bucket' if folder != nil && folder.bucket_id != new_bucket.id
+      update(
+        folder_id: folder ? folder.id : nil,
+        file_name: new_file_name,
+        bucket: new_bucket)
       refresh
     end
   end

--- a/metis/lib/revision.rb
+++ b/metis/lib/revision.rb
@@ -7,6 +7,8 @@ class Metis
       @source = Metis::PathWithObjects.new(params[:source])
       @dest = Metis::PathWithObjects.new(params[:dest])
 
+      @paths = [@source, @dest]
+
       @user = params[:user]
       @errors = nil
       # TODO: Will have to handle DELETE differently,
@@ -31,8 +33,18 @@ class Metis
       !!@errors&.empty?
     end
 
-    def validate (user_authorized_bucket_names)
-      raise 'not implemented'
+    def validate
+      @errors = []
+      validate_source(@source)
+      validate_dest(@dest)
+    end
+
+    def to_hash
+      {
+        dest: @dest.mpath.path,
+        source: @source.mpath.path,
+        errors: @errors
+      }
     end
 
     def bucket_names
@@ -40,15 +52,15 @@ class Metis
       #   all relevant bucket names, even before validation of
       #   the Revision.
       # So, if @source isn't valid, we return empty list.
-      if @source.mpath.valid?
-        return [@source.mpath.bucket_name]
-      end
-
-      return []
+      @paths.map do |path|
+        path.mpath.bucket_name if path.mpath.valid?
+      end.compact
     end
 
     def mpaths
-      @source.mpath.valid? ? [@source.mpath] : []
+      @paths.map do |path|
+        path.mpath if path.mpath.valid?
+      end.compact
     end
 
     private

--- a/metis/spec/file_rename_revision_spec.rb
+++ b/metis/spec/file_rename_revision_spec.rb
@@ -1,0 +1,466 @@
+describe Metis::FileRenameRevision do
+
+  def app
+    OUTER_APP
+  end
+
+  before(:each) do
+    default_bucket('athena')
+
+    @user = Etna::User.new({
+      first: 'Athena',
+      last: 'Pallas',
+      email: 'athena@olympus.org',
+      perm: 'a:athena'
+    })
+
+    @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+    stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+  end
+
+  after(:each) do
+    stubs.clear
+
+    expect(stubs.contents(:athena)).to be_empty
+  end
+
+  it 'creates a Metis::PathWithObjects as the dest parameter' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/wisdom.txt',
+          user: @user
+      })
+      expect(revision.dest.instance_of? Metis::PathWithObjects).to eq(true)
+  end
+
+  it 'adds error message if user cannot access the dest bucket' do
+      sundry_bucket = create( :bucket, project_name: 'athena', name: 'sundry', access: 'viewer', owner: 'metis' )
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/sundry/wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid bucket: \"sundry\""
+      )
+  end
+
+  it 'does not add error message if user can access the dest bucket' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'adds error message if the dest path is invalid' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: "metis://athena/files/learn\nwisdom.txt",
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"metis://athena/files/learn\nwisdom.txt\""
+      )
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'does not add error message if the dest path is valid' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/learn-wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+
+      blueprints_folder = create_folder('athena', 'blueprints')
+      stubs.create_folder('athena', 'files', 'blueprints')
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/blueprints/build-helmet.jpg',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.dest.folder = blueprints_folder
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'returns the source and dest bucket_names in an array' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/helmet.jpg',
+          dest: 'metis://athena/files/wisdom.txt',
+          user: @user
+      })
+      expect(revision.bucket_names).
+          to eq(['files', 'files'])
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/helmet.jpg',
+          dest: nil,
+          user: @user
+      })
+      expect(revision.bucket_names).
+          to eq(['files'])
+  end
+
+  it 'adds error message if dest bucket is read-only' do
+      contents_folder = create_folder('athena', 'contents', read_only: true)
+      stubs.create_folder('athena', 'files', 'contents')
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/contents/wisdom.txt',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.dest.folder = contents_folder
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Folder \"contents\" is read-only"
+      )
+  end
+
+  it 'adds error message if source file exists and is read-only' do
+      @wisdom2_file = create_file('athena', 'wisdom2.txt', WISDOM*2, read_only: true)
+      stubs.create_file('athena', 'files', 'wisdom2.txt', WISDOM*2)
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom2.txt',
+          dest: 'metis://athena/files/wisdom3.txt',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "File \"metis://athena/files/wisdom2.txt\" is read-only"
+      )
+  end
+
+  it 'adds error message if dest file exists' do
+    @wisdom2_file = create_file('athena', 'wisdom2.txt', WISDOM*2)
+    stubs.create_file('athena', 'files', 'wisdom2.txt', WISDOM*2)
+
+    revision = Metis::FileRenameRevision.new({
+        source: 'metis://athena/files/wisdom.txt',
+        dest: 'metis://athena/files/wisdom2.txt',
+        user: @user
+    })
+
+    revision.source.bucket = default_bucket('athena')
+    revision.dest.bucket = default_bucket('athena')
+    expect(revision.errors).to eq(nil)
+    revision.validate
+    expect(revision.errors.length).to eq(1)
+    expect(revision.errors[0]).to eq(
+        "File \"metis://athena/files/wisdom2.txt\" already exists"
+    )
+end
+
+  it 'reports multiple errors from validation' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/helmet.jpg',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+
+      expect(revision.errors.length).to eq(2)
+
+      expect(revision.errors[0]).to eq(
+          "File \"metis://athena/files/helmet.jpg\" not found"
+      )
+      expect(revision.errors[1]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'adds error message if trying to copy over an existing folder' do
+      wisdom_folder = create_folder('athena', 'wisdom.txt')
+      stubs.create_folder('athena', 'files', 'wisdom.txt')
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/wisdom.txt',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Cannot copy over existing folder: \"metis://athena/files/wisdom.txt\""
+      )
+  end
+
+  it 'executes the revision' do
+      expect(Metis::File.count).to eq(1)
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/learn-wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.validate
+      learn_wisdom = revision.revise!
+      expect(Metis::File.count).to eq(1)
+      expect(learn_wisdom.data_block).to eq(@wisdom_file.data_block)
+  end
+
+  it 'throws exception if you try to revise without setting user' do
+      expect(Metis::File.count).to eq(1)
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/learn-wisdom.txt'
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.validate
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::File.count).to eq(1)
+  end
+
+  it 'adds error message if source bucket is invalid' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/war/helmet.jpg',
+          dest: 'metis://athena/files/helmet2.jpg',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid bucket: \"war\""
+      )
+  end
+
+  it 'adds error message if source file does not exist' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/learn-wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "File \"metis://athena/files/learn-wisdom.txt\" not found"
+      )
+  end
+
+  it 'adds error message if the source path is invalid' do
+      revision = Metis::FileRenameRevision.new({
+          source: "metis://athena/files/build\nhelmet.jpg",
+          dest: "metis://athena/magma/learn-wisdom.txt",
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"metis://athena/files/build\nhelmet.jpg\""
+      )
+
+      revision = Metis::FileRenameRevision.new({
+          source: nil,
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(2)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"\""
+      )
+      expect(revision.errors[1]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'does not add error message if the source path is valid' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/learn-wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'adds error message if user cannot access the source bucket' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/magma/wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid bucket: \"magma\""
+      )
+  end
+
+  it 'does not add error message if user can access the source bucket' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/magma/wisdom2.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'will not execute the revision if not valid' do
+      expect(Metis::File.count).to eq(1)
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::File.count).to eq(1)
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::File.count).to eq(1)
+  end
+
+  it 'is invalid if validate not run' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/wisdom.txt',
+          dest: 'metis://athena/files/wisdom.txt',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      expect(revision.valid?).to eq(false)
+  end
+
+  it 'returns the dest and source paths in an array' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/helmet.jpg',
+          dest: 'metis://athena/magma/wisdom.txt'
+      })
+      expect(revision.mpaths.length).to eq(2)
+      expect(revision.mpaths[0].path).
+          to eq('metis://athena/files/helmet.jpg')
+      expect(revision.mpaths[1].path).
+          to eq('metis://athena/magma/wisdom.txt')
+
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/files/helmet.jpg',
+          dest: nil
+      })
+      expect(revision.mpaths.length).to eq(1)
+      expect(revision.mpaths[0].path).
+          to eq('metis://athena/files/helmet.jpg')
+  end
+
+  it 'returns a hash representation' do
+      revision = Metis::FileRenameRevision.new({
+          source: 'metis://athena/magma/wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+
+      expect(revision.to_hash).to eq({
+          source: 'metis://athena/magma/wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          errors: nil
+      })
+
+      revision.validate
+
+      expect(revision.to_hash).to eq({
+          source: 'metis://athena/magma/wisdom.txt',
+          dest: 'metis://athena/files/wisdom2.txt',
+          errors: ["Invalid bucket: \"magma\""]
+      })
+  end
+end

--- a/metis/spec/file_spec.rb
+++ b/metis/spec/file_spec.rb
@@ -225,8 +225,10 @@ describe FileController do
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
     end
 
-    def rename_file(path, new_path)
-      json_post("/athena/file/rename/files/#{path}", new_file_path: new_path)
+    def rename_file(path, new_path, params={})
+      json_post("/athena/file/rename/files/#{path}", {
+        new_file_path: new_path
+      }.merge(params))
     end
 
     it 'renames a file' do
@@ -246,7 +248,7 @@ describe FileController do
 
       @wisdom_file.refresh
       expect(last_response.status).to eq(422)
-      expect(json_body[:error]).to eq('Invalid path')
+      expect(json_body[:errors]).to eq(["Invalid path: \"metis://athena/files/learn\nwisdom.txt\""])
       expect(@wisdom_file.file_name).to eq('wisdom.txt')
       expect(@wisdom_file).to be_has_data
     end
@@ -267,8 +269,8 @@ describe FileController do
       token_header(:editor)
       rename_file('folly.txt', 'learn-folly.txt')
 
-      expect(last_response.status).to eq(404)
-      expect(json_body[:error]).to eq('File not found')
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(["File \"metis://athena/files/folly.txt\" not found"])
 
       # the actual file is untouched
       @wisdom_file.refresh
@@ -283,8 +285,9 @@ describe FileController do
       token_header(:editor)
       rename_file('wisdom.txt', 'learn-wisdom.txt')
 
-      expect(last_response.status).to eq(403)
-      expect(json_body[:error]).to eq('Cannot rename over existing file')
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(
+        ["File \"metis://athena/files/learn-wisdom.txt\" already exists"])
 
       # the file we tried to rename is untouched
       @wisdom_file.refresh
@@ -309,8 +312,9 @@ describe FileController do
       token_header(:editor)
       rename_file('wisdom.txt', 'learn-wisdom.txt')
 
-      expect(last_response.status).to eq(403)
-      expect(json_body[:error]).to eq('Cannot rename over existing folder')
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(
+        ["Cannot copy over existing folder: \"metis://athena/files/learn-wisdom.txt\""])
 
       # the file we tried to rename is untouched
       @wisdom_file.refresh
@@ -333,8 +337,9 @@ describe FileController do
       token_header(:editor)
       rename_file('wisdom.txt', 'learn-wisdom.txt')
 
-      expect(last_response.status).to eq(403)
-      expect(json_body[:error]).to eq('File is read-only')
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(
+        ["File \"metis://athena/files/wisdom.txt\" is read-only"])
       @wisdom_file.refresh
       expect(@wisdom_file.file_path).to eq('wisdom.txt')
       expect(@wisdom_file).to be_has_data
@@ -361,8 +366,8 @@ describe FileController do
       token_header(:editor)
       rename_file('wisdom.txt', 'contents/wisdom.txt')
 
-      expect(last_response.status).to eq(403)
-      expect(json_body[:error]).to eq('Folder is read-only')
+      expect(last_response.status).to eq(422)
+      expect(json_body[:errors]).to eq(["Folder \"contents\" is read-only"])
       @wisdom_file.refresh
       expect(@wisdom_file.file_path).to eq('wisdom.txt')
       expect(@wisdom_file.folder).to be_nil
@@ -379,6 +384,27 @@ describe FileController do
       expect(@wisdom_file.file_path).to eq('wisdom.txt')
       expect(@wisdom_file.folder).to be_nil
       expect(@wisdom_file).to be_has_data
+    end
+
+    it 'renames a file into a new bucket and folder' do
+      token_header(:editor)
+      sundry_bucket = create(:bucket, project_name: 'athena', name: 'sundry', access: 'viewer', owner: 'metis' )
+      sundry_wisdom_folder = create_folder('athena', 'sundry-wisdom', bucket: sundry_bucket)
+      stubs.create_folder('athena', 'sundry', 'sundry-wisdom')
+
+      rename_file('wisdom.txt', 'sundry-wisdom/updated-wisdom.txt', {
+        new_bucket_name: 'sundry'
+      })
+
+      expect(last_response.status).to eq(200)
+
+      # the old file is updated
+      expect(Metis::File.count).to eq(1)
+      @wisdom_file.refresh
+      expect(@wisdom_file.file_name).to eq('updated-wisdom.txt')
+      expect(@wisdom_file).to be_has_data
+      expect(@wisdom_file.bucket).to eq(sundry_bucket)
+      expect(@wisdom_file.folder).to eq(sundry_wisdom_folder)
     end
   end
 
@@ -1328,6 +1354,59 @@ describe FileController do
       }.to raise_error(StandardError)
 
       expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
+    end
+  end
+
+  context '#update_bucket_and_rename!' do
+    before(:each) do
+      @backup_files_bucket = create( :bucket, project_name: 'athena', name: 'backup_files', owner: 'metis', access: 'viewer')
+      stubs.create_bucket('athena', 'backup_files')
+
+      @wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+
+      @blueprints_folder = create_folder('athena', 'blueprints')
+      stubs.create_folder('athena', 'files', 'blueprints')
+
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @helmet_file = create_file('athena', 'helmet.jpg', HELMET, folder: @helmet_folder)
+      stubs.create_file('athena', 'files', 'blueprints/helmet/helmet.jpg', HELMET)
+    end
+
+    it 'moves a file to the new bucket when does not have a parent folder' do
+      expect(@wisdom_file.bucket).not_to eq(@backup_files_bucket)
+
+      @wisdom_file.update_bucket_and_rename!(nil, 'additional_wisdom.txt', @backup_files_bucket)
+
+      expect(@wisdom_file.bucket).to eq(@backup_files_bucket)
+      expect(@wisdom_file.file_name).to eq('additional_wisdom.txt')
+    end
+
+    it 'moves a file to the new bucket when does have a parent folder' do
+      backup_blueprints_folder = create_folder('athena', 'blueprints', bucket: @backup_files_bucket)
+      stubs.create_folder('athena', 'backup_files', 'blueprints')
+
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
+
+      @helmet_file.update_bucket_and_rename!(backup_blueprints_folder, 'backup_helmet.jpg', @backup_files_bucket)
+
+      expect(@helmet_file.bucket).to eq(@backup_files_bucket)
+      expect(@helmet_file.folder).to eq(backup_blueprints_folder)
+      expect(@helmet_file.file_name).to eq('backup_helmet.jpg')
+    end
+
+    it 'cannot move a file to a different bucket than its folder\'s bucket' do
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
+
+      expect {
+        @helmet_file.update_bucket_and_rename!(@blueprints_folder, 'backup_helmet.jpg', @backup_files_bucket)
+      }.to raise_error(StandardError)
+
+      expect(@helmet_file.bucket).not_to eq(@backup_files_bucket)
+      expect(@helmet_file.folder).not_to eq(@blueprints_folder)
+      expect(@helmet_file.file_name).not_to eq('backup_helmet.jpg')
     end
   end
 end

--- a/metis/spec/file_spec.rb
+++ b/metis/spec/file_spec.rb
@@ -406,6 +406,25 @@ describe FileController do
       expect(@wisdom_file.bucket).to eq(sundry_bucket)
       expect(@wisdom_file.folder).to eq(sundry_wisdom_folder)
     end
+
+    it 'renames a file into a new bucket and no folder' do
+      token_header(:editor)
+      sundry_bucket = create(:bucket, project_name: 'athena', name: 'sundry', access: 'viewer', owner: 'metis' )
+
+      rename_file('wisdom.txt', 'updated-wisdom.txt', {
+        new_bucket_name: 'sundry'
+      })
+
+      expect(last_response.status).to eq(200)
+
+      # the old file is updated
+      expect(Metis::File.count).to eq(1)
+      @wisdom_file.refresh
+      expect(@wisdom_file.file_name).to eq('updated-wisdom.txt')
+      expect(@wisdom_file).to be_has_data
+      expect(@wisdom_file.bucket).to eq(sundry_bucket)
+      expect(@wisdom_file.folder).to eq(nil)
+    end
   end
 
   context '#copy' do

--- a/metis/spec/revision_spec.rb
+++ b/metis/spec/revision_spec.rb
@@ -48,10 +48,10 @@ describe Metis::Revision do
         }.to raise_error(StandardError)
     end
 
-    it 'returns the source bucket_name in an array' do
+    it 'returns the bucket_name in an array' do
         revision = Metis::Revision.new({
             source: 'metis://athena/files/helmet.jpg',
-            dest: 'metis://athena/magma/wisdom.txt'
+            dest: nil
         })
         expect(revision.bucket_names).
             to eq(['files'])
@@ -61,13 +61,30 @@ describe Metis::Revision do
             dest: 'metis://athena/magma/wisdom.txt'
         })
         expect(revision.bucket_names).
-            to eq([])
-    end
+            to eq(['magma'])
 
-    it 'returns the source path in an array' do
         revision = Metis::Revision.new({
             source: 'metis://athena/files/helmet.jpg',
             dest: 'metis://athena/magma/wisdom.txt'
+        })
+        expect(revision.bucket_names).
+            to eq(['files', 'magma'])
+    end
+
+    it 'returns the paths in an array' do
+        revision = Metis::Revision.new({
+            source: 'metis://athena/files/helmet.jpg',
+            dest: 'metis://athena/magma/wisdom.txt'
+        })
+        expect(revision.mpaths.length).to eq(2)
+        expect(revision.mpaths[0].path).
+            to eq('metis://athena/files/helmet.jpg')
+        expect(revision.mpaths[1].path).
+            to eq('metis://athena/magma/wisdom.txt')
+
+        revision = Metis::Revision.new({
+            source: 'metis://athena/files/helmet.jpg',
+            dest: nil
         })
         expect(revision.mpaths.length).to eq(1)
         expect(revision.mpaths[0].path).
@@ -77,8 +94,9 @@ describe Metis::Revision do
             source: nil,
             dest: 'metis://athena/magma/wisdom.txt'
         })
-        expect(revision.mpaths).
-            to eq([])
+        expect(revision.mpaths.length).to eq(1)
+        expect(revision.mpaths[0].path).
+            to eq('metis://athena/magma/wisdom.txt')
     end
 
     it 'sets the bucket on a Metis Path with Objects' do

--- a/polyphemus/Gemfile
+++ b/polyphemus/Gemfile
@@ -5,6 +5,7 @@ gem 'sequel'
 gem 'pg'
 gem 'nokogiri'
 gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/c140d60d78c368df7d56e71112eed1c4ecd6d431'
+gem 'puma', '5.0.2'
 
 group :development, :test do
   gem 'rack-test', require: "rack/test"

--- a/timur/Gemfile
+++ b/timur/Gemfile
@@ -13,6 +13,8 @@ gem 'pg', '~> 0.21'
 # provides database models
 gem 'sequel', '4.49.0'
 
+gem 'puma', '5.0.2'
+
 group :development, :test do
   gem 'rspec'
   gem 'simplecov'

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
+    nio4r (2.5.4)
     pg (0.21.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -51,6 +52,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.5)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -97,6 +100,7 @@ DEPENDENCIES
   pg (~> 0.21)
   pry
   pry-byebug
+  puma (= 5.0.2)
   rack-test
   rltk
   rspec


### PR DESCRIPTION
This PR allows the Metis waiver_data functionality to handle folders that exist in both the source and target buckets. Current behavior of Metis throws an exception when you try to rename onto an existing folder, which is a problem if waiver data moves a partially-uploaded folder.

This PR does several things:

* Adds the ability for Metis `file_rename` route to handle moving files to a different bucket. The current behavior does not clobber existing files (the unix `mv` command does), which I thought was safer since we don't have any UI toggle or prompt to warn the user that they may clobber an existing file. This functionality only exists at the API level and is not exposed in the UI.
* Updates the "rename with regex" convenience function in the `etna` Metis client to call a new method if the target folder exists. This new method moves sub-folders and files into the target folder, and then deletes the source folders. So to the user it appears like the old "rename folder" behavior but instead individually moves files / folders over.
* Also pins the version of Puma in each app's Gemfile. I ran into the same issue as Anton after bringing the apps back up, in that the Puma version automatically bumped and introduced new dependencies.

There may still be an exception thrown if a file is duplicated in both folders (since the rename won't overwrite), but that shouldn't happen with the waiver_data use case unless someone uploads a file multiple times.

This requires a deployment to both Metis and Polyphemus.