### PR TITLE
add stderr messages to metis client

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -743,11 +743,13 @@ EOT
 
           if current_attempt_number <= max_number_attempts
             puts "UploadError -- retrying the upload"
+            MetisShell.log_error(e)
             upload = Upload.new(actual_path)
             upload_json = @shell.client.reset_upload(upload_path, upload)
             upload.current_byte_position = 0
           else
             puts "UploadError -- max retries reached. Giving up."
+            MetisShell.log_error(e)
           end
         end
       end
@@ -917,6 +919,12 @@ EOT
 
   private
 
+  def self.log_error(e)
+    puts e.message
+    STDERR.puts(e.message)
+    STDERR.puts(e.backtrace)
+  end
+
   def run_command(command=nil, *args)
     return if !command
     command = Command.list.find { |c| c.command_name == command.to_s }
@@ -931,13 +939,14 @@ EOT
       args = cmd.parse(args)
       cmd.run(*args) unless cmd.done?
     rescue ShellError => e
-      puts e.message
+      MetisShell.log_error(e)
     rescue MetisClient::Error => e
-      puts e.message
+      MetisShell.log_error(e)
     rescue ArgumentError => e
       puts(command.usage ? "Usage:\n#{command.usage}" : e.message)
+      MetisShell.log_error(e)
     rescue Net::ReadTimeout => e
-      puts e.message
+      MetisShell.log_error(e)
     end
   end
 


### PR DESCRIPTION
This PR adds `stderr` messages to Metis Client. It is useful for folks who feed commands to the client instead of running it interactively, so they can log `stdout` and `stderr` messages to more easily detect failed uploads in a large sea of uploads, where it's impractical to parse through a log file manually.
