### PR TITLE
Fixing shibboleth issue in development

### DIFF
--- a/docker/etna-apache/Dockerfile
+++ b/docker/etna-apache/Dockerfile
@@ -10,6 +10,17 @@ RUN curl -o /tmp/dockerize.tgz -L $DOCKERIZE_URL && ( cd /usr/bin && tar xzf /tm
 
 COPY certs /root/certs
 COPY src/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+# In production, shibboleth environemnt is mounted with a bind mount into the /usr/opt directory.
+# We can't just mount that shibboleth prod directly into /etc/shibboleth because we only want to inject
+# a subset of configuration, not replacing the entire thing.
+# The solution is to have a separate directory that is mounted, but links into the individual files
+# we want injected.  BUT we cannot optionally configure shibboleth in Apache due to its configuration
+# language not supporting lazy evaluation, so we are ALSO forced to leave a plausible shibboleth2.xml
+# in case we are not backing the link (which has to be created at a build time, which is common
+# to all environments).  Yeesh.
+RUN mkdir -p /usr/opt/shibboleth/
+RUN cp /etc/shibboleth/shibboleth2.xml /usr/opt/shibboleth/shibboleth2.xml
 RUN ln -sf /usr/opt/shibboleth/shibboleth2.xml /etc/shibboleth/shibboleth2.xml
 RUN ln -sf /usr/opt/shibboleth/incommon.pem /etc/shibboleth/incommon.pem
 RUN ln -sf /usr/opt/shibboleth/sp-cert.pem /etc/shibboleth/sp-cert.pem

--- a/docker/etna-base/entrypoints/build.sh
+++ b/docker/etna-base/entrypoints/build.sh
@@ -71,6 +71,12 @@ if [ -n "$RUN_NPM_INSTALL" ]; then
   if [ -e ../etna ]; then npm link ../etna/packages/etna-js; fi
 fi
 
+if [ -n "$RELEASE_TEST" ]; then
+  # TODO: Find a better test harness for this.  In release tests, let's also ensure that in the resulting
+  # setup, the app_fe comes up successfully.
+  dockerize -wait tcp://${APP_NAME}_app_fe:80 -timeout 300s
+fi
+
 echo 'for file in /app/*.completion; do source $file || true; done' >> /root/.bashrc
 echo 'export PATH="/app/bin:$PATH"' >> /root/.bashrc
 # Allow other users to use the root bash setup


### PR DESCRIPTION
So, the comment explains the situation.

I tried adding an e2e test that should veirfy in the future that the apache docker config changes never break bringing up that service, as well.