### PR TITLE
show project shortname on metis and timur homepages as well as full name

### DIFF
--- a/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
+++ b/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
@@ -10,7 +10,7 @@ describe('Janus Utils', () => {
     ];
     const result = projectNameFull(projects, 'xyz1');
 
-    expect(result).toEqual('ACME corporation');
+    expect(result).toEqual('ACME corporation (xyz1)');
   });
 
   it('returns the shortname if no matching project', () => {

--- a/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
+++ b/etna/packages/etna-js/utils/__tests__/janus.spec.jsx
@@ -10,7 +10,7 @@ describe('Janus Utils', () => {
     ];
     const result = projectNameFull(projects, 'xyz1');
 
-    expect(result).toEqual('ACME corporation (xyz1)');
+    expect(result).toEqual('ACME corporation - xyz1');
   });
 
   it('returns the shortname if no matching project', () => {

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -2,18 +2,21 @@ const ROLES = {a: 'administrator', e: 'editor', v: 'viewer'};
 
 const parsePermissions = (perms) => {
   // Permissions are encoded as 'a:project1,project2;v:project3'
-  return perms.split(/;/).map(perm => {
-    let [encoded_role, projects] = perm.split(/:/);
-    let role = ROLES[encoded_role.toLowerCase()];
-    let privileged = encoded_role.toUpperCase() == encoded_role;
-    return projects.split(/,/).map(
-      project_name => ({ role, privileged, project_name })
-    )
-  }).reduce((perms, projects) => {
-    projects.forEach(perm => perms[perm.project_name] = perm);
-    return perms
-  }, {});
-}
+  return perms
+    .split(/;/)
+    .map((perm) => {
+      let [encoded_role, projects] = perm.split(/:/);
+      let role = ROLES[encoded_role.toLowerCase()];
+      let privileged = encoded_role.toUpperCase() == encoded_role;
+      return projects
+        .split(/,/)
+        .map((project_name) => ({role, privileged, project_name}));
+    })
+    .reduce((perms, projects) => {
+      projects.forEach((perm) => (perms[perm.project_name] = perm));
+      return perms;
+    }, {});
+};
 
 export function parseToken(token) {
   let [header, params, signature] = token.split(/\./);
@@ -34,5 +37,7 @@ export const projectNameFull = (projects, project_name) => {
     return project.project_name === project_name;
   });
 
-  return matching_project ? matching_project.project_name_full : project_name;
+  return matching_project
+    ? `${matching_project.project_name_full} (${project_name})`
+    : project_name;
 };

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -38,6 +38,6 @@ export const projectNameFull = (projects, project_name) => {
   });
 
   return matching_project
-    ? `${matching_project.project_name_full} (${project_name})`
+    ? `${matching_project.project_name_full} - ${project_name}`
     : project_name;
 };

--- a/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
+++ b/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`RootView renders 1`] = `
         className="project_name"
         href="/labors"
       >
-        The Twelve Labors of Hercules (labors)
+        The Twelve Labors of Hercules - labors
       </a>
       - 
       <span
@@ -36,7 +36,7 @@ exports[`RootView renders 1`] = `
         className="project_name"
         href="/wisdom"
       >
-        Athena's Wisdom (wisdom)
+        Athena's Wisdom - wisdom
       </a>
       - 
       <span

--- a/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
+++ b/metis/lib/client/jsx/components/__tests__/__snapshots__/root_view.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`RootView renders 1`] = `
         className="project_name"
         href="/labors"
       >
-        The Twelve Labors of Hercules
+        The Twelve Labors of Hercules (labors)
       </a>
       - 
       <span
@@ -36,7 +36,7 @@ exports[`RootView renders 1`] = `
         className="project_name"
         href="/wisdom"
       >
-        Athena's Wisdom
+        Athena's Wisdom (wisdom)
       </a>
       - 
       <span

--- a/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
@@ -20,7 +20,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/labors"
     >
-      The Twelve Labors of Hercules (labors)
+      The Twelve Labors of Hercules - labors
         
       <span
         className="home-page-project-role"
@@ -34,7 +34,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/wisdom"
     >
-      Athena's Wisdom (wisdom)
+      Athena's Wisdom - wisdom
         
       <span
         className="home-page-project-role"

--- a/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/home_page.test.js.snap
@@ -20,7 +20,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/labors"
     >
-      The Twelve Labors of Hercules
+      The Twelve Labors of Hercules (labors)
         
       <span
         className="home-page-project-role"
@@ -34,7 +34,7 @@ exports[`HomePage renders 1`] = `
       className="home-page-project-link"
       href="/wisdom"
     >
-      Athena's Wisdom
+      Athena's Wisdom (wisdom)
         
       <span
         className="home-page-project-role"


### PR DESCRIPTION
As noted yesterday during standup, only showing the project's full name on the Timur / Metis landing pages is a bit confusing when you toggle between Janus and the apps, since most of us don't have all the project names and full names memorized. So this small PR includes the short name after the full name. Now it appears something like `The Twelve Labors of Hercules - labors (administrator)`.

