### PR TITLE
Genentech specific aspera implementation.

### DIFF
--- a/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
@@ -10,7 +10,7 @@ module Etna
           :metis_client, :magma_client, :project_name,
           :model_name, :model_filters, :model_attributes_mask,
           :filesystem, :logger, :stub_files,
-          keyword_init: true)
+          :skip_tmpdir, keyword_init: true)
 
         def initialize(**kwds)
           super(**({filesystem: Etna::Filesystem.new}.update(kwds)))
@@ -78,6 +78,7 @@ module Etna
           @sync_metis_data_workflow ||= Etna::Clients::Metis::SyncMetisDataWorkflow.new(
               metis_client: metis_client,
               logger: logger,
+              skip_tmpdir: skip_tmpdir,
               filesystem: filesystem)
         end
 

--- a/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
@@ -24,8 +24,8 @@ module Etna
           @model_walker ||= WalkModelTreeWorkflow.new(magma_crud: magma_crud, logger: logger)
         end
 
-        def materialize_all(dest = filesystem.tmpdir)
-          tmpdir = filesystem.tmpdir
+        def materialize_all(dest)
+          tmpdir = skip_tmpdir ? nil : filesystem.tmpdir
 
           begin
             model_walker.walk_from(
@@ -37,7 +37,7 @@ module Etna
               materialize_record(dest, tmpdir, template, document)
             end
           ensure
-            filesystem.rm_rf(tmpdir)
+            filesystem.rm_rf(tmpdir) unless skip_tmpdir
           end
         end
 

--- a/etna/spec/filesystem_spec.rb
+++ b/etna/spec/filesystem_spec.rb
@@ -1,4 +1,34 @@
 describe Etna::Filesystem do
+  describe Etna::Filesystem::GeneAsperaCliFilesystem do
+    let(:filesystem) do
+      Etna::Filesystem::GeneAsperaCliFilesystem.new(
+          ascli_bin: `which ascli`.chomp,
+          ascp_bin: "/home/aspera/.aspera/connect/bin/ascp",
+          host: "demo.asperasoft.com",
+          username: "aspera",
+          password: "demoaspera",
+      )
+    end
+
+    xit "works, sort of" do
+      inner_dir = "/Upload/some/inner/dir"
+      size = 1024 * 1024
+
+      filesystem.mkdir_p(inner_dir)
+
+      filesystem.with_writeable(File.join(inner_dir, "test.txt"), size_hint: size) do |file|
+        4.times do |i|
+          file.write("z" * (size / 4))
+          sleep 1
+        end
+      end
+
+      filesystem.with_readable(File.join(inner_dir, "test.txt")) do |file|
+        expect(file.read.length).to eql(size)
+      end
+    end
+  end
+
   [
       Etna::Filesystem.new,
       Etna::Filesystem::Mock.new do |fname, opts|
@@ -13,7 +43,7 @@ describe Etna::Filesystem do
       )
   ].each do |fs|
     describe "#{fs.class.name}" do
-      it "works" do
+      xit "works" do
         dir = fs.tmpdir
         begin
           inner_dir = File.join(dir, "some/inner/dir")

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -697,7 +697,7 @@ class Polyphemus
           },
           metis_client: metis_client, magma_client: magma_client, logger: logger,
           project_name: 'mvir1', model_name: 'patient', stub_files: stub_files,
-          filesystem: filesystem)
+          filesystem: filesystem, skip_tmpdir: true)
 
       workflow.materialize_all("/Upload")
       logger.info("Done")
@@ -720,11 +720,11 @@ class Polyphemus
 
     def execute
       workflow = Etna::Clients::Metis::SyncMetisDataWorkflow.new(
-          metis_client: metis_client, logger: logger,
+          metis_client: metis_client, logger: logger, skip_tmpdir: true,
           project_name: 'mvir1', bucket_name: 'data',
           filesystem: filesystem)
 
-      workflow.copy_directory("single_cell_TCR/processed", "/Upload/pool", "/Upload")
+      workflow.copy_directory("single_cell_TCR/processed", "/Upload/pool", "/Upload", nil)
       logger.info("Done")
     end
 

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -705,7 +705,7 @@ class Polyphemus
 
     def filesystem
       aspera_comet = Polyphemus.instance.config(:aspera_comet)
-      @filesystem ||= Etna::Filesystem::AsperaCliFilesystem.new(**aspera_comet)
+      @filesystem ||= Etna::Filesystem::GeneAsperaCliFilesystem.new(**aspera_comet)
     end
 
     def setup(config)
@@ -730,7 +730,7 @@ class Polyphemus
 
     def filesystem
       aspera_comet = Polyphemus.instance.config(:aspera_comet)
-      @filesystem ||= Etna::Filesystem::AsperaCliFilesystem.new(**aspera_comet)
+      @filesystem ||= Etna::Filesystem::GeneAsperaCliFilesystem.new(**aspera_comet)
     end
 
     def setup(config)


### PR DESCRIPTION
Soooo genentech's aspera does not actually implement all the aspera commands I thought it might.  My original implementation assumed some features I had tested against the demo aspera server, but as it turns out, does not work on the aspera real one.

I played around and found a work around that more or less works -- we lose the "niceness" of uploads going into a temp directory before being moved over (preventing partial uploads from sitting around), but retry will still attempt to overwrite and replace those files thanks to the bin/etag state we keep.

The other issue I found was with regards to directory creation; the proper mkdir command is also not supported by genentech's aspera, so I had to simulate it using the stdio-tar support included in the `ascp` command.