### PR TITLE
Tentative workflow for copying around users more easily.

### DIFF
--- a/etna/etna.completion
+++ b/etna/etna.completion
@@ -369,12 +369,102 @@ all_flag_completion_names="$all_flag_completion_names  "
 string_flag_completion_names="$string_flag_completion_names  "
 while [[ "$#" != "0" ]]; do
 if [[ "$#" == "1" ]];  then
-all_completion_names="create help"
+all_completion_names="apply_users_template copy_users_template create help"
 all_completion_names="$all_completion_names $all_flag_completion_names"
 if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
 return
 fi
 COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ "$1" == "apply_users_template" ]]; then
+shift
+if [[ "$#" == "1" ]];  then
+all_completion_names="__project_name__"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+all_flag_completion_names="$all_flag_completion_names --file "
+string_flag_completion_names="$string_flag_completion_names --file "
+declare _completions_for_file="__file__"
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+a=$1
+shift
+if [[ "$string_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
+return
+elif [[ "$1" == "copy_users_template" ]]; then
+shift
+if [[ "$#" == "1" ]];  then
+all_completion_names="__project_name__"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+all_flag_completion_names="$all_flag_completion_names --file "
+string_flag_completion_names="$string_flag_completion_names --file "
+declare _completions_for_file="__file__"
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+a=$1
+shift
+if [[ "$string_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
 return
 elif [[ "$1" == "create" ]]; then
 shift

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -110,6 +110,42 @@ class EtnaApp
           create_project_workflow.create!
         end
       end
+
+      class CopyUsersTemplate < Etna::Command
+        include WithEtnaClients
+        include WithLogger
+
+        string_flags << '--file'
+
+        def execute(project_name, file: "#{project_name}_users.csv")
+          workflow = Etna::Clients::Janus::CopyProjectUsersWorkflow.new(
+              janus_client: janus_client,
+              project_name: project_name,
+          )
+
+          workflow.write_user_templates_csv(File.open(file, 'w'))
+          puts "Done.  Edit #{file} and run apply_users_template to execute!"
+        end
+      end
+
+      class ApplyUsersTemplate < Etna::Command
+        include WithEtnaClients
+        include WithLogger
+
+        string_flags << '--file'
+
+        def execute(project_name, file: "#{project_name}_users.csv")
+          workflow = Etna::Clients::Janus::CopyProjectUsersWorkflow.new(
+              janus_client: janus_client,
+              project_name: project_name,
+          )
+
+          workflow.apply_user_templates_csv(File.open(file, 'r')) do |row|
+            puts "Copying #{row[:email]}..."
+          end
+          puts "Done!"
+        end
+      end
     end
 
     class Models

--- a/etna/lib/etna/clients/janus.rb
+++ b/etna/lib/etna/clients/janus.rb
@@ -1,2 +1,3 @@
 require_relative './janus/client'
 require_relative './janus/models'
+require_relative './janus/workflows'

--- a/etna/lib/etna/clients/janus/client.rb
+++ b/etna/lib/etna/clients/janus/client.rb
@@ -20,9 +20,7 @@ module Etna
 
       def get_project(get_project_request = GetProjectRequest.new)
         html = nil
-        @etna_client.get(
-          "/project/#{get_project_request.project_name}",
-          get_project_request) do |res|
+        @etna_client.get("/project/#{get_project_request.project_name}") do |res|
           html = res.body
         end
 

--- a/etna/lib/etna/clients/janus/workflows.rb
+++ b/etna/lib/etna/clients/janus/workflows.rb
@@ -1,0 +1,1 @@
+require_relative './workflows/copy_project_users_workflow'

--- a/etna/lib/etna/clients/janus/workflows/copy_project_users_workflow.rb
+++ b/etna/lib/etna/clients/janus/workflows/copy_project_users_workflow.rb
@@ -1,0 +1,76 @@
+require 'base64'
+require 'json'
+require 'ostruct'
+require_relative '../models'
+
+module Etna
+  module Clients
+    class Janus
+      class CopyProjectUsersWorkflow < Struct.new(:janus_client, :project_name, keyword_init: true)
+        COLUMNS = [
+            :name,
+            :email,
+            :role,
+            :affiliation,
+        ]
+
+        def each_user_template_csv_row
+          yield COLUMNS
+          require 'oga'
+
+          # TODO:  Replace with a real api at some point.
+          parsed = Oga.parse_html(janus_client.get_project(GetProjectRequest.new(project_name: project_name)).html)
+
+          parsed.css('.items .item').each do |item|
+            name = item.at_css('.name').text.chomp
+            email = item.at_css('.email').text.chomp
+            role = item.at_css('.role').at_css('option[selected=""]').text.chomp
+            affiliation = item.at_css('.affiliation').attribute('value').first.value
+
+            yield row_from_columns(name: name, email: email, role: role, affiliation: affiliation)
+          end
+        end
+
+        def copy_user_row(user_row)
+          role = user_row[:role]
+          role = 'editor' if role == 'administrator'
+
+          janus_client.add_user(Etna::Clients::Janus::AddUserRequest.new(
+              project_name: project_name,
+              email: user_row[:email],
+              name: user_row[:name],
+              role: role,
+              affiliation: user_row[:affiliation]
+          ))
+
+          if user_row[:role] == 'administrator'
+            janus_client.update_permission(Etna::Clients::Janus::UpdatePermissionRequest.new(
+                project_name: project_name,
+                email: user_row[:email],
+                role: 'administrator',
+            ))
+          end
+        end
+
+        def apply_user_templates_csv(io, &update_block)
+          CSV.parse(io, headers: true, header_converters: :symbol).each do |row|
+            copy_user_row(row)
+            yield row if block_given?
+          end
+        end
+
+        def write_user_templates_csv(io)
+          csv = CSV.new(io)
+          each_user_template_csv_row do |row|
+            csv << row
+          end
+        end
+
+        def row_from_columns(**columns)
+          COLUMNS.map { |c| (columns[c] || '').to_s }
+        end
+      end
+    end
+  end
+end
+

--- a/etna/lib/etna/clients/magma/workflows/create_project_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/create_project_workflow.rb
@@ -35,7 +35,6 @@ module Etna
         def promote_to_administrator(email)
           janus_client.update_permission(Etna::Clients::Janus::UpdatePermissionRequest.new(
             project_name: project_name,
-            # email: user['email'],
             email: email,
             role: 'administrator',
           ))
@@ -87,7 +86,12 @@ module Etna
             puts "Confirm? Y/n"
             break unless STDIN.gets.chomp == 'Y'
 
-            add_janus_user(email, name, role)
+            if role == 'administrator'
+              add_janus_user(email, name, 'editor')
+              promote_to_administrator(email)
+            else
+              add_janus_user(email, name, role)
+            end
           end
 
           puts "Done with setting up the project in Janus!"

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    curb (0.9.11)
     database_cleaner (1.8.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
@@ -149,6 +150,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   debase
   etna!


### PR DESCRIPTION
Just to generate some discussion and in case it is useful, maybe it's not. 

This afternoon I was trying to replicate production projects into staging and get the users setup there so that our data scientists could easily start editing and sharing their tentative modeling. 

It's actually a major PITA to add users en masse.  It's difficult to copy each column bit by bit and set things like affiliation and role correctly as well.  It's also super error prone.

I create a simple workflow to help me.  Maybe we don't include this in our public gem, but it seemed useful enough to keep around in case I needed to do something like this again in the future.