### PR TITLE
relax permissions on update_model to allow project admins

### DIFF
--- a/magma/lib/magma/server.rb
+++ b/magma/lib/magma/server.rb
@@ -22,7 +22,7 @@ class Magma
 
     post '/update', as: :update, action: 'update#action', auth: { user: { can_edit?: :project_name } } 
 
-    post '/update_model', action: 'update_model#action', auth: { user: { is_superuser?: :project_name } }
+    post '/update_model', action: 'update_model#action', auth: { user: { is_admin?: :project_name } }
 
     get '/' do
       [ 200, {}, [ 'Magma is available.' ] ]


### PR DESCRIPTION
As it says, per our conversation, we are opening update_model to project admins.