### PR TITLE
Metis client can ls file directly

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -428,7 +428,7 @@ EOT
 
       folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(path))
 
-      raise ShellError, "Invalid path #{path}" unless folder
+      raise ShellError, "Invalid path, cannot mv #{path}" unless folder
 
       file = folder[:files].find do |f|
         f[:file_name] == name
@@ -477,12 +477,12 @@ EOT
 
       name = ::File.basename(file_path)
 
-      folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(file_path))
+      parent_folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(file_path))
 
-      raise ShellError, "Invalid path #{file_path}" unless folder
+      raise ShellError, "Invalid path, cannot list #{file_path}" unless parent_folder
 
       begin
-        file = folder[:files].find do |f|
+        file = parent_folder[:files].find do |f|
           f[:file_name] == name
         end
 
@@ -494,9 +494,13 @@ EOT
           )
           return
         end
-      end if folder[:files]
+      end if parent_folder[:files]
 
-      folder = @shell.client.list_folder(@shell.project_name, file_path)
+      begin
+        folder = @shell.client.list_folder(@shell.project_name, file_path)
+      rescue MetisClient::Error
+        raise ShellError, "No such file or folder: #{file_path}" unless folder
+      end
 
       display(
         folders: folder[:folders] || [],
@@ -611,7 +615,7 @@ EOT
 
       folder = @shell.client.list_folder(@shell.project_name, path)
 
-      raise ShellError, "No such folder #{dirname}" unless folder
+      raise ShellError, "Could not find folder #{dirname}" unless folder
 
       @shell.cwd = path
     end
@@ -671,7 +675,7 @@ EOT
 
       folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(path))
 
-      raise ShellError, "Invalid path #{path}" unless folder
+      raise ShellError, "Invalid path, cannot rm #{path}" unless folder
 
       file = folder[:files].find do |f|
         f[:file_name] == name

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -455,7 +455,7 @@ EOT
   end
 
   class Ls < Command
-    usage "ls [<remote_folder_path>]"
+    usage "ls [<remote_folder_or_file_path>]"
 
     def parse(args)
       parse_opts(args) do |opts|
@@ -474,6 +474,27 @@ EOT
         display(buckets: @shell.client.list_buckets(@shell.project_name) || [])
         return
       end
+
+      name = ::File.basename(file_path)
+
+      folder = @shell.client.list_folder(@shell.project_name, ::File.dirname(file_path))
+
+      raise ShellError, "Invalid path #{file_path}" unless folder
+
+      begin
+        file = folder[:files].find do |f|
+          f[:file_name] == name
+        end
+
+        if file
+          file[:file_name] = file_path
+          display(
+            folders: [],
+            files: [file]
+          )
+          return
+        end
+      end if folder[:files]
 
       folder = @shell.client.list_folder(@shell.project_name, file_path)
 

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -91,11 +91,35 @@ describe MetisShell do
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
       expect_output("metis://athena/armor/", "ls", "helmet") { "helmet.jpg\n" }
     end
+
     it 'lists the project root directory' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
       helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
       expect_output("metis://athena/armor/helmet", "ls", "/") { "armor/\n" }
+    end
+
+
+    it 'lists files directly' do
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
+      stubs.create_file('athena', 'armor', 'helmet/helmet.jpg', HELMET)
+
+      expect_output("metis://athena/armor", "ls", "helmet/helmet.jpg") { %r!armor/helmet/helmet.jpg!m }
+    end
+
+    it 'lists files directly in long format' do
+      Timecop.freeze(DateTime.parse("2020-06-17T04:37"))
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      helmet_folder = create_folder('athena', 'helmet', bucket: bucket)
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket, folder: helmet_folder)
+      stubs.create_file('athena', 'armor', 'helmet/helmet.jpg', HELMET)
+
+      expect_output("metis://athena/armor", "ls", "-l", "helmet/helmet.jpg") {
+        "metis 13 Jun 17 04:37 armor/helmet/helmet.jpg\n"
+      }
+      Timecop.return
     end
   end
 


### PR DESCRIPTION
Per mountetna/metis#97, this add `ls` for files in metis_client. If a file exists, `ls` will return the full path (including bucket) to the file. Otherwise it throws an error as before.