### PR TITLE
Metis logging by day

### DIFF
--- a/etna/lib/etna/logger.rb
+++ b/etna/lib/etna/logger.rb
@@ -3,14 +3,7 @@ require 'rollbar'
 
 module Etna
   class Logger < ::Logger
-    def initialize(log_dev, age, size)
-      super
-      self.formatter = proc do |severity, datetime, progname, msg|
-        format(severity, datetime, progname, msg)
-      end
-    end
-
-    def initialize(log_dev, age)
+    def initialize(log_dev, age, size=1048576)
       super
       self.formatter = proc do |severity, datetime, progname, msg|
         format(severity, datetime, progname, msg)

--- a/etna/lib/etna/logger.rb
+++ b/etna/lib/etna/logger.rb
@@ -10,6 +10,13 @@ module Etna
       end
     end
 
+    def initialize(log_dev, age)
+      super
+      self.formatter = proc do |severity, datetime, progname, msg|
+        format(severity, datetime, progname, msg)
+      end
+    end
+
     def format(severity, datetime, progname, msg)
       "#{severity}:#{datetime.iso8601} #{msg}\n"
     end

--- a/metis/lib/metis.rb
+++ b/metis/lib/metis.rb
@@ -23,7 +23,7 @@ class Metis
     @logger = Etna::Logger.new(
       # The name of the log_file, required.
       config(:log_file),
-      'daily'  # Logger doesn't rotate out old daily logs, though, so we'll manage that via logrotate
+      config(:log_age) || 'daily'  # Logger doesn't rotate out old daily logs, though, so we'll manage that via logrotate
     )
     log_level = (config(:log_level) || 'warn').upcase.to_sym
     @logger.level = Logger.const_defined?(log_level) ? Logger.const_get(log_level) : Logger::WARN

--- a/metis/lib/metis.rb
+++ b/metis/lib/metis.rb
@@ -16,6 +16,19 @@ class Metis
     @db.pool.connection_validation_timeout = -1
   end
 
+  def setup_logger
+    # Override this to get daily logs instead of by size. Easier to
+    #   debug Metis, since uploading in bulk won't overwrite
+    #   errors.
+    @logger = Etna::Logger.new(
+      # The name of the log_file, required.
+      config(:log_file),
+      'daily'  # Logger doesn't rotate out old daily logs, though, so we'll manage that via logrotate
+    )
+    log_level = (config(:log_level) || 'warn').upcase.to_sym
+    @logger.level = Logger.const_defined?(log_level) ? Logger.const_get(log_level) : Logger::WARN
+  end
+
   def load_models
     setup_db
 

--- a/metis/lib/metis.rb
+++ b/metis/lib/metis.rb
@@ -23,7 +23,7 @@ class Metis
     @logger = Etna::Logger.new(
       # The name of the log_file, required.
       config(:log_file),
-      config(:log_age) || 'daily'  # Logger doesn't rotate out old daily logs, though, so we'll manage that via logrotate
+      config(:log_age) || 'daily'  # Logger doesn't rotate out old daily logs, though, so we'll manage that via a system process
     )
     log_level = (config(:log_level) || 'warn').upcase.to_sym
     @logger.level = Logger.const_defined?(log_level) ? Logger.const_get(log_level) : Logger::WARN


### PR DESCRIPTION
This is a small PR that adds an `Etna::Logger` option to rotate logs by time period (daily, weekly, monthly), and also configures daily logging in Metis instead of size / # of files like the other applications. 

Note that the Ruby Logger doesn't actually rotate out logs when used with this configuration (delete ones older than X days), so I'll set that up with `logrotate` after this is merged and deployed. Any system software could be used to rotate the logs, but we seem to have `logrotate` already installed on the server.