### PR TITLE
Project full names

### DIFF
--- a/etna/packages/etna-js/actions/janus-actions.jsx
+++ b/etna/packages/etna-js/actions/janus-actions.jsx
@@ -1,0 +1,14 @@
+import {getProjects} from '../api/janus-api';
+
+export const FETCH_PROJECTS = 'FETCH_PROJECTS';
+
+export const fetchProjectsAction = () => {
+  return (dispatch) => {
+    getProjects().then((projects) => {
+      dispatch({
+        type: FETCH_PROJECTS,
+        projects: projects
+      });
+    });
+  };
+};

--- a/etna/packages/etna-js/api/janus-api.jsx
+++ b/etna/packages/etna-js/api/janus-api.jsx
@@ -1,0 +1,7 @@
+export const getProjects = () => {
+  let projects = require('./projects.json');
+
+  return new Promise((resolve, reject) => {
+    resolve(projects);
+  });
+};

--- a/etna/packages/etna-js/api/projects.json
+++ b/etna/packages/etna-js/api/projects.json
@@ -1,0 +1,97 @@
+[
+  {
+    "project_name": "ipi",
+    "project_name_full": "immunoprofiler initiative",
+    "project_description": "The Immunoprofiler Initiative"
+  },
+  {
+    "project_name": "bap",
+    "project_name_full": "biospeciment acquisition protocol",
+    "project_description": "Biospecimen Acquisition Protocol For Analysis Of Biomarkers In Cancers"
+  },
+  {
+    "project_name": "all_samples",
+    "project_name_full": "All Samples for CIP/Fong Lab",
+    "project_description": null
+  },
+  {
+    "project_name": "imx_cv",
+    "project_name_full": "ImmunoX Chronic Viral",
+    "project_description": null
+  },
+  {
+    "project_name": "administration",
+    "project_name_full": "administration",
+    "project_description": "The main project for Mount Etna."
+  },
+  {
+    "project_name": "imx_humu",
+    "project_name_full": "ImmunoX Human-Mouse Translation",
+    "project_description": null
+  },
+  {
+    "project_name": "dscolab",
+    "project_name_full": "Data Science CoLab",
+    "project_description": null
+  },
+  {
+    "project_name": "test_project",
+    "project_name_full": "The Test Project",
+    "project_description": null
+  },
+  {
+    "project_name": "xvir1",
+    "project_name_full": "Chronic Viral Infection",
+    "project_description": null
+  },
+  {
+    "project_name": "xcrs1",
+    "project_name_full": "Human-Mouse Cancer Translator",
+    "project_description": null
+  },
+  {
+    "project_name": "mvir1",
+    "project_name_full": "COMET",
+    "project_description": null
+  },
+  {
+    "project_name": "xcan1",
+    "project_name_full": "Early-stage lung adenocarcinoma",
+    "project_description": null
+  },
+  {
+    "project_name": "xhlt1",
+    "project_name_full": "Immune Cell Census",
+    "project_description": null
+  },
+  {
+    "project_name": "xhlt2",
+    "project_name_full": "Immunomicrobiome",
+    "project_description": null
+  },
+  {
+    "project_name": "xneu1",
+    "project_name_full": "Frontotemporal lobar degeneration",
+    "project_description": null
+  },
+  {
+    "project_name": "xaut1",
+    "project_name_full": "Checkpoint Induced Colitis 1",
+    "project_description": null
+  },
+  {
+    "project_name": "xaut2",
+    "project_name_full": "Checkpoint Induced Colitis 2",
+    "project_description": null
+  },
+  {
+    "project_name": "coprojects_template",
+    "project_name_full": "Coprojects Template",
+    "project_description": null
+  },
+  {
+    "project_name": "xorg1",
+    "project_name_full": "Organoids",
+    "project_description": null
+  }
+]

--- a/etna/packages/etna-js/reducers/janus-reducer.jsx
+++ b/etna/packages/etna-js/reducers/janus-reducer.jsx
@@ -1,0 +1,19 @@
+import {FETCH_PROJECTS} from '../actions/janus-actions';
+
+const janusReducer = (janus, action) => {
+  if (!janus) {
+    janus = {
+      projects: []
+    };
+  }
+  switch (action.type) {
+    case FETCH_PROJECTS:
+      return {
+        projects: [...action.projects]
+      };
+    default:
+      return janus;
+  }
+};
+
+export default janusReducer;

--- a/etna/packages/etna-js/selectors/__tests__/janus-selector.spec.jsx
+++ b/etna/packages/etna-js/selectors/__tests__/janus-selector.spec.jsx
@@ -1,0 +1,12 @@
+import {selectProjects} from '../janus-selector';
+
+describe('Janus Selector', () => {
+  it('returns projects', () => {
+    const projects = [{project_name: 'xyz1'}];
+    const result = selectProjects({
+      janus: {projects}
+    });
+
+    expect(result).toEqual(projects);
+  });
+});

--- a/etna/packages/etna-js/selectors/janus-selector.jsx
+++ b/etna/packages/etna-js/selectors/janus-selector.jsx
@@ -1,0 +1,1 @@
+export const selectProjects = ({janus: {projects}}) => projects;

--- a/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
+++ b/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
@@ -32,4 +32,10 @@ describe('Janus Utils', () => {
 
     expect(result).toEqual('xyz2');
   });
+
+  it('returns the shortname if no projects', () => {
+    const result = projectNameFull(null, 'xyz2');
+
+    expect(result).toEqual('xyz2');
+  });
 });

--- a/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
+++ b/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
@@ -1,0 +1,35 @@
+import {projectNameFull} from '../janus';
+
+describe('Janus Utils', () => {
+  it('returns the matching project', () => {
+    const state = {
+      janus: {
+        projects: [
+          {
+            project_name: 'xyz1',
+            project_name_full: 'ACME corporation'
+          }
+        ]
+      }
+    };
+    const result = projectNameFull(state, 'xyz1');
+
+    expect(result).toEqual('ACME corporation');
+  });
+
+  it('returns the shortname if no matching project', () => {
+    const state = {
+      janus: {
+        projects: [
+          {
+            project_name: 'xyz1',
+            project_name_full: 'ACME corporation'
+          }
+        ]
+      }
+    };
+    const result = projectNameFull(state, 'xyz2');
+
+    expect(result).toEqual('xyz2');
+  });
+});

--- a/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
+++ b/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
@@ -2,33 +2,25 @@ import {projectNameFull} from '../janus';
 
 describe('Janus Utils', () => {
   it('returns the matching project', () => {
-    const state = {
-      janus: {
-        projects: [
-          {
-            project_name: 'xyz1',
-            project_name_full: 'ACME corporation'
-          }
-        ]
+    const projects = [
+      {
+        project_name: 'xyz1',
+        project_name_full: 'ACME corporation'
       }
-    };
-    const result = projectNameFull(state, 'xyz1');
+    ];
+    const result = projectNameFull(projects, 'xyz1');
 
     expect(result).toEqual('ACME corporation');
   });
 
   it('returns the shortname if no matching project', () => {
-    const state = {
-      janus: {
-        projects: [
-          {
-            project_name: 'xyz1',
-            project_name_full: 'ACME corporation'
-          }
-        ]
+    const projects = [
+      {
+        project_name: 'xyz1',
+        project_name_full: 'ACME corporation'
       }
-    };
-    const result = projectNameFull(state, 'xyz2');
+    ];
+    const result = projectNameFull(projects, 'xyz2');
 
     expect(result).toEqual('xyz2');
   });

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -2,18 +2,21 @@ const ROLES = {a: 'administrator', e: 'editor', v: 'viewer'};
 
 const parsePermissions = (perms) => {
   // Permissions are encoded as 'a:project1,project2;v:project3'
-  return perms.split(/;/).map(perm => {
-    let [encoded_role, projects] = perm.split(/:/);
-    let role = ROLES[encoded_role.toLowerCase()];
-    let privileged = encoded_role.toUpperCase() == encoded_role;
-    return projects.split(/,/).map(
-      project_name => ({ role, privileged, project_name })
-    )
-  }).reduce((perms, projects) => {
-    projects.forEach(perm => perms[perm.project_name] = perm);
-    return perms
-  }, {});
-}
+  return perms
+    .split(/;/)
+    .map((perm) => {
+      let [encoded_role, projects] = perm.split(/:/);
+      let role = ROLES[encoded_role.toLowerCase()];
+      let privileged = encoded_role.toUpperCase() == encoded_role;
+      return projects
+        .split(/,/)
+        .map((project_name) => ({role, privileged, project_name}));
+    })
+    .reduce((perms, projects) => {
+      projects.forEach((perm) => (perms[perm.project_name] = perm));
+      return perms;
+    }, {});
+};
 
 export function parseToken(token) {
   let [header, params, signature] = token.split(/\./);
@@ -26,3 +29,13 @@ export function parseToken(token) {
     permissions: parsePermissions(perm)
   };
 }
+
+export const projectNameFull = (projects, project_name) => {
+  if (!projects) return project_name;
+
+  let matching_project = projects.find((project) => {
+    return project.project_name === project_name;
+  });
+
+  return matching_project ? matching_project.project_name_full : project_name;
+};

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -2,21 +2,18 @@ const ROLES = {a: 'administrator', e: 'editor', v: 'viewer'};
 
 const parsePermissions = (perms) => {
   // Permissions are encoded as 'a:project1,project2;v:project3'
-  return perms
-    .split(/;/)
-    .map((perm) => {
-      let [encoded_role, projects] = perm.split(/:/);
-      let role = ROLES[encoded_role.toLowerCase()];
-      let privileged = encoded_role.toUpperCase() == encoded_role;
-      return projects
-        .split(/,/)
-        .map((project_name) => ({role, privileged, project_name}));
-    })
-    .reduce((perms, projects) => {
-      projects.forEach((perm) => (perms[perm.project_name] = perm));
-      return perms;
-    }, {});
-};
+  return perms.split(/;/).map(perm => {
+    let [encoded_role, projects] = perm.split(/:/);
+    let role = ROLES[encoded_role.toLowerCase()];
+    let privileged = encoded_role.toUpperCase() == encoded_role;
+    return projects.split(/,/).map(
+      project_name => ({ role, privileged, project_name })
+    )
+  }).reduce((perms, projects) => {
+    projects.forEach(perm => perms[perm.project_name] = perm);
+    return perms
+  }, {});
+}
 
 export function parseToken(token) {
   let [header, params, signature] = token.split(/\./);

--- a/janus/lib/server.rb
+++ b/janus/lib/server.rb
@@ -23,6 +23,8 @@ class Janus
 
     get '/project/:project_name', action: 'admin#project', auth: { user: { can_edit?: :project_name } }
 
+    get '/projects', action: 'user#projects', auth: { user: { active?: true } }
+
     get '/refresh_token', action: 'user#refresh_token', auth: { user: { active?: true } }
 
     # Once we figure out a long-term token strategy, this should probably get

--- a/janus/lib/server/controllers/user_controller.rb
+++ b/janus/lib/server/controllers/user_controller.rb
@@ -35,4 +35,24 @@ class UserController < Janus::Controller
 
     success(@janus_user.create_token!(viewer_only: true))
   end
+
+  def projects
+    @janus_user = User[email: @user.email]
+
+    raise Etna::Forbidden, 'User not found' unless @janus_user
+
+    projects = @janus_user.permissions.map do |perm|
+      perm.project
+    end.uniq.map do |proj|
+      # Don't use proj.to_hash because we don't necessarily want to send back
+      #   all the information.
+      {
+        project_name: proj.project_name,
+        project_name_full: proj.project_name_full,
+        project_description: proj.project_description
+      }
+    end
+
+    success_json({projects: projects})
+  end
 end

--- a/janus/spec/user_spec.rb
+++ b/janus/spec/user_spec.rb
@@ -269,4 +269,37 @@ describe UserController do
       expect(last_response.status).to eq(403)
     end
   end
+
+  context '#projects' do
+    it 'returns the user\'s projects' do
+      user = create(:user, first_name: 'Janus', last_name: 'Bifrons', email: 'janus@two-faces.org')
+
+      gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway')
+      tunnel = create(:project, project_name: 'tunnel', project_name_full: 'Tunnel')
+      mirror = create(:project, project_name: 'mirror', project_name_full: 'Mirror')
+
+      # the JWT will include a string encoding these permissions
+      perm = create(:permission, project: tunnel, user: user, role: 'viewer', privileged: true)
+      perm = create(:permission, project: mirror, user: user, role: 'editor')
+      perm = create(:permission, project: gateway, user: user, role: 'editor')
+
+      auth_header(:janus)
+      get('/projects')
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:projects]).to eq([{
+        project_description: nil,
+        project_name: "tunnel",
+        project_name_full: "Tunnel"
+      }, {
+        project_description: nil,
+        project_name: "mirror",
+        project_name_full: "Mirror"
+      }, {
+        project_description: nil,
+        project_name: "gateway",
+        project_name_full: "Gateway"
+      }])
+    end
+  end
 end

--- a/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
+++ b/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RootView renders 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="title"
+  >
+    Available Projects
+  </div>
+  <div
+    className="projects"
+  >
+    <div
+      className="project"
+    >
+      <a
+        className="project_name"
+        href="/labors"
+      >
+        The Twelve Labors of Hercules
+      </a>
+      - 
+      <span
+        className="role"
+      >
+        viewer
+        
+      </span>
+    </div>
+    <div
+      className="project"
+    >
+      <a
+        className="project_name"
+        href="/wisdom"
+      >
+        Athena's Wisdom
+      </a>
+      - 
+      <span
+        className="role"
+      >
+        viewer
+        
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/metis/lib/client/jsx/components/__tests__/fixtures/project_names.json
+++ b/metis/lib/client/jsx/components/__tests__/fixtures/project_names.json
@@ -1,0 +1,12 @@
+[
+  {
+    "project_name": "labors",
+    "project_name_full": "The Twelve Labors of Hercules",
+    "project_description": "The Twelve Labors of Hercules"
+  },
+  {
+    "project_name": "wisdom",
+    "project_name_full": "Athena's Wisdom",
+    "project_description": "Athena's Wisdom"
+  }
+]

--- a/metis/lib/client/jsx/components/__tests__/fixtures/root_view_permissions.json
+++ b/metis/lib/client/jsx/components/__tests__/fixtures/root_view_permissions.json
@@ -1,0 +1,12 @@
+{
+  "labors": {
+    "role": "viewer",
+    "privileged": false,
+    "project_name": "labors"
+  },
+  "wisdom": {
+    "role": "viewer",
+    "privileged": false,
+    "project_name": "wisdom"
+  }
+}

--- a/metis/lib/client/jsx/components/__tests__/root_view.spec.jsx
+++ b/metis/lib/client/jsx/components/__tests__/root_view.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import renderer from 'react-test-renderer';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import RootView from '../root-view';
+
+const permissions = require('./fixtures/root_view_permissions.json');
+const projects = require('./fixtures/project_names.json');
+
+describe('RootView', () => {
+  it('renders', () => {
+    const mockStore = configureMockStore([thunk]);
+
+    const tree = renderer
+      .create(
+        <Provider
+          store={mockStore({
+            user: {
+              permissions: permissions
+            },
+            janus: {
+              projects: projects
+            }
+          })}
+        >
+          <RootView />
+        </Provider>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/metis/lib/client/jsx/components/metis-ui.jsx
+++ b/metis/lib/client/jsx/components/metis-ui.jsx
@@ -60,8 +60,6 @@ class MetisUI extends React.Component {
   }
 }
 
-// export default MetisUI;
-
 export default connect(
   null,
   { fetchProjectsAction }

--- a/metis/lib/client/jsx/components/metis-ui.jsx
+++ b/metis/lib/client/jsx/components/metis-ui.jsx
@@ -9,6 +9,8 @@ import ModalDialog from './modal-dialog';
 
 import { findRoute, setRoutes } from '../router';
 
+import {fetchProjectsAction} from 'etna-js/actions/janus-actions';
+
 const ROUTES = [
   {
     name: 'root',
@@ -37,6 +39,13 @@ setRoutes(ROUTES);
 const Invalid = () => <div>Path invalid</div>;
 
 class MetisUI extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // Fetch the projects from Janus
+    props.fetchProjectsAction();
+  }
+
   render() {
     let { route, params }  = findRoute({ path: window.location.pathname } ,ROUTES);
     let Component = route ? route.component : Invalid;
@@ -51,4 +60,9 @@ class MetisUI extends React.Component {
   }
 }
 
-export default MetisUI;
+// export default MetisUI;
+
+export default connect(
+  null,
+  { fetchProjectsAction }
+)(MetisUI);

--- a/metis/lib/client/jsx/components/root-view.jsx
+++ b/metis/lib/client/jsx/components/root-view.jsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { selectUserPermissions } from '../selectors/user-selector';
+import { selectProjects } from 'etna-js/selectors/janus-selector';
+import { projectNameFull } from 'etna-js/utils/janus';
 
 export class RootView extends React.Component{
   render(){
-    let { permissions } = this.props;
-
+    let { permissions, projects } = this.props;
+    
     if (Object.keys(permissions).length <= 0)
       return <div className='projects'>{'No available projects.'}</div>;
 
@@ -23,7 +25,7 @@ export class RootView extends React.Component{
                 <a className='project_name'
                   key={project_name}
                   href={`/${project_name}`}>
-                  {project_name}
+                  {projectNameFull(projects, project_name)}
                 </a>
                 - <span className='role'>{role}{ privileged ? ', privileged access' : '' }</span>
               </div>
@@ -37,6 +39,7 @@ export class RootView extends React.Component{
 
 export default connect(
   (state)=>({
-    permissions: selectUserPermissions(state)
+    permissions: selectUserPermissions(state),
+    projects: selectProjects(state)
   })
 )(RootView);

--- a/metis/lib/client/jsx/store.jsx
+++ b/metis/lib/client/jsx/store.jsx
@@ -1,8 +1,10 @@
 import * as Redux from 'redux';
+import thunk from 'redux-thunk';
 import * as ReduxLogger from 'redux-logger';
 import directory from './reducers/directory-reducer';
 import user from './reducers/user-reducer';
 import dialog from './reducers/dialog-reducer';
+import janus from 'etna-js/reducers/janus-reducer';
 
 import * as fileActions from './actions/file_actions';
 import * as folderActions from './actions/folder_actions';
@@ -16,7 +18,8 @@ const createStore = () => {
   let reducers = {
     directory,
     dialog,
-    user
+    user,
+    janus
   };
 
   // action handlers to import
@@ -31,22 +34,16 @@ const createStore = () => {
     // returnFile: fileActions.retrieveFile
   };
 
+  let middleWares = [thunk, asyncDispatcher(actions), workDispatcher()];
 
-  let middleWares = [
-    asyncDispatcher(actions),
-    workDispatcher()
-  ];
+  if (process.env.NODE_ENV != 'production')
+    middleWares.unshift(ReduxLogger.createLogger({collapsed: true}));
 
-  if(process.env.NODE_ENV != 'production') middleWares.unshift(ReduxLogger.createLogger({collapsed: true}));
-
-  let store = Redux.applyMiddleware(...middleWares)(
-    Redux.createStore
-  )(
-    Redux.combineReducers(reducers)
+  return Redux.createStore(
+    Redux.combineReducers(reducers),
+    {},
+    Redux.applyMiddleware(...middleWares)
   );
-
-  return store;
-}
-
+};
 
 export default createStore;

--- a/timur/lib/client/jsx/components/home_page.jsx
+++ b/timur/lib/client/jsx/components/home_page.jsx
@@ -5,11 +5,13 @@ import * as _ from 'lodash';
 
 // Module imports.
 import { selectUserPermissions } from '../selectors/user_selector';
+import { selectProjects } from 'etna-js/selectors/janus-selector';
+import { projectNameFull } from 'etna-js/utils/janus';
 
 export default class HomePage extends React.Component{
   renderProjects(){
-    let { permissions } = this.props;
-
+    let { permissions, projects } = this.props;
+    
     if(_.keys(permissions).length <= 0){
       return <span>{'No available projects.'}</span>;
     }
@@ -20,7 +22,7 @@ export default class HomePage extends React.Component{
           return <a className='home-page-project-link'
             key={project_name}
             href={`/${project_name}`}>
-            {project_name} &nbsp;
+            {projectNameFull(projects, project_name)} &nbsp;
             <span className='home-page-project-role'>({role})</span>
           </a>
       })}
@@ -51,7 +53,8 @@ export default class HomePage extends React.Component{
 export const HomePageContainer = connect(
   (state = {}, own_props)=>(
     {
-      permissions: selectUserPermissions(state)
+      permissions: selectUserPermissions(state),
+      projects: selectProjects(state)
     }
   )
 )(HomePage);

--- a/timur/lib/client/jsx/components/model_map.jsx
+++ b/timur/lib/client/jsx/components/model_map.jsx
@@ -9,6 +9,8 @@ import ModelNode from './model_map/model_node';
 import ModelReport from './model_map/model_report';
 import Layout from './model_map/tree_layout';
 
+import { selectProjects } from 'etna-js/selectors/janus-selector';
+import { projectNameFull } from 'etna-js/utils/janus';
 
 class ModelMap extends React.Component {
   constructor() {
@@ -26,14 +28,14 @@ class ModelMap extends React.Component {
   }
   render() {
     let [ width, height ] = [ 600, 600 ];
-    let { templates, model_names } = this.props;
+    let { templates, model_names, projects } = this.props;
     let { current_model, current_attribute } = this.state;
     let layout = new Layout(current_model, templates, width, height);
 
     return <div id="model_map">
       <div className="map">
         <div className="heading report_row">
-        <span className="name">Project</span> <span className="title">{CONFIG.project_name}</span>
+        <span className="name">Project</span> <span className="title">{projectNameFull(projects, CONFIG.project_name)}</span>
         </div>
         <svg width={width} height={height}>
           <defs>
@@ -79,7 +81,8 @@ export default connect(
     let model_names = selectModelNames(state);
     return {
       model_names,
-      templates: model_names.map(model_name => selectTemplate(state,model_name))
+      templates: model_names.map(model_name => selectTemplate(state,model_name)),
+      projects: selectProjects(state)
     }
   },
   { requestModels }

--- a/timur/lib/client/jsx/timur_store.jsx
+++ b/timur/lib/client/jsx/timur_store.jsx
@@ -17,6 +17,7 @@ import exchanges from './reducers/exchanges_reducer';
 import predicates from './reducers/predicates_reducer';
 import location from './reducers/location_reducer';
 import directory from './reducers/directory_reducer';
+import janus from 'etna-js/reducers/janus-reducer';
 
 import * as uploadActions from 'etna-js/upload/actions/upload_actions';
 
@@ -37,7 +38,8 @@ export const timurStore = () => {
     exchanges,
     predicates,
     location,
-    directory
+    directory,
+    janus
   });
 
   let middlewares = [

--- a/timur/lib/client/jsx/timur_ui.jsx
+++ b/timur/lib/client/jsx/timur_ui.jsx
@@ -99,8 +99,13 @@ class TimurUI extends React.Component {
 
     window.onpopstate = this.updateLocation.bind(this);
 
+  }
+
+  componentDidMount() {
+    let { fetchProjectsAction } = this.props;
+
     // Fetch the projects from Janus
-    props.fetchProjectsAction();
+    fetchProjectsAction();
   }
 
   updateLocation() {

--- a/timur/lib/client/jsx/timur_ui.jsx
+++ b/timur/lib/client/jsx/timur_ui.jsx
@@ -14,6 +14,7 @@ import Messages from './components/messages';
 
 import {showMessages} from './actions/message_actions';
 import {updateLocation} from './actions/location_actions';
+import {fetchProjectsAction} from 'etna-js/actions/janus-actions';
 
 import ModelMap from './components/model_map';
 import Search from './components/search/search';
@@ -97,6 +98,9 @@ class TimurUI extends React.Component {
     super(props);
 
     window.onpopstate = this.updateLocation.bind(this);
+
+    // Fetch the projects from Janus
+    props.fetchProjectsAction();
   }
 
   updateLocation() {
@@ -143,5 +147,5 @@ class TimurUI extends React.Component {
 
 export default connect(
   (state) => ({ location: state.location, user: selectUser(state) }),
-  { showMessages, updateLocation }
+  { showMessages, updateLocation, fetchProjectsAction }
 )(TimurUI);

--- a/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
@@ -20,7 +20,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/labors"
     >
-      labors
+      The Twelve Labors of Hercules
         
       <span
         className="home-page-project-role"
@@ -34,7 +34,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/wisdom"
     >
-      wisdom
+      Athena's Wisdom
         
       <span
         className="home-page-project-role"

--- a/timur/test/javascript/components/home_page.test.js
+++ b/timur/test/javascript/components/home_page.test.js
@@ -6,11 +6,12 @@ import {mockStore} from '../helpers';
 import HomePage from '../../../lib/client/jsx/components/home_page';
 
 const permissions = require('../fixtures/home_page_permissions.json');
+const projects = require('../fixtures/project_names.json')
 
 describe('HomePage', () => {
   it('renders', () => {
     const tree = renderer
-      .create(<HomePage permissions={permissions} />)
+      .create(<HomePage permissions={permissions} projects={projects} />)
       .toJSON();
 
     expect(tree).toMatchSnapshot();

--- a/timur/test/javascript/components/model_map.test.js
+++ b/timur/test/javascript/components/model_map.test.js
@@ -17,7 +17,7 @@ describe('ModelMap', () => {
   it('renders', () => {
     store = mockStore({
       magma: { models },
-      janus: { projects: [] }
+      janus: { projects: require('../fixtures/project_names.json') }
     });
 
     global.CONFIG = {

--- a/timur/test/javascript/components/model_map.test.js
+++ b/timur/test/javascript/components/model_map.test.js
@@ -16,7 +16,8 @@ describe('ModelMap', () => {
 
   it('renders', () => {
     store = mockStore({
-      magma: { models }
+      magma: { models },
+      janus: { projects: [] }
     });
 
     global.CONFIG = {
@@ -39,7 +40,8 @@ describe('ModelMap', () => {
     let { monster, project } = models;
 
     store = mockStore({
-      magma: { models: { monster, project } }
+      magma: { models: { monster, project } },
+      janus: { projects: [] }
     });
 
     global.CONFIG = {

--- a/timur/test/javascript/fixtures/project_names.json
+++ b/timur/test/javascript/fixtures/project_names.json
@@ -1,0 +1,12 @@
+[
+  {
+    "project_name": "labors",
+    "project_name_full": "The Twelve Labors of Hercules",
+    "project_description": "The Twelve Labors of Hercules"
+  },
+  {
+    "project_name": "wisdom",
+    "project_name_full": "Athena's Wisdom",
+    "project_description": "Athena's Wisdom"
+  }
+]


### PR DESCRIPTION
Per discussion at today's standup, this PR adds in the ability for Metis and Timur landing pages to display the full name of a project instead of just the short name. The Timur Map page also uses the full name if available. The functionality is tied into a mocked Janus API (JSON file for now) in `etna-js`, so it should be relatively simple to replace once we get that API built.

Goal is to have this deployed before the Dec 15th co-projects presentation.


Now includes the Janus API for this, but no JS to tie the two together yet ... have to provide the Janus host configuration in each app, so that'll be a little bit more work later.