### PR TITLE
Json files also need size hint for GNE upload

### DIFF
--- a/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
@@ -97,8 +97,9 @@ module Etna
 
           dest_file = File.join(dest_dir, metadata_file_name(record_name: record[template.identifier], record_model_name: template.name, ext: '.json'))
           filesystem.mkdir_p(File.dirname(dest_file))
-          filesystem.with_writeable(dest_file, "w") do |io|
-            io.write(record_to_serialize.to_json)
+          json = record_to_serialize.to_json
+          filesystem.with_writeable(dest_file, "w", size_hint: json.bytes.length) do |io|
+            io.write(json)
           end
         end
 

--- a/etna/lib/etna/filesystem.rb
+++ b/etna/lib/etna/filesystem.rb
@@ -230,6 +230,8 @@ module Etna
       end
 
       def with_writeable(dest, opts = 'w', size_hint: nil, &block)
+        raise "#{self.class.name} requires size_hint in with_writeable" if size_hint.nil?
+
         super do |io|
           io.write("File: #{::File.basename(dest)}\n")
           io.write("Size: #{size_hint}\n")

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -699,7 +699,7 @@ class Polyphemus
           project_name: 'mvir1', model_name: 'patient', stub_files: stub_files,
           filesystem: filesystem, skip_tmpdir: true)
 
-      workflow.materialize_all("/Upload")
+      workflow.materialize_all("/Upload/processed")
       logger.info("Done")
     end
 
@@ -721,10 +721,10 @@ class Polyphemus
     def execute
       workflow = Etna::Clients::Metis::SyncMetisDataWorkflow.new(
           metis_client: metis_client, logger: logger, skip_tmpdir: true,
-          project_name: 'mvir1', bucket_name: 'data',
+          project_name: 'mvir1', bucket_name: 'GNE_redacted_data',
           filesystem: filesystem)
 
-      workflow.copy_directory("single_cell_TCR/processed", "/Upload/pool", "/Upload", nil)
+      workflow.copy_directory("data", "/Upload/processed/GNE_redacted_data", "/Upload/processed", nil)
       logger.info("Done")
     end
 


### PR DESCRIPTION
Fixes an issue with the json uploads performed for GNE due to size_hint being requires for their version of aspera.
Other changes were hotfixes I hadn't yet gotten into master.