### PR TITLE
Timur Chrome CSS

### DIFF
--- a/timur/lib/client/jsx/components/search/search.jsx
+++ b/timur/lib/client/jsx/components/search/search.jsx
@@ -31,7 +31,6 @@ import {
   emptySearchCache,
   setSearchAttributeNames,
   setFilterString,
-  setSearchShowDisconnected,
   setSelectedModel,
 } from '../../actions/search_actions';
 
@@ -191,7 +190,6 @@ export default connect(
     setSearchPageSize,
     setSearchAttributeNames,
     setFilterString,
-    setSearchShowDisconnected,
     emptySearchCache,
     setSelectedModel,
     showMessages,

--- a/timur/lib/client/scss/attribute.scss
+++ b/timur/lib/client/scss/attribute.scss
@@ -28,10 +28,8 @@
   }
 
   .collection {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-    grid-auto-rows: minmax(5px, auto);
+    column-count: 3;
+    column-width: 150px;
     padding-bottom: 3px;
   }
 
@@ -44,6 +42,12 @@
       color: green;
       font-weight: bold;
     }
+  }
+
+  .collection_item:nth-child(1),
+  .list_item:nth-child(1) {
+    display: inline-block;
+    width: 100%;
   }
 
   .markdown {

--- a/timur/lib/client/scss/attribute.scss
+++ b/timur/lib/client/scss/attribute.scss
@@ -28,8 +28,10 @@
   }
 
   .collection {
-    column-count: 3;
-    column-width: 150px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    grid-auto-rows: minmax(5px, auto);
     padding-bottom: 3px;
   }
 


### PR DESCRIPTION
This small change fixes the CSS for collection attributes in Chrome when there is only one item. Instead of the one item being centered in the div, it will be pulled to the left so it lines up with other elements. This mimics the behavior seen in FireFox.