### PR TITLE
more restrictive find params for flow FCS files

### DIFF
--- a/polyphemus/lib/ipi/flow_fcs_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_fcs_file_linker.rb
@@ -14,7 +14,8 @@ class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
         metis_client: metis_client,
         project_name: project_name,
         bucket_name: bucket_name,
-        extension: 'fcs'
+        extension: 'fcs',
+        flow_fcs_only: true
       ).each do |fcs_file|
         file_path = fcs_file.file_path
         key = [{

--- a/polyphemus/lib/ipi/ipi_helper.rb
+++ b/polyphemus/lib/ipi/ipi_helper.rb
@@ -6,7 +6,10 @@ class IpiHelper
   def initialize
   end
 
-  def find_files_by_extension(metis_client:, project_name:, bucket_name:, extension:)
+  def find_files_by_extension(metis_client:, project_name:, bucket_name:, extension:, flow_fcs_only: false)
+    regex = "/.*\.#{extension}$/i" unless flow_fcs_only
+    regex = "/.*_flow_.*\.#{extension}$/i" if flow_fcs_only
+
     metis_client.find(
       Etna::Clients::Metis::FindRequest.new(
         project_name: project_name,
@@ -14,7 +17,7 @@ class IpiHelper
         params: [Etna::Clients::Metis::FindParam.new(
           attribute: 'name',
           predicate: '=~',
-          value: "/.*\.#{extension}$/i",
+          value: regex,
           type: 'file'
         )]
     )).files.all


### PR DESCRIPTION
This PR fixes the IPI linking command for linking FCS files from integral_data into Magma `flow` records. Cytof files are also `*.fcs` but shouldn't be injected into the `Flow` model, so need to filter those out when running this command.