### PR TITLE
remove auth constraint on polyphemus configuration endpoint

### DIFF
--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -333,7 +333,7 @@ describe RetrieveController do
       )
 
       header, *table = CSV.parse(last_response.body, col_sep: "\t")
-      expect(table).to eq([ [ "The Twelve Labors of Hercules", labors.map(&:identifier).join(', ') ] ])
+      expect(table).to match_array([ [ "The Twelve Labors of Hercules", labors.map(&:identifier).join(', ') ] ])
     end
 
     it 'retrieves a TSV with file attributes as urls' do

--- a/polyphemus/lib/server.rb
+++ b/polyphemus/lib/server.rb
@@ -13,7 +13,7 @@ class Polyphemus
     end
 
     # Return the app host configuration values
-    get '/configuration', as: :configuration, action: 'configuration#action', auth: { user: { is_superuser?: true } }
+    get '/configuration', as: :configuration, action: 'configuration#action', auth: { noauth: true }
 
     get '/' do
       [ 200, {}, [ 'Polyphemus is available.' ] ]

--- a/polyphemus/spec/server_spec.rb
+++ b/polyphemus/spec/server_spec.rb
@@ -5,11 +5,11 @@ describe Polyphemus::Server do
     OUTER_APP
   end
 
-  it 'configuration fails for non-superusers' do
-    auth_header(:editor)
+  it 'configuration open to anyone' do
     get('/configuration')
 
-    expect(last_response.status).to eq(403)
+    expect(last_response.status).to eq(200)
+    expect(json_body[:test].keys.sort).to eq([:magma, :metis, :janus, :timur, :polyphemus, :auth_redirect, :docker].sort)
   end
 
   it 'superusers can fetch app configuration' do


### PR DESCRIPTION
Small PR to set no-auth requirement on the polyphemus `/configuration` endpoint. Should be easier for users to configure the gem with this.