### PR TITLE
Show type errors on add_attribute action

### DIFF
--- a/magma/lib/magma/actions/add_attribute.rb
+++ b/magma/lib/magma/actions/add_attribute.rb
@@ -32,12 +32,22 @@ class Magma
     def validations
       [
         :validate_model,
+        :validate_type,
         :validate_attribute_name_unique,
         :validate_restricted_attribute,
         :validate_options,
         :validate_not_link,
         :validate_attribute,
       ]
+    end
+
+    def validate_type
+      return if Magma::Attribute.attribute_types.include?(@action_params[:type])
+
+      @errors << Magma::ActionError.new(
+        message: 'Type is invalid',
+        source: @action_params.slice(:action_name, :model_name)
+      )
     end
 
     def validate_model
@@ -59,7 +69,7 @@ class Magma
     end
 
     def validate_attribute_name_unique
-      return if !model&.has_attribute?(attribute.attribute_name)
+      return if !model&.has_attribute?(attribute&.attribute_name)
 
       @errors << Magma::ActionError.new(
         message: "attribute_name already exists on #{model.name}",
@@ -77,7 +87,7 @@ class Magma
     end
 
     def validate_options
-      return unless model
+      return unless model && attribute
       @action_params.except(:action_name, :model_name, :attribute_name).keys.each do |option|
         if !attribute.respond_to?(option)
           @errors << Magma::ActionError.new(
@@ -89,7 +99,7 @@ class Magma
     end
 
     def validate_attribute
-      return unless model
+      return unless model && attribute
       return if attribute.valid?
 
       attribute.errors.full_messages.each do |error|
@@ -101,11 +111,11 @@ class Magma
     end
 
     def attribute
-      @attribute ||= attribute_class.new(attribute_params)
+      @attribute ||= attribute_class&.new(attribute_params)
     end
 
     def attribute_class
-      Magma::Attribute.sti_class_from_sti_key(@action_params[:type])
+      @action_params[:type] && Magma::Attribute.sti_class_from_sti_key(@action_params[:type])
     end
 
     def attribute_params

--- a/magma/lib/magma/actions/add_attribute.rb
+++ b/magma/lib/magma/actions/add_attribute.rb
@@ -46,7 +46,7 @@ class Magma
 
       @errors << Magma::ActionError.new(
         message: 'Type is invalid',
-        source: @action_params.slice(:action_name, :model_name)
+        source: @action_params.slice(:action_name, :type)
       )
     end
 

--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -34,6 +34,16 @@ class Magma
 :format_hint, :loader, :link_model_name, :restricted]
       end
 
+      def type_attributes
+        descendants.reject do |att_class|
+          att_class == Magma::ForeignKeyAttribute
+        end
+      end
+
+      def attribute_types
+        type_attributes.map(&:attribute_type)
+      end
+
       def attribute_type
         @attribute_type ||= name.match("Magma::(.*)Attribute")[1].underscore
       end

--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -1,12 +1,10 @@
 class Magma
   class Model < Sequel::Model
     class << self
-      Magma::Attribute.descendants.
-                      reject { |attribute| attribute == Magma::ForeignKeyAttribute }.
-                      each do |attribute|
-        define_method attribute.attribute_type do |attribute_name = nil, opts = {}|
-          @parent = attribute_name if attribute == Magma::ParentAttribute
-          attributes[attribute_name] = attribute.new(opts.merge(
+      Magma::Attribute.type_attributes.each do |attribute|
+          define_method attribute.attribute_type do |attribute_name=nil, opts={}|
+            @parent = attribute_name if attribute == Magma::ParentAttribute
+            attributes[attribute_name] = attribute.new(opts.merge(
               project_name: project_name,
               model_name: model_name,
               attribute_name: attribute_name,

--- a/magma/spec/actions/add_attribute_actions_spec.rb
+++ b/magma/spec/actions/add_attribute_actions_spec.rb
@@ -61,7 +61,15 @@ describe Magma::AddAttributeAction do
       it 'captures a model error' do
         action = Magma::AddAttributeAction.new(project_name, action_params.except(:type))
         expect(action.validate).to eq(false)
-        expect(action.errors.first[:message]).to eq("type is not present")
+        expect(action.errors.first[:message]).to eq("Type is invalid")
+      end
+    end
+
+    context "when the type is an invalid type" do
+      it 'captures a model error' do
+        action = Magma::AddAttributeAction.new(project_name, action_params.merge(type: 'boot'))
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("Type is invalid")
       end
     end
 

--- a/magma/spec/actions/add_attribute_actions_spec.rb
+++ b/magma/spec/actions/add_attribute_actions_spec.rb
@@ -57,6 +57,14 @@ describe Magma::AddAttributeAction do
       end
     end
 
+    context "when the type is missing" do
+      it 'captures a model error' do
+        action = Magma::AddAttributeAction.new(project_name, action_params.except(:type))
+        expect(action.validate).to eq(false)
+        expect(action.errors.first[:message]).to eq("type is not present")
+      end
+    end
+
     context "when the model doesn't exist" do
       let(:model_name) { 'super_duper' }
 


### PR DESCRIPTION
Just a little one to add some error-handling to the add_attribute action, which I often have trouble with because of missing parameters.