### PR TITLE
fix get in root folder (identified yesterday in slack)

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -740,7 +740,7 @@ EOT
     usage "get <remote_folder_path> <local_path>"
 
     def run(folder_path, local_path)
-      raise ShellError, 'No remote folder selected!' unless @shell.cwd
+      raise ShellError, 'No remote folder selected!' unless @shell.relative_path(folder_path)
 
       path = local_path =~ %r!^/! ?
         local_path :


### PR DESCRIPTION
This PR implements the fix identified by @graft  for metis client, when trying to run `get` on a root path. Issue was raised by Arjun on Slack.