### PR TITLE
add config option to redact log params for routes

### DIFF
--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -96,7 +96,7 @@ module Etna
       @application ||= Etna::Application.instance
     end
 
-    def truncate(value)
+    def compact(value)
       value = value.to_s
       value = value[0..500] + "..." + value[-100..-1] if value.length > 600
       value
@@ -111,7 +111,7 @@ module Etna
     def redact(key, value)
       # From configuration, redact any values for the supplied key values, so they
       #   don't appear in the logs.
-      return truncate(value) unless application.config(:log_redact_keys)
+      return compact(value) unless application.config(:log_redact_keys)
 
       if value.is_a?(Hash)
         redacted_value = value.map do |value_key, value_value|
@@ -122,7 +122,7 @@ module Etna
         return "*"
       end
 
-      return value
+      return compact(value)
     end
 
     def authorized?(request)

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -72,9 +72,7 @@ module Etna
         user = request.env['etna.user']
 
         params = request.env['rack.request.params'].map do |key,value|
-          value = value.to_s
-          value = value[0..500] + "..." + value[-100..-1] if value.length > 600
-          [ key, value ]
+          [ key, redact(key, value) ]
         end.to_h
 
         logger.warn("User #{user ? user.email : :unknown} calling #{controller}##{action} with params #{params}")
@@ -93,6 +91,39 @@ module Etna
     end
 
     private
+
+    def application
+      @application ||= Etna::Application.instance
+    end
+
+    def truncate(value)
+      value = value.to_s
+      value = value[0..500] + "..." + value[-100..-1] if value.length > 600
+      value
+    end
+
+    def redact_keys
+      @redact_keys ||= application.config(:log_redact_keys).split(",").map do |key|
+        key.to_sym
+      end
+    end
+
+    def redact(key, value)
+      # From configuration, redact any values for the supplied key values, so they
+      #   don't appear in the logs.
+      return truncate(value) unless application.config(:log_redact_keys)
+
+      if value.is_a?(Hash)
+        redacted_value = value.map do |value_key, value_value|
+          [ value_key, redact(value_key, value_value) ]
+        end.to_h
+        return redacted_value
+      elsif redact_keys.include?(key)
+        return "*"
+      end
+
+      return value
+    end
 
     def authorized?(request)
       # If there is no @auth requirement, they are ok - this doesn't preclude

--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -6,7 +6,7 @@ gem 'rack'
 gem 'rack-throttle'
 gem 'pg'
 gem 'sequel'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5'
 gem 'jwt'
 gem 'puma', '5.0.2'
 

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 13bdf05dc8beb607bc8a40c111e6132cc2020c03
-  branch: refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11
+  revision: ccbf5521ee114866abeeeb992354d12b50bf9e17
+  branch: refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5
   specs:
     etna (0.1.27)
       jwt

--- a/magma/Gemfile
+++ b/magma/Gemfile
@@ -5,7 +5,7 @@ require 'fileutils'
 
 ruby '~> 2.5'
 
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5'
 gem 'pg'
 gem 'sequel', '5.28.0'
 gem 'mini_magick'

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 13bdf05dc8beb607bc8a40c111e6132cc2020c03
-  branch: refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11
+  revision: ccbf5521ee114866abeeeb992354d12b50bf9e17
+  branch: refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5
   specs:
     etna (0.1.27)
       jwt

--- a/metis/Gemfile
+++ b/metis/Gemfile
@@ -7,7 +7,7 @@ gem 'pg'
 gem 'sequel'
 gem 'fog-aws'
 gem 'puma', '5.0.2'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5'
 
 gem 'puma', '5.0.2'
 

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 13bdf05dc8beb607bc8a40c111e6132cc2020c03
-  branch: refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11
+  revision: ccbf5521ee114866abeeeb992354d12b50bf9e17
+  branch: refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5
   specs:
     etna (0.1.27)
       jwt

--- a/metis/package-lock.json
+++ b/metis/package-lock.json
@@ -5374,8 +5374,8 @@
       "dev": true
     },
     "etna-js": {
-      "version": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
-      "from": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
+      "version": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
+      "from": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
       "requires": {
         "animate.css": "^4.1.0",
         "react-notifications-component": "^2.4.0"

--- a/metis/package.json
+++ b/metis/package.json
@@ -19,7 +19,7 @@
     "@fortawesome/fontawesome-free": "^5.12.0",
     "copy-webpack-plugin": "^4.6.0",
     "downzip": "git+https://git@github.com/mountetna/downzip.git",
-    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
+    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
     "event-hooks-webpack-plugin": "^1.0.0",
     "fs-extra": "^9.0.1",
     "js-cookie": "^2.2.1",

--- a/polyphemus/Gemfile
+++ b/polyphemus/Gemfile
@@ -5,7 +5,7 @@ gem 'sequel'
 gem 'pg'
 gem 'nokogiri'
 gem 'puma', '5.0.2'
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5'
 gem 'actionpack' # For streaming the job controller results back...
 gem 'aspera-cli'
 

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 13bdf05dc8beb607bc8a40c111e6132cc2020c03
-  branch: refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11
+  revision: ccbf5521ee114866abeeeb992354d12b50bf9e17
+  branch: refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5
   specs:
     etna (0.1.27)
       jwt

--- a/timur/Gemfile
+++ b/timur/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # etna application/server gem
-gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11'
+gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5'
 
 # provides lexer/parser
 gem 'rltk'

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mountetna/monoetna.git
-  revision: 13bdf05dc8beb607bc8a40c111e6132cc2020c03
-  branch: refs/artifacts/gem-etna/91048bfdb46b22134ad644210cdb94043048ac11
+  revision: ccbf5521ee114866abeeeb992354d12b50bf9e17
+  branch: refs/artifacts/gem-etna/fdb1b9ea69f2f43725574fe56b3ad4046962fac5
   specs:
     etna (0.1.27)
       jwt

--- a/timur/package-lock.json
+++ b/timur/package-lock.json
@@ -5524,8 +5524,8 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etna-js": {
-      "version": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
-      "from": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
+      "version": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
+      "from": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
       "requires": {
         "animate.css": "^4.1.0",
         "react-notifications-component": "^2.4.0"

--- a/timur/package.json
+++ b/timur/package.json
@@ -14,7 +14,7 @@
     "d3": "^5.5.0",
     "d3-ease": "^1.0.3",
     "downloadjs": "^1.4.7",
-    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#be5cf2fd5b2070f2eb649ba50322cbd153ee74b0",
+    "etna-js": "git+https://git@github.com/mountetna/monoetna.git#b5e38c3b579f26463441a35e5f75f82ea2145f14",
     "identity-obj-proxy": "^3.0.0",
     "js-cookie": "^2.2.0",
     "json2csv": "^4.0.1",


### PR DESCRIPTION
This PR adds the ability to redact portions of the route logging, when parameters are logged for an action. This is useful for Polyphemus, since we can't be sure what types of data will be passed along in the parameters for each job.