### PR TITLE
retry in metis_client

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -159,23 +159,33 @@ class MetisClient
     json_body(response)
   end
 
-  def blob_upload(upload_path, upload, blob, retries=0)
-    response = multipart_post(
-      upload_path, [
-        [ 'action', 'blob', ],
-        [ 'blob_data', blob[:blob_data], {filename: 'blob'} ],
-        [ 'next_blob_size', blob[:next_blob_size].to_s ],
-        [ 'next_blob_hash', blob[:next_blob_hash].to_s ],
-        [ 'current_byte_position', blob[:current_byte_position].to_s ]
-      ]
-    )
+  def retry_blob(upload_path, upload, blob, retries)
+    sleep 60
+    blob_upload(upload_path, upload, blob, retries+1) if retries < 5
+  end
 
-    if response.code == '503'
-      sleep 60
-      if retries < 5
-        blob_upload(upload_path, upload, blob, retries+1)
+  def blob_upload(upload_path, upload, blob, retries=0)
+    begin
+      response = multipart_post(
+        upload_path, [
+          [ 'action', 'blob', ],
+          [ 'blob_data', blob[:blob_data], {filename: 'blob'} ],
+          [ 'next_blob_size', blob[:next_blob_size].to_s ],
+          [ 'next_blob_hash', blob[:next_blob_hash].to_s ],
+          [ 'current_byte_position', blob[:current_byte_position].to_s ]
+        ]
+      )
+    rescue OpenSSL::SSL::SSLError => e
+      if e.message =~ /write client hello/
+        retry_blob(upload_path, upload, blob, retries)
         return
       end
+      raise e
+    end
+
+    if response.code == '503'
+      retry_blob(upload_path, upload, blob, retries)
+      return
     end
 
     raise MetisClient::UploadError, "Problem with uploading the blob: #{error(response)}" if response.code == '422'

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -160,8 +160,18 @@ class MetisClient
   end
 
   def retry_blob(upload_path, upload, blob, retries)
-    sleep 60
-    blob_upload(upload_path, upload, blob, retries+1) if retries < 5
+    retries += 1
+
+    print "\rWaiting for server restart"+"."*retries+"\x1b[0K"
+
+    sleep 15
+
+    if retries < 60
+      blob_upload(upload_path, upload, blob, retries)
+      return
+    end
+
+    raise MetisClient::Error, "Could not contact server, giving up"
   end
 
   def blob_upload(upload_path, upload, blob, retries=0)
@@ -177,13 +187,14 @@ class MetisClient
       )
     rescue OpenSSL::SSL::SSLError => e
       if e.message =~ /write client hello/
-        retry_blob(upload_path, upload, blob, retries)
-        return
+        return retry_blob(upload_path, upload, blob, retries)
       end
       raise e
+    rescue Errno::ECONNREFUSED => e
+      return retry_blob(upload_path, upload, blob, retries)
     end
 
-    if response.code == '503'
+    if response.code == '503' || response.code == '502'
       retry_blob(upload_path, upload, blob, retries)
       return
     end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -159,7 +159,7 @@ class MetisClient
     json_body(response)
   end
 
-  def blob_upload(upload_path, upload, blob)
+  def blob_upload(upload_path, upload, blob, retries=0)
     response = multipart_post(
       upload_path, [
         [ 'action', 'blob', ],
@@ -169,6 +169,14 @@ class MetisClient
         [ 'current_byte_position', blob[:current_byte_position].to_s ]
       ]
     )
+
+    if response.code == '503'
+      sleep 60
+      if retries < 5
+        blob_upload(upload_path, upload, blob, retries+1)
+        return
+      end
+    end
 
     raise MetisClient::UploadError, "Problem with uploading the blob: #{error(response)}" if response.code == '422'
     raise MetisClient::Error, "Could not upload file #{upload.file_path}\n#{error(response)}" unless response.code == "200"

--- a/metis/config.yml.template
+++ b/metis/config.yml.template
@@ -35,7 +35,7 @@
   :metis_uid_name: METIS_DEV_UID
   :token_domain: development.local
   :token_life: 31536000
-  :upload_expiration: 60
+  :upload_expiration: 86400
   :download_expiration: 86400
   :hmac_keys:
     :metis: 35e7c8775406612c431b654663fed668


### PR DESCRIPTION
A tweak to the metis_client to hopefully make it resilient to metis restarts. While this works in dev (i simulated by restarting apache and by restarting the metis service), I'm not sure it would work with our current deploy process, it needs to be tested in staging I think. The rescue of the OpenSSL error seems a bit dodgy to me, and might not be very consistent across different systems.