### PR TITLE
add spark-md5 dependency to timur

### DIFF
--- a/timur/package-lock.json
+++ b/timur/package-lock.json
@@ -13145,6 +13145,11 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
+    "spark-md5": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.1.tgz",
+      "integrity": "sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig=="
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",

--- a/timur/package.json
+++ b/timur/package.json
@@ -38,6 +38,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.5",
     "reselect": "^3.0.1",
+    "spark-md5": "^3.0.0",
     "style-loader": "^1.2.1",
     "webworkify-webpack": "^2.1.1"
   },


### PR DESCRIPTION
Hm, so apparently there is a difference in CI as well, where the CI in monoetna passes for Timur, but it fails in the mountetna/timur repository....so adding in this dependency.