### PR TITLE
Removing bundler env variable path for Polyphemus binary

### DIFF
--- a/polyphemus/bin/polyphemus
+++ b/polyphemus/bin/polyphemus
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler'
-ENV['BUNDLE_GEMFILE'] = '/app/Gemfile'
+# ENV['BUNDLE_GEMFILE'] = '/app/Gemfile'
 Bundler.require :default, (ENV['POLYPHEMUS_ENV'] || :development).to_sym
 
 require_relative '../lib/polyphemus'

--- a/polyphemus/bin/polyphemus
+++ b/polyphemus/bin/polyphemus
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'bundler'
-# ENV['BUNDLE_GEMFILE'] = '/app/Gemfile'
 Bundler.require :default, (ENV['POLYPHEMUS_ENV'] || :development).to_sym
 
 require_relative '../lib/polyphemus'


### PR DESCRIPTION
I ran into this today when updating polyphemus on production -- seems like setting this Bundler environment variable breaks polyphemus production / staging because they are not currently deployed in Docker (?). So I manually unset this on the server but am also submitting this PR .... the other apps don't appear to set this environment variable, so I'm wondering if it will be safe to remove both for local development in Docker and server deploys outside of Docker?