### PR TITLE
remove unused action

### DIFF
--- a/timur/lib/client/jsx/reducers/magma_reducer.js
+++ b/timur/lib/client/jsx/reducers/magma_reducer.js
@@ -22,7 +22,6 @@ import {
   ADD_TEMPLATE,
   REVISE_DOCUMENT,
   DISCARD_REVISION,
-  DISCARD_ATTRIBUTE_REVISION,
   ADD_PREDICATES
 } from '../actions/magma_actions';
 
@@ -63,10 +62,6 @@ var revisions = function (old_revisions, action) {
         ...old_revisions,
         [action.record_name]: null
       };
-    case DISCARD_ATTRIBUTE_REVISION:
-      let updated_revision = { ...old_revisions };
-      delete updated_revision[action.record_name][action.attribute_name];
-      return updated_revision;
     default:
       return old_revisions;
   }
@@ -93,7 +88,6 @@ var model = function (old_model, action) {
       };
     case REVISE_DOCUMENT:
     case DISCARD_REVISION:
-    case DISCARD_ATTRIBUTE_REVISION:
       return {
         ...old_model,
         revisions: revisions(old_model.revisions, action)
@@ -110,7 +104,6 @@ var models = function (models, action) {
     case ADD_DOCUMENTS:
     case REVISE_DOCUMENT:
     case DISCARD_REVISION:
-    case DISCARD_ATTRIBUTE_REVISION:
       return {
         ...models,
         [action.model_name]: model(models[action.model_name], action)
@@ -131,7 +124,6 @@ var magmaReducer = function (magma, action) {
     case ADD_DOCUMENTS:
     case REVISE_DOCUMENT:
     case DISCARD_REVISION:
-    case DISCARD_ATTRIBUTE_REVISION:
       return {
         ...magma,
         models: models(magma.models, action)


### PR DESCRIPTION
I had removed this action in `magma_actions`, but did not remove it from the reducer. Webpack is okay with this locally in development mode, but not okay with this on staging in production mode (?), so cleaning up the cruft.