### PR TITLE
Simplify the browser data loading pathway.

### DIFF
--- a/docker/build_image
+++ b/docker/build_image
@@ -81,7 +81,7 @@ function addToDigest() {
 }
 function recursiveDigest() {
   if [[ -n "$digestOnly" ]]; then
-     find "$1" -type f ! -path '*/node_modules/*' -exec md5sum {} \;
+     find "$1" -type f ! -path '*/node_modules/*' ! -path '*/.npmrc' ! -path '*/.bundle/config' -exec md5sum {} \;
      echo
   fi
 }
@@ -94,7 +94,7 @@ function findNewest() {
     find=gfind
   fi
 
-  lastModifiedFile=$($find $1 -type f ! -path '*/node_modules/*' -printf "%T+ %p\n" | sort | tail -1 | cut -d ' ' -f2)
+  lastModifiedFile=$($find $1 -type f ! -path '*/node_modules/*' ! -path '*/.npmrc' ! -path '*/.bundle/config' -printf "%T+ %p\n" | sort | tail -1 | cut -d ' ' -f2)
   if [ "$lastModifiedFile" -nt "$newestFile" ]; then
       newestFile="$lastModifiedFile"
    fi

--- a/etna/packages/etna-js/hooks/useAsyncWork.js
+++ b/etna/packages/etna-js/hooks/useAsyncWork.js
@@ -25,7 +25,9 @@ export default function useAsyncWork(f, { cancelWhenChange = undefined }) {
   const [cancellable, setCancellable] = cancelWhenChange ? useState(new Cancellable()) : [null, null];
 
   if (cancellable) useEffect(function () {
-    cancellable.cancel();
+    // Return the cancel as a cleanup operation -- this will get invokved only between the cancelWhenChange has new
+    // values, or the component is dismounted.
+    return () => cancellable.cancel();
   }, cancelWhenChange);
 
   const wrapper = useCallback(_wrapper, [setLoading, f, cancellable, setCancellable]);

--- a/etna/packages/etna-js/hooks/useAsyncWork.js
+++ b/etna/packages/etna-js/hooks/useAsyncWork.js
@@ -20,8 +20,15 @@ import {Cancellable} from "../utils/cancellable";
     that result in calls to this hook may trigger a cancellation of the last known invocation of f.  Any consecutive
     invocations of f cancel any previous invocations.
  */
-export default function useAsyncWork(f, { cancelWhenChange = undefined }) {
+export default function useAsyncWork(f, { cancelWhenChange = undefined, renderedState = undefined }) {
   const [loading, setLoading] = useState(false);
+  const [lastPendingResolve, setPendingResolve] = useState(null);
+  if (lastPendingResolve) {
+    lastPendingResolve(renderedState);
+    setPendingResolve(null);
+  }
+  // const [last, setLoading] = useState(false);
+
   const [cancellable, setCancellable] = cancelWhenChange ? useState(new Cancellable()) : [null, null];
 
   if (cancellable) useEffect(function () {
@@ -31,7 +38,14 @@ export default function useAsyncWork(f, { cancelWhenChange = undefined }) {
   }, cancelWhenChange);
 
   const wrapper = useCallback(_wrapper, [setLoading, f, cancellable, setCancellable]);
-  return [loading, wrapper];
+  const awaitNextRender = useCallback(_awaitNextRender, [setPendingResolve]);
+  return [loading, wrapper, awaitNextRender];
+
+  function _awaitNextRender() {
+    return new Promise((resolve) => {
+      setPendingResolve(() => resolve);
+    })
+  }
 
   function _wrapper() {
     let result = f.apply(this, arguments);

--- a/timur/lib/client/jsx/actions/exchange_actions.js
+++ b/timur/lib/client/jsx/actions/exchange_actions.js
@@ -28,13 +28,6 @@ export class Exchange{
       })
     );
 
-    let localResponse = (response)=>{
-      return new Promise((resolve, reject)=>{
-        this.dispatch(removeExchange(this.exchange_name));
-        resolve(response);
-      })
-    };
-
-    return fetch(path, options).then(localResponse);
+    return fetch(path, options).finally(() => this.dispatch(removeExchange(this.exchange_name)));
   }
 }

--- a/timur/lib/client/jsx/actions/magma_actions.js
+++ b/timur/lib/client/jsx/actions/magma_actions.js
@@ -118,14 +118,14 @@ export const requestDocuments = (args) => {
         return Promise.reject(e);
       }
 
-      e.response.json().then((response) => {
+      return e.response.json().then((response) => {
         let errStr = response.error
           ? response.error
           : response.errors.map((error) => `* ${error}`);
         errStr = [`### Our request was refused.\n\n${errStr}`];
         dispatch(showMessages(errStr));
+        return Promise.reject(e);
       });
-      return Promise.reject(e);
     };
 
     let get_doc_args = [

--- a/timur/lib/client/jsx/actions/magma_actions.js
+++ b/timur/lib/client/jsx/actions/magma_actions.js
@@ -115,7 +115,7 @@ export const requestDocuments = (args) => {
     let handleRequestError = (e) => {
       if (!e.response) {
         dispatch(showMessages([`Something is amiss. ${e}`]));
-        return;
+        return Promise.reject(e);
       }
 
       e.response.json().then((response) => {

--- a/timur/lib/client/jsx/actions/magma_actions.js
+++ b/timur/lib/client/jsx/actions/magma_actions.js
@@ -125,9 +125,7 @@ export const requestDocuments = (args) => {
         errStr = [`### Our request was refused.\n\n${errStr}`];
         dispatch(showMessages(errStr));
       });
-      return new Promise((resolve, reject) => {
-        reject(e);
-      });
+      return Promise.reject(e);
     };
 
     let get_doc_args = [

--- a/timur/lib/client/jsx/actions/magma_actions.js
+++ b/timur/lib/client/jsx/actions/magma_actions.js
@@ -395,20 +395,22 @@ const cleanFileCollectionRevisions = (revisions, model_template) => {
 // Download a TSV from magma via Timur.
 export const requestTSV = (params) => (dispatch) => getTSVForm(params)
 
-export const requestAnswer = (question, callback) => {
+export const requestAnswer = (question, callback = null) => {
   return (dispatch) => {
     let localSuccess = (response) => {
       if ('error' in response) {
         dispatch(showMessages([`There was a ${response.type} error.`]));
         console.log(response.error);
-        return;
+        if(!callback) throw new Error(response.error);
       }
 
-      if (callback != undefined) callback(response);
+      if (callback) callback(response);
+      else return response
     };
 
     let localError = (error) => {
       console.log(error);
+      if (!callback) throw new Error(error);
     };
 
     let question_name = question;
@@ -416,7 +418,7 @@ export const requestAnswer = (question, callback) => {
       question_name = [].concat.apply([], question).join('-');
     }
     let exchange = new Exchange(dispatch, question_name);
-    getAnswer(question, exchange).then(localSuccess).catch(localError);
+    return getAnswer(question, exchange).then(localSuccess).catch(localError);
   };
 };
 

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -10,17 +10,17 @@ const addView = (view_name, view) => ({ type: 'ADD_VIEW', view_name, view })
  * Request a view for a given model/record/tab and send requests for additional 
  * data.
  */
-export const requestView = (model_name, success, error) => (dispatch) => {
+export const requestView = (model_name) => (dispatch) => {
   let exchange = new Exchange(dispatch,`view for ${model_name}`);
   getView(model_name, exchange)
     .then(
       ({document})=>{
         dispatch(addView(model_name, document));
-        if (success) success(document);
+        return document;
       }
     ).catch(e => {
       let { response } = e;
       if (response && response.status == 404) dispatch(addView(model_name, {}));
-      if (error) error(e);
+      else throw new Error('Failed to load view: ' + e.toString())
     });
 };

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -12,7 +12,7 @@ const addView = (view_name, view) => ({ type: 'ADD_VIEW', view_name, view })
  */
 export const requestView = (model_name) => (dispatch) => {
   let exchange = new Exchange(dispatch,`view for ${model_name}`);
-  getView(model_name, exchange)
+  return getView(model_name, exchange)
     .then(
       ({document})=>{
         dispatch(addView(model_name, document));

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -20,7 +20,11 @@ export const requestView = (model_name) => (dispatch) => {
       }
     ).catch(e => {
       let { response } = e;
-      if (response && response.status == 404) dispatch(addView(model_name, {}));
+      if (response && response.status == 404) {
+        // Default view
+        dispatch(addView(model_name, {}));
+        return {};
+      }
       else throw new Error('Failed to load view: ' + e.toString())
     });
 };

--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -153,12 +153,12 @@ export default function Browser({ model_name, record_name, tab_name }) {
     });
   }, [])
 
-  if (mode === 'loading') {
-    return loadingDiv;
-  }
-
   if (error) {
     return errorDiv;
+  }
+
+  if (mode === 'loading') {
+    return loadingDiv;
   }
 
   if (!record) {

--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -110,10 +110,15 @@ export default function Browser({ model_name, record_name, tab_name }) {
       return;
     }
 
-    if (!template) template = yield invoke(requestModel(model_name));
+    if (!template) {
+      const magma = yield invoke(requestModel(model_name));
+      template = selectTemplate({ magma }, model_name);
+    }
+
     if (!view) {
       // we are told the model and record name, get the view
       view = yield invoke(requestView(model_name));
+      view = selectView({ views: { [model_name]: view } }, model_name, template)
     }
 
     if (!tab_name) {
@@ -149,6 +154,7 @@ export default function Browser({ model_name, record_name, tab_name }) {
   // On mount, startup the loading process.
   useEffect(() => {
     loadDocuments(model_name, template, view).catch(e => {
+      console.error(e);
       setError(e);
     });
   }, [])

--- a/timur/lib/client/jsx/components/search/search.jsx
+++ b/timur/lib/client/jsx/components/search/search.jsx
@@ -37,22 +37,8 @@ import {
 import ModelViewer from '../model_viewer';
 import useAsyncWork from "etna-js/hooks/useAsyncWork";
 import SearchQuery from "./search_query";
-import {Loading} from "etna-js/components/Loading";
 import {showMessages} from "../../actions/message_actions";
 import {useRequestDocuments} from "../../hooks/useRequestDocuments";
-
-const spinnerCss = css`
-  display: block;
-  margin: 2rem auto;
-`;
-
-const loadingSpinner =
-  <ClimbingBoxLoader
-    css={spinnerCss}
-    color='green'
-    size={20}
-    loading={true}
-  />
 
 export function Search({
   queryableAttributes, cache, setSearchPageSize, cacheSearchPage,

--- a/timur/lib/client/jsx/utils/fetch_utils.js
+++ b/timur/lib/client/jsx/utils/fetch_utils.js
@@ -18,6 +18,7 @@ export const parseJSON = (response)=>{
   }
   catch(err){
     console.log(err);
+    throw err;
   }
 };
 


### PR DESCRIPTION
Still testing, but I found a way to unwind a lot of the logic and present a clear loading path for the browser component.  Prevents infinite cycles and is orders of magnitude easier to read.

Also introduced a crude "error state" visually when loading fails.  I'd like to develop it more, but as a first step getting the component to be able to detect and render based on a failed load is better than existing (just shows nothing and loops infinitely).