### PR TITLE
Assign hmac headers for authorized upload

### DIFF
--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -150,8 +150,7 @@ class Metis
           id: :metis,
           headers: user ? {
             email: user.email,
-            first: user.first,
-            last: user.last
+            name: user.name.strip
           } : {}
         ).url_params
       )

--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -67,33 +67,34 @@ class Metis
       %x{ md5sum "#{path}" }.split.first
     end
 
-    def self.upload_url(request, project_name, bucket_name, file_path)
+    def self.upload_url(request, project_name, bucket_name, file_path, user)
       hmac_url(
-        'POST',
-        request.host,
-        Metis::Server.route_path(
+        method: 'POST',
+        host: request.host,
+        path: Metis::Server.route_path(
           request,
           :upload,
           project_name: project_name,
           bucket_name: bucket_name,
           file_path: file_path
         ),
-        Metis.instance.config(:upload_expiration)
+        user: user,
+        expiration: Metis.instance.config(:upload_expiration)
       )
     end
 
     def self.download_url(request, project_name, bucket_name, file_path)
       hmac_url(
-        'GET',
-        request.host,
-        Metis::Server.route_path(
+        method: 'GET',
+        host: request.host,
+        path: Metis::Server.route_path(
           request,
           :download,
           project_name: project_name,
           bucket_name: bucket_name,
           file_path: file_path
         ),
-        Metis.instance.config(:download_expiration)
+        expiration: Metis.instance.config(:download_expiration)
       )
     end
 
@@ -136,7 +137,7 @@ class Metis
 
     private
 
-    def self.hmac_url(method, host, path, expiration=0)
+    def self.hmac_url(method:, host:, path:, user:  nil, expiration: 0)
 
       URI::HTTPS.build(
         Etna::Hmac.new(
@@ -147,7 +148,11 @@ class Metis
           expiration: (Time.now + expiration).iso8601,
           nonce: Metis.instance.sign.uid,
           id: :metis,
-          headers: { }
+          headers: user ? {
+            email: user.email,
+            first: user.first,
+            last: user.last
+          } : {}
         ).url_params
       )
     end

--- a/metis/lib/server/controllers/upload_controller.rb
+++ b/metis/lib/server/controllers/upload_controller.rb
@@ -123,10 +123,19 @@ class UploadController < Metis::Controller
   private
 
   def user_by_hmac(hmac)
+    hmac_name = hmac.headers[:name]
+
+    # Definitely an assumption on how names are constructed...
+    hmac_name_parts = hmac_name&.split(' ')
+    first = hmac_name_parts ? hmac_name_parts.first : hmac.id
+    last = hmac_name_parts ?
+      hmac_name_parts.slice(1, hmac_name_parts.length - 1).join(" ") :
+      hmac.id
+
     return Etna::User.new(
         email: (hmac.headers[:email] || hmac.id).to_s,
-        first: (hmac.headers[:first] || hmac.id).to_s,
-        last: (hmac.headers[:last] || hmac.id).to_s) if hmac and hmac.valid?
+        first: first.to_s,
+        last: last.to_s) if hmac and hmac.valid?
     @user
   end
 

--- a/metis/lib/server/controllers/upload_controller.rb
+++ b/metis/lib/server/controllers/upload_controller.rb
@@ -22,7 +22,8 @@ class UploadController < Metis::Controller
       @request,
       @params[:project_name],
       @params[:bucket_name],
-      @params[:file_path]
+      @params[:file_path],
+      @user
     )
 
     success_json(url: url)

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -33,7 +33,7 @@ describe MetisShell do
     )
 
     token = Base64.strict_encode64(
-      { email: 'metis@olympus.org', perm: 'a:athena', exp: 253371439590 }.to_json
+      { email: 'metis@olympus.org', first: "Metis", last: "User", perm: 'a:athena', exp: 253371439590 }.to_json
     )
 
     ENV['TOKEN'] = "something.#{token}"
@@ -166,7 +166,8 @@ describe MetisShell do
       # There is a non-reset call to start the upload
       expect(WebMock).to have_requested(:post, /https:\/\/metis.test\/athena\/upload\/armor\/helmet.txt/).
         with(query: hash_including({
-          "X-Etna-Id": "metis"
+          "X-Etna-Id": "metis",
+          "X-Etna-Headers": "email,name"
         })).
         with(headers: {
           "Content-Type": "application/json"

--- a/metis/spec/upload_spec.rb
+++ b/metis/spec/upload_spec.rb
@@ -45,8 +45,8 @@ describe UploadController do
       expect(hmac_params['X-Etna-Id']).to eq('metis')
 
       expect(hmac_params['X-Etna-Email']).to eq('metis@olympus.org')
-      expect(hmac_params['X-Etna-First']).to eq('Metis')
-      expect(hmac_params['X-Etna-Headers']).to eq('email,first,last')
+      expect(hmac_params['X-Etna-Name']).to eq('Metis')
+      expect(hmac_params['X-Etna-Headers']).to eq('email,name')
       upload = Metis::Upload.first
       expect(upload).to be_nil  # No Uploads now until upload_start
     end
@@ -349,7 +349,7 @@ describe UploadController do
       expect(Metis::Upload.count).to eq(2)
     end
 
-    it 'should create a new upload on start using hmac email, first, and last, if does not exist' do
+    it 'should create a new upload on start using hmac email and name, if does not exist' do
       file = create_file('athena', 'wisdom.txt', WISDOM)
 
       # we create an upload, but the metis_uid is different from ours
@@ -366,8 +366,7 @@ describe UploadController do
       # we attempt to post to the path
       hmac_header(params={
         email: 'athena@olympus.org',
-        first: 'Athena',
-        last: 'Pallas'
+        name: 'Athena Pallas'
       })
       json_post(
         upload_path('athena', 'wisdom.txt'),

--- a/metis/spec/upload_spec.rb
+++ b/metis/spec/upload_spec.rb
@@ -43,6 +43,10 @@ describe UploadController do
       expect(last_response.status).to eq(200)
       expect(uri.path).to eq("/#{params[:project_name]}/upload/files/#{params[:file_path]}")
       expect(hmac_params['X-Etna-Id']).to eq('metis')
+
+      expect(hmac_params['X-Etna-Email']).to eq('metis@olympus.org')
+      expect(hmac_params['X-Etna-First']).to eq('Metis')
+      expect(hmac_params['X-Etna-Headers']).to eq('email,first,last')
       upload = Metis::Upload.first
       expect(upload).to be_nil  # No Uploads now until upload_start
     end


### PR DESCRIPTION
This PR adds HMAC headers for the user when authorizing an upload. Currently when you upload via Browser or metis_client, the user is set to `metis|Metis`, not the original user that initiated the upload. This change allows for better trackability for each upload.