### PR TITLE
Use puma from gemfile no system one

### DIFF
--- a/docker/etna-base/Dockerfile
+++ b/docker/etna-base/Dockerfile
@@ -44,7 +44,6 @@ ENV BUNDLE_BIN="$BUNDLE_PATH/bin"
 ENV BUNDLE_SILENCE_ROOT_WARNING=0
 ENV BUNDLE_APP_CONFIG="/app/.bundle"
 
-RUN gem install puma
 RUN gem install bundler --default -v "=$BUNDLER_VERSION"
 RUN gem update --system
 

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    curb (0.9.11)
     database_cleaner (1.8.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
@@ -147,6 +148,7 @@ DEPENDENCIES
   activesupport (>= 4.2.6)
   carrierwave
   carrierwave-sequel
+  curb
   database_cleaner
   debase
   etna!


### PR DESCRIPTION
puma already exists in gemfiles, but because it was also installed without version specifier  in the image it could get locked with an incompatible future version.