### PR TITLE
metis client auto-refreshes token when it nears expiration

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -114,7 +114,77 @@ class Upload
   end
 end
 
-class MetisClient
+class Client
+  # This is duplicated code because we need to refactor Metis client
+  #   to use the etna gem clients...
+  def token_expired?
+    # Has the token already expired?
+    token_will_expire?(0)
+  end
+
+  def token_will_expire?(offset=3000)
+    # Will the user's token expire in the given amount of time?
+    epoch_seconds = JSON.parse(Base64.urlsafe_decode64(@token.split('.')[1]))["exp"]
+    expiration = DateTime.strptime(epoch_seconds.to_s, "%s").to_time
+    expiration <= DateTime.now.new_offset.to_time + offset
+  end
+
+  private
+
+  def get(path)
+    request(path, Net::HTTP::Get)
+  end
+
+  def post(path)
+    request(path, Net::HTTP::Post)
+  end
+
+  def delete(path)
+    request(path, Net::HTTP::Delete)
+  end
+
+  def request
+    raise "Needs to be implemented in subclass."
+  end
+
+  def https
+    @https ||= begin
+      https = Net::HTTP.new(@host,443)
+      https.use_ssl = true
+      https
+    end
+  end
+end
+
+class JanusClient < Client
+  class Error < StandardError
+  end
+
+  def initialize(host, token)
+    @host = host
+    @token = token
+  end
+
+  def refresh_token
+    get_request("/refresh_token").body
+  end
+
+  private
+
+  def get_request(path)
+    req = get(path)
+    https.request(req)
+  end
+
+  def request(path, method)
+    uri = URI.parse("https://#{@host}#{path}")
+    req = method.new(uri.request_uri)
+    req['Authorization'] = "Etna #{@token}"
+    return req
+  end
+end
+
+class MetisClient < Client
   class Error < StandardError
   end
 
@@ -280,6 +350,11 @@ class MetisClient
 
   private
 
+  def janus
+    # Don't memoize because we always will need the current @token value
+    JanusClient.new(@host.gsub("metis", "janus"), @token)
+  end
+
   def json_post(path, body={})
     req = post(path)
     req['Content-Type'] = 'application/json'
@@ -298,27 +373,9 @@ class MetisClient
     https.request(req)
   end
 
-  def get(path)
-    request(path, Net::HTTP::Get)
-  end
-
-  def post(path)
-    request(path, Net::HTTP::Post)
-  end
-
-  def delete(path)
-    request(path, Net::HTTP::Delete)
-  end
-
-  def https
-    @https ||= begin
-      https = Net::HTTP.new(@host,443)
-      https.use_ssl = true
-      https
-    end
-  end
-
   def request(path, method)
+    @token = janus.refresh_token if token_will_expire?
+
     uri = URI.parse("https://#{@host}#{path}")
     req = method.new(uri.request_uri)
     req['Authorization'] = "Etna #{@token}"
@@ -942,11 +999,6 @@ EOT
       exit
     end
 
-    if token_expired?
-      puts "Your token is expired. Please provide a new one in your environment."
-      exit
-    end
-
     match = METIS_PATH.match(path)
 
     @host = MetisConfig[:metis_host]
@@ -954,6 +1006,11 @@ EOT
     @args = args
 
     raise 'No metis host selected' if !@host
+
+    if client.token_expired?
+      puts "Your token is expired. Please provide a new one in your environment."
+      exit
+    end
 
     if match&.[](:path)
       set_path(match[:path])
@@ -1134,20 +1191,6 @@ EOT
       input[:command],
       *Shellwords.split(input[:args] || '')
     ]
-  end
-
-  # This is duplicated code because we need to refactor Metis client
-  #   to use the etna gem clients...
-  def token_expired?
-    # Has the token already expired?
-    token_will_expire?(0)
-  end
-
-  def token_will_expire?(offset=3000)
-    # Will the user's token expire in the given amount of time?
-    epoch_seconds = JSON.parse(Base64.urlsafe_decode64(@token.split('.')[1]))["exp"]
-    expiration = DateTime.strptime(epoch_seconds.to_s, "%s")
-    expiration <= DateTime.now.new_offset + offset
   end
 end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -374,7 +374,13 @@ class MetisClient < Client
   end
 
   def request(path, method)
-    @token = janus.refresh_token if token_will_expire?
+    begin
+      @token = janus.refresh_token
+
+      # Make sure to set this in the current process, so
+      #   we can export it into a file later.
+      ENV["TOKEN"] = @token
+    end if token_will_expire?
 
     uri = URI.parse("https://#{@host}#{path}")
     req = method.new(uri.request_uri)
@@ -1270,6 +1276,10 @@ def start
   MetisConfig.instance.config(config)
   MetisShell.new(ARGV[0], *ARGV[1..-1]).run
   puts
+
+  # As a convenience, we'll print out the current
+  #   token, in case it was refreshed.
+  puts "TOKEN=#{ENV["TOKEN"]}"
 end
 
 start unless test_env?

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1276,10 +1276,6 @@ def start
   MetisConfig.instance.config(config)
   MetisShell.new(ARGV[0], *ARGV[1..-1]).run
   puts
-
-  # As a convenience, we'll print out the current
-  #   token, in case it was refreshed.
-  puts "TOKEN=#{ENV["TOKEN"]}"
 end
 
 start unless test_env?


### PR DESCRIPTION
This PR updates metis_client to check if a token is near expiration. If so, it calls Janus to get a new token so that long-lived downloads and uploads can occur without manual intervention.