### PR TITLE
Fix shibd issues caused from servername -> implied proto, speed up sh…

### DIFF
--- a/docker/etna-apache/Dockerfile
+++ b/docker/etna-apache/Dockerfile
@@ -1,11 +1,11 @@
 FROM library/httpd:2.4.43
 WORKDIR /app
 
-ENV DOCKERIZE_VERSION 0.5.0
+ENV DOCKERIZE_VERSION 0.6.1
 ENV DOCKERIZE_URL https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 
 RUN apt-get update -y
-RUN apt-get install -y libapache2-mod-xsendfile libapache2-mod-shib2 curl
+RUN apt-get install -y libapache2-mod-xsendfile libapache2-mod-shib2 xmlsec1 curl
 RUN curl -o /tmp/dockerize.tgz -L $DOCKERIZE_URL && ( cd /usr/bin && tar xzf /tmp/dockerize.tgz )
 
 COPY certs /root/certs
@@ -29,5 +29,7 @@ RUN ln -sf /shibboleth/idp-metadata.xml /etc/shibboleth/idp-metadata.xml
 RUN ln -sf /shibboleth/attribute-map.xml /etc/shibboleth/attribute-map.xml
 
 # Prepare the environment with ascript that can start shibd before httpd
-COPY src/bin/httpd_with_shibd.sh /bin/
-RUN chmod +x /bin/httpd_with_shibd.sh
+COPY src/bin/* /bin/
+RUN chmod +x /bin/*
+
+RUN /bin/prepare_shib.sh

--- a/docker/etna-apache/bin/prepare_shib.sh
+++ b/docker/etna-apache/bin/prepare_shib.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERIFIED_SHIB_DIR=/opt/shibboleth/
+mkdir -p $VERIFIED_SHIB_DIR
+
+cd $VERIFIED_SHIB_DIR
+curl -o InCommon-metadata.xml https://md.incommon.org/InCommon/InCommon-metadata.xml
+curl -o inc-md-cert.pem https://md.incommon.org/certs/inc-md-cert.pem
+
+# Verify the metadata's signing
+xmlsec1 --verify --pubkey-cert-pem inc-md-cert.pem --id-attr:ID "urn:oasis:names:tc:SAML:2.0:metadata:EntitiesDescriptor" InCommon-metadata.xml
+
+
+
+

--- a/docker/etna-base/fe.conf.erb
+++ b/docker/etna-base/fe.conf.erb
@@ -1,7 +1,15 @@
+# We are the proxy service backing http termination on a secure internal docker network, so we just use port 80.
 <VirtualHost *:80>
   DocumentRoot /app/public
 
-  ServerName <%= @app_name %>_app_fe
+  # NOTE:  This url is a bit of a lie.  This virtual host is actually serving off port 80, and this
+  # isn't the physical access url in front of this service, either.  However,
+  # 1.  Mod shib requires us to specify the 443 and https in order for the idp to correctly respond
+  # 2.  We can't get the full physical url due to this file being backed in at build time.
+  # Rather than force, say, chef managing this file, the simple answer is to tell a white lie about our
+  # servername here for the sake of shibd.
+  # The actual https termination occurs via edge-apache service stood up on each host via monoetna recipes.
+  ServerName https://<%= @app_name %>_app_fe:443
 
   # Disable TRACE and TRACK. This bit here prevents a certain kind of attack
   # which leaks info by repeatedly calling these two methods.

--- a/janus/build/shibboleth.addon.include
+++ b/janus/build/shibboleth.addon.include
@@ -1,3 +1,5 @@
+# ShibCompatValidUser Off
+
 <If "env('JANUS_ENV') == 'production'">
     # This line sets a special header available to Thin/Rack/Ruby.
     # The variable 'EMAIL' is only set IF Shibboleth is working and has


### PR DESCRIPTION
…ibd startup by using pre-verified metadata

Comments explain the shibd issue around https.  :shrug:   It works in staging.  Proxies being proxies I suppose.  Feel free to ask questions for clarification here, I realize this docker deployment stuff is still new.

The other fix is to pre-bake and pre-verify the incommon metadata to improve shibd startup performance.  There is a chef side change to `shibboleth2.xml` (on my docker branch) that uses this pre-baked file rather than the exhausting performance of its internal signature validation algorithm (which pegs the cpu for minutes at a time, woah).