### PR TITLE
auto-scroll the filter modal when lots of attributes

### DIFF
--- a/timur/lib/client/scss/search.scss
+++ b/timur/lib/client/scss/search.scss
@@ -67,6 +67,7 @@ $query-sep: 1px solid #ddd;
   background: white;
   max-height: 70vh;
   font-family: $body_font;
+  overflow-y: auto;
 
 
   .actions {


### PR DESCRIPTION
This PR add simple styling to the search attribute filters modal, so when there are a lot of attributes the modal becomes scrollable instead of the button being pushed off the screen. See issue in timurfixes.