### PR TITLE
Additional Metis Client commands

### DIFF
--- a/etna/spec/clients/magma/workflows/update_attributes_from_csv_workflow_spec.rb
+++ b/etna/spec/clients/magma/workflows/update_attributes_from_csv_workflow_spec.rb
@@ -330,7 +330,7 @@ describe Etna::Clients::Magma::UpdateAttributesFromCsvWorkflowSingleModel do
         project_name: PROJECT,
         filepath: './spec/fixtures/magma/nonexistent_input.csv'
       )
-    }.to raise_error(StandardError, 'Single Model invokation must include keyword :model_name.')
+    }.to raise_error(RuntimeError, 'Single Model invocation must include keyword :model_name.')
 
     expect(WebMock).not_to have_requested(:post, /#{MAGMA_HOST}\/update/)
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -669,6 +669,8 @@ EOT
         @shell.client.remove_folder(@shell.project_name, path)
         return
       end
+
+      raise ShellError, "Invalid path, cannot remove: #{path}" unless file || folder
     end
   end
 
@@ -1065,7 +1067,6 @@ EOT
   private
 
   def self.log_error(e)
-    puts e.message
     STDERR.puts(e.message)
     STDERR.puts(e.backtrace)
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -672,6 +672,27 @@ EOT
     end
   end
 
+  class Mkdir < Command
+    usage "mkdir <remote_path>"
+    def run(path)
+      raise ShellError, 'No project is selected' if !@shell.project_name
+
+      path = @shell.relative_path(path)
+
+      begin
+        folder = @shell.client.list_folder(@shell.project_name, path)
+
+        raise ShellError, "Folder already exists #{path}" if folder
+      rescue MetisClient::Error
+        # parent folder may not exist, but that's okay. This command
+        #   replicates `mkdir -p` so parent folders do not have to
+        #   exist a priori.
+      end
+
+      @shell.client.create_folder(@shell.project_name, path)
+    end
+  end
+
   class Pwd < Command
     usage "pwd"
     def run

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -597,6 +597,16 @@ EOT
       if !source_file_path.start_with?('metis://')
         source_file_path.sub!(%r!(?<=.)/$!,'')
         source_file_path = @shell.relative_path(source_file_path)
+
+        source_folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(source_file_path))
+
+        raise ShellError, "Invalid source path #{source_file_path}" unless source_folder
+
+        file = source_folder[:files].find do |f|
+          f[:file_name] == ::File.basename(source_file_path)
+        end
+
+        raise ShellError, "That source file does not exist #{source_file_path}" unless file
       end
 
       if !destination_file_path.start_with?('metis://')

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1067,7 +1067,7 @@ EOT
   private
 
   def self.log_error(e)
-    STDERR.puts(e.message)
+    puts e.message
     STDERR.puts(e.backtrace)
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1067,8 +1067,7 @@ EOT
   private
 
   def self.log_error(e)
-    puts e.message
-    STDERR.puts(e.backtrace)
+    STDERR.puts(e.message)
   end
 
   def run_command(command=nil, *args)

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -42,6 +42,10 @@ def progress(completion, rate, path)
   "\r#{progress} #{path} - #{rate}B/s"
 end
 
+def metis_path(path)
+  /^metis:\/\/(?<project>[^\/]+)\/(?<bucket>[^\/]+)\/(?<file_path>.+)$/.match(path)
+end
+
 class MetisConfig
   include Singleton
 
@@ -238,6 +242,41 @@ class MetisClient
         yield chunk
       end
     end
+  end
+
+  def remove_folder(project_name, folder_path)
+    response = json_post("/#{project_name}/folder/remove/#{URI.encode(folder_path)}")
+    raise MetisClient::Error, "Could not remove folder #{folder_path}\n#{error(response)}" unless response.code == "200"
+  end
+
+  def remove_file(project_name, file_path)
+    response = json_post("/#{project_name}/file/remove/#{URI.encode(file_path)}")
+    raise MetisClient::Error, "Could not remove file #{file_path}\n#{error(response)}" unless response.code == "200"
+  end
+
+  def copy_file(project_name, file_path, proposed_file_path)
+    if proposed_file_path.start_with?('metis://')
+      match = metis_path(proposed_file_path)
+      new_bucket_name = match[:bucket]
+      new_file_path = match[:file_path]
+    else
+      split_parts = proposed_file_path.split('/')
+      new_bucket_name = split_parts.first
+      new_file_path = split_parts.slice(1, split_parts.length - 1).join('/')
+    end
+
+    if file_path.start_with?('metis://')
+      match = metis_path(file_path)
+      old_file_path = "#{match[:bucket]}/#{match[:file_path]}"
+    else
+      old_file_path = file_path
+    end
+
+    response = json_post("/#{project_name}/file/copy/#{URI.encode(old_file_path)}",
+      new_file_path: new_file_path,
+      new_bucket_name: new_bucket_name)
+
+    raise MetisClient::Error, "Could not copy file #{file_path} to #{proposed_file_path}\n#{error(response)}" unless response.code == "200"
   end
 
   private
@@ -545,6 +584,39 @@ EOT
       raise ShellError, "No such folder #{dirname}" unless folder
 
       @shell.cwd = path
+    end
+  end
+
+  class Cp < Command
+    usage "cp <source_file_path> <destination_file_path>"
+    def run(source_file_path, destination_file_path)
+      raise ShellError, 'No source file selected!' unless source_file_path
+
+      raise ShellError, 'No destination file defined!' unless destination_file_path
+
+      if !source_file_path.start_with?('metis://')
+        source_file_path.sub!(%r!(?<=.)/$!,'')
+        source_file_path = @shell.relative_path(source_file_path)
+      end
+
+      if !destination_file_path.start_with?('metis://')
+        destination_file_path.sub!(%r!(?<=.)/$!,'')
+        destination_file_path = @shell.relative_path(destination_file_path)
+
+        # Need to account for user providing a directory without a filename...
+        begin
+          folder = @shell.client.list_folder(@shell.project_name, destination_file_path)
+          source_file_name = source_file_path.split('/').last
+          destination_file_path = "#{destination_file_path}/#{source_file_name}" if folder
+        rescue MetisClient::Error
+          # Not a folder, so we'll keep the path
+        end
+      end
+
+      @shell.client.copy_file(
+        @shell.project_name,
+        source_file_path,
+        destination_file_path)
     end
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -245,12 +245,12 @@ class MetisClient
   end
 
   def remove_folder(project_name, folder_path)
-    response = json_post("/#{project_name}/folder/remove/#{URI.encode(folder_path)}")
+    response = delete_request("/#{project_name}/folder/remove/#{URI.encode(folder_path)}")
     raise MetisClient::Error, "Could not remove folder #{folder_path}\n#{error(response)}" unless response.code == "200"
   end
 
   def remove_file(project_name, file_path)
-    response = json_post("/#{project_name}/file/remove/#{URI.encode(file_path)}")
+    response = delete_request("/#{project_name}/file/remove/#{URI.encode(file_path)}")
     raise MetisClient::Error, "Could not remove file #{file_path}\n#{error(response)}" unless response.code == "200"
   end
 
@@ -288,6 +288,11 @@ class MetisClient
     https.request(req)
   end
 
+  def delete_request(path)
+    req = delete(path)
+    https.request(req)
+  end
+
   def multipart_post(path, body)
     req = post(path)
     req.set_form(body, 'multipart/form-data')
@@ -300,6 +305,10 @@ class MetisClient
 
   def post(path)
     request(path, Net::HTTP::Post)
+  end
+
+  def delete(path)
+    request(path, Net::HTTP::Delete)
   end
 
   def https
@@ -592,7 +601,7 @@ EOT
     def run(source_file_path, destination_file_path)
       raise ShellError, 'No source file selected!' unless source_file_path
 
-      raise ShellError, 'No destination file defined!' unless destination_file_path
+      raise ShellError, 'No destination file selected!' unless destination_file_path
 
       if !source_file_path.start_with?('metis://')
         source_file_path.sub!(%r!(?<=.)/$!,'')
@@ -627,6 +636,39 @@ EOT
         @shell.project_name,
         source_file_path,
         destination_file_path)
+    end
+  end
+
+  class Rm < Command
+    usage "rm <remote_path>"
+    def run(path)
+      raise ShellError, 'No project is selected' if !@shell.project_name
+
+      path = @shell.relative_path(path)
+
+      name = ::File.basename(path)
+
+      folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(path))
+
+      raise ShellError, "Invalid path #{path}" unless folder
+
+      file = folder[:files].find do |f|
+        f[:file_name] == name
+      end
+
+      if file
+        @shell.client.remove_file(@shell.project_name, path)
+        return
+      end
+
+      folder = folder[:folders].find do |f|
+        f[:folder_name] == name
+      end
+
+      if folder
+        @shell.client.remove_folder(@shell.project_name, path)
+        return
+      end
     end
   end
 

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -236,7 +236,7 @@ describe MetisShell do
   end
 
   describe MetisShell::Rm do
-    it 'does nothing if the source file does not exist' do
+    it 'warns if the path does not exist' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
@@ -244,7 +244,7 @@ describe MetisShell do
 
       expect(Metis::File.count).to eq(1)
 
-      expect_output("metis://athena/armor", "rm", "helmet/helmet2.jpg") { // }
+      expect_output("metis://athena/armor", "rm", "helmet/helmet2.jpg") { /Invalid path/ }
 
       expect(Metis::File.count).to eq(1)
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -9,6 +9,15 @@ def expect_output(path, *args)
   }.to output(yield).to_stdout
 end
 
+def expect_error(path, *args)
+  expect {
+    begin
+      MetisShell.new(path, *args).run
+    rescue SystemExit
+    end
+  }.to output(yield).to_stderr_from_any_process
+end
+
 describe MetisShell do
   include Rack::Test::Methods
 
@@ -216,7 +225,7 @@ describe MetisShell do
 
       expect(Metis::Folder.count).to eq(1)
 
-      expect_output("metis://athena/armor", "mkdir", "helmet") { /Folder already exists/ }
+      expect_error("metis://athena/armor", "mkdir", "helmet") { /Folder already exists/ }
 
       expect(Metis::Folder.count).to eq(1)
     end
@@ -244,7 +253,7 @@ describe MetisShell do
 
       expect(Metis::File.count).to eq(1)
 
-      expect_output("metis://athena/armor", "rm", "helmet/helmet2.jpg") { /Invalid path/ }
+      expect_error("metis://athena/armor", "rm", "helmet/helmet2.jpg") { /Invalid path/ }
 
       expect(Metis::File.count).to eq(1)
     end
@@ -257,7 +266,7 @@ describe MetisShell do
 
       expect(Metis::File.count).to eq(1)
 
-      expect_output("metis://athena/armor", "rm", "helmet2/helmet.jpg") { /Invalid folder/ }
+      expect_error("metis://athena/armor", "rm", "helmet2/helmet.jpg") { /Invalid folder/ }
 
       expect(Metis::File.count).to eq(1)
     end
@@ -281,7 +290,7 @@ describe MetisShell do
 
       expect(Metis::Folder.count).to eq(1)
 
-      expect_output("metis://athena/armor", "rm", "helmet2") { // }
+      expect_error("metis://athena/armor", "rm", "helmet2") { /Invalid path/ }
 
       expect(Metis::Folder.count).to eq(1)
     end


### PR DESCRIPTION
Based off of the recent uploading, this PR adds in some additional commands to the Metis Client. All of these work with commands fed in from a text file as well:

1) `cp` of files. You should be able to use relative paths (i.e. `cp file.txt ../` or `cp ../file.txt .` as well as just copy within a directory. To copy to / from a different bucket, you need to use a Metis path for the appropriate file, in the form of `metis://<project>/<bucket>/<file_path>`
2) `rm` of files and folders. I think this would be useful for startup. I'm hesitant to implement `rm -r`, so people still have to think a little bit and removing a whole hierarchy is still a bit onerous, but at least there is now a way to do it in the client instead of going to the UI, and it could be scripted to make it easier. If we don't think `rm -rf` is too dangerous, we can add that later...
3) `mkdir` (but really `mkdir -p`) for folders. This seems like it will make Arjun's life easier, since the folder hierarchy on the storage server isn't easy to match to the desired target on Metis sometimes.

