### PR TITLE
Addressing config behavior

### DIFF
--- a/etna/bin/etna
+++ b/etna/bin/etna
@@ -9,10 +9,59 @@ require 'yaml'
 require_relative '../lib/etna'
 require_relative '../lib/commands'
 
-config = if File.exists?(EtnaApp.config_file_path)
-  YAML.load(File.read(EtnaApp.config_file_path))
-else
-  {}
+# Base config enabled
+config = {
+    production: {
+        docker: {
+            default_tag: 'latest',
+        },
+        magma: {
+            host: 'https://magma.ucsf.edu',
+        },
+        metis: {
+            host: 'https://metis.ucsf.edu',
+        },
+        janus: {
+            host: 'https://janus.ucsf.edu',
+        },
+        timur: {
+            host: 'https://timur.ucsf.edu',
+        },
+        polyphemus: {
+            host: 'https://polyphemus.ucsf.edu',
+        },
+        auth_redirect: 'https://janus.ucsf.edu',
+        ignore_ssl: false,
+    },
+    staging: {
+        docker: {
+            default_tag: 'latest',
+        },
+        magma: {
+            host: 'https://magma-stage.ucsf.edu',
+        },
+        metis: {
+            host: 'https://metis-stage.ucsf.edu',
+        },
+        janus: {
+            host: 'https://janus-stage.ucsf.edu',
+        },
+        timur: {
+            host: 'https://timur-stage.ucsf.edu',
+        },
+        polyphemus: {
+            host: 'https://polyphemus-stage.ucsf.edu',
+        },
+        auth_redirect: 'https://janus-stage.ucsf.edu',
+        ignore_ssl: true,
+    },
+    local: {
+        enabled_environments: [ :production ],
+    }
+}
+
+if File.exists?(EtnaApp.config_file_path)
+  config.update(YAML.load(File.read(EtnaApp.config_file_path)))
 end
 
 EtnaApp.instance.run_command(config, *ARGV)

--- a/etna/etna.completion
+++ b/etna/etna.completion
@@ -512,12 +512,100 @@ all_flag_completion_names="$all_flag_completion_names  "
 string_flag_completion_names="$string_flag_completion_names  "
 while [[ "$#" != "0" ]]; do
 if [[ "$#" == "1" ]];  then
-all_completion_names="help set show"
+all_completion_names="disable enable help set show"
 all_completion_names="$all_completion_names $all_flag_completion_names"
 if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
 return
 fi
 COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ "$1" == "disable" ]]; then
+shift
+if [[ "$#" == "1" ]];  then
+all_completion_names="__environment__"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+all_flag_completion_names="$all_flag_completion_names  "
+string_flag_completion_names="$string_flag_completion_names  "
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+a=$1
+shift
+if [[ "$string_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
+return
+elif [[ "$1" == "enable" ]]; then
+shift
+if [[ "$#" == "1" ]];  then
+all_completion_names="__environment__"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+all_flag_completion_names="$all_flag_completion_names  "
+string_flag_completion_names="$string_flag_completion_names  "
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+a=$1
+shift
+if [[ "$string_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
 return
 elif [[ "$1" == "help" ]]; then
 shift

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.19'
+  spec.version           = '0.1.20'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/helpers.rb
+++ b/etna/lib/helpers.rb
@@ -6,11 +6,13 @@ module WithEtnaClients
     EtnaApp.instance.environment
   end
 
-  def token
-    if environment == :many
-      raise "You have multiple environments configured, please specify your environment by adding --environment #{@config.keys.join("|")}"
-    elsif environment == :none
-      raise "You do not have a successfully configured environment, please run #{program_name} config set https://polyphemus.ucsf.edu"
+  def token(require_environment: true)
+    if require_environment
+      if environment == :many
+        raise "You have multiple environments configured, please specify your environment by running adding --environment <target-env>"
+      elsif environment == :none
+        raise "You do not have a successfully configured environment, please run #{program_name} config set https://polyphemus.ucsf.edu"
+      end
     end
 
     env_token = ENV['TOKEN']

--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -6,7 +6,7 @@ gem 'rack'
 gem 'rack-throttle'
 gem 'pg'
 gem 'sequel'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a'
 gem 'jwt'
 gem 'puma', '5.0.2'
 

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 6767394e113a4373bb0638484878cc26cb520d72
-  branch: refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef
+  revision: 55fa5038c7929f9221afdf5b6ff2501f6fd0c1c6
+  branch: refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a
   specs:
-    etna (0.1.19)
+    etna (0.1.20)
       jwt
       multipart-post
       net-http-persistent

--- a/magma/Gemfile
+++ b/magma/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 ruby '~> 2.5'
 
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a'
 gem 'pg'
 gem 'sequel', '5.28.0'
 gem 'mini_magick'

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 6767394e113a4373bb0638484878cc26cb520d72
-  branch: refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef
+  revision: 55fa5038c7929f9221afdf5b6ff2501f6fd0c1c6
+  branch: refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a
   specs:
-    etna (0.1.19)
+    etna (0.1.20)
       jwt
       multipart-post
       net-http-persistent
@@ -40,6 +40,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    curb (0.9.11)
     database_cleaner (1.8.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
@@ -149,6 +150,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   debase
   etna!

--- a/metis/Gemfile
+++ b/metis/Gemfile
@@ -7,7 +7,7 @@ gem 'pg'
 gem 'sequel'
 gem 'fog-aws'
 gem 'puma', '5.0.2'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a'
 
 gem 'puma', '5.0.2'
 

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 6767394e113a4373bb0638484878cc26cb520d72
-  branch: refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef
+  revision: 55fa5038c7929f9221afdf5b6ff2501f6fd0c1c6
+  branch: refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a
   specs:
-    etna (0.1.19)
+    etna (0.1.20)
       jwt
       multipart-post
       net-http-persistent

--- a/metis/package-lock.json
+++ b/metis/package-lock.json
@@ -5375,8 +5375,8 @@
       "dev": true
     },
     "etna-js": {
-      "version": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
-      "from": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
+      "version": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
+      "from": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
       "requires": {
         "animate.css": "^4.1.0",
         "react-notifications-component": "^2.4.0"

--- a/metis/package.json
+++ b/metis/package.json
@@ -19,7 +19,7 @@
     "@fortawesome/fontawesome-free": "^5.12.0",
     "copy-webpack-plugin": "^4.6.0",
     "downzip": "git+https://git@github.com/mountetna/downzip.git",
-    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
+    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
     "event-hooks-webpack-plugin": "^1.0.0",
     "fs-extra": "^9.0.1",
     "js-cookie": "^2.2.1",

--- a/polyphemus/Gemfile
+++ b/polyphemus/Gemfile
@@ -5,7 +5,7 @@ gem 'sequel'
 gem 'pg'
 gem 'nokogiri'
 gem 'puma', '5.0.2'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a'
 
 group :development, :test do
   gem 'rack-test', require: "rack/test"

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 6767394e113a4373bb0638484878cc26cb520d72
-  branch: refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef
+  revision: 55fa5038c7929f9221afdf5b6ff2501f6fd0c1c6
+  branch: refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a
   specs:
-    etna (0.1.19)
+    etna (0.1.20)
       jwt
       multipart-post
       net-http-persistent

--- a/timur/Gemfile
+++ b/timur/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # etna application/server gem
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a'
 
 # provides lexer/parser
 gem 'rltk'

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 6767394e113a4373bb0638484878cc26cb520d72
-  branch: refs/artifacts/gem-etna/645f976fb9fc2b801f64aa08f5528fb8d82270ef
+  revision: 55fa5038c7929f9221afdf5b6ff2501f6fd0c1c6
+  branch: refs/artifacts/gem-etna/7b96bd5739003d5e26c87a1340c6903bd9bf649a
   specs:
-    etna (0.1.19)
+    etna (0.1.20)
       jwt
       multipart-post
       net-http-persistent

--- a/timur/package-lock.json
+++ b/timur/package-lock.json
@@ -5529,8 +5529,8 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etna-js": {
-      "version": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
-      "from": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
+      "version": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
+      "from": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
       "requires": {
         "animate.css": "^4.1.0",
         "react-notifications-component": "^2.4.0"

--- a/timur/package.json
+++ b/timur/package.json
@@ -14,7 +14,7 @@
     "d3": "^5.5.0",
     "d3-ease": "^1.0.3",
     "downloadjs": "^1.4.7",
-    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#21d882fd09a04954bf84173b24a1370210dfa901",
+    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#51ea1a97a7e7e89925833b50518a94bfec7a1977",
     "identity-obj-proxy": "^3.0.0",
     "js-cookie": "^2.2.0",
     "json2csv": "^4.0.1",


### PR DESCRIPTION
Changes the way config works in the etna bin based on my experience with Ravi.  This PR may generate some discussion and be controversial but I think it's important to consider ahead of rolling out for more of our users.

There were three main issues when guiding Ravi through config setup
1.  Ravi needed to swap out tokens in order to call `etna config set` for staging and production.  Because the config endpoint authenticates, it requires users to remember to swap tokens just to get setup.  This was confusing and non obvious since the authentication failing obviously has no way to inform a user that they need to go back to janus and swap tokens for one in the environment of the configuration setup.
2.  Remembering to use `--ignore-ssl` for staging but not production.  This one is difficult to explain the why for, but again, the error messages around the http client failing are not super useful, and it wasn't clear why one needed this and other didn't.  It's kind of magic that has to be memorized.
3.  Took some to explain 'when' to use the config commands.  I explained he shouldn't need to use them most of the time after we successfully set it up, but he 'might' need to run them again for both staging and production if there's a change or upgrade.

I felt like this was a pretty bad experience, so I spoke with @coleshaw and we came up with alternative

1.  Package production and staging config defaults.    When upgrading the etna gem, production and staging config defaults come 'for free', so for most users config set is never needed.
2.  Add the concept of enabled environments.  By default, staging is not enabled and must be enabled with a single command.  This command doesn't require memorizing much, and only ever needs to be run once.  External app users never need to run this at all.
3.   Keep config set for other environments (development, dogfood, etc) as is.

I feel this will greatly reduce the overhead spent trying to keep user's configurations working overall.