### PR TITLE
Vulcan plot refactor

### DIFF
--- a/etna/packages/etna-js/plots/components/xy_plot/xy_plot.jsx
+++ b/etna/packages/etna-js/plots/components/xy_plot/xy_plot.jsx
@@ -11,11 +11,11 @@ const COMPONENTS = {
 };
 
 const SeriesComponent = ({series, ...props}) => {
-  let Component = COMPONENTS[series.series_type];
+  let SComponent = COMPONENTS[series.series_type];
 
-  if (!Component) return null;
+  if (!SComponent) return null;
 
-  return <Component series={series} {...props} />;
+  return <SComponent series={series} {...props} />;
 };
 
 export default class XYPlot extends Component {

--- a/vulcan/lib/client/jsx/api/__tests__/vulcan.spec.js
+++ b/vulcan/lib/client/jsx/api/__tests__/vulcan.spec.js
@@ -222,7 +222,7 @@ describe('Vulcan API', () => {
       host: CONFIG.vulcan_host
     });
 
-    return getData(url).then((returnedData) => {
+    return getData(`${CONFIG.vulcan_host}${url}`).then((returnedData) => {
       expect(data).toEqual(returnedData);
       done();
     });

--- a/vulcan/lib/client/jsx/components/workflow/output.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output.jsx
@@ -1,4 +1,10 @@
-import React, {useState, useContext, useEffect} from 'react';
+import React, {
+  useState,
+  useContext,
+  useEffect,
+  useRef,
+  forwardRef
+} from 'react';
 
 import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
 import {showMessages} from 'etna-js/actions/message_actions';
@@ -26,6 +32,7 @@ const WORKFLOW = require('../../../../server/data/steps.json');
 const UMAP_DATA = require('../../../../server/data/umap_data.json');
 
 export default function Output() {
+  const outputRef = useRef(null);
   const invoke = useActionInvoker();
   const {workflow, pathIndex, stepIndex, setData, setWorkflow} = useContext(
     VulcanContext
@@ -114,7 +121,11 @@ export default function Output() {
           onSelect={handleOnSelectView}
         ></Dropdown>
       </div>
-      {Component ? <Component md5sum='some-cell-hash'></Component> : null}
+      <div ref={outputRef}>
+        {Component ? (
+          <Component md5sum='some-cell-hash' parentRef={outputRef}></Component>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/vulcan/lib/client/jsx/components/workflow/output.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output.jsx
@@ -63,7 +63,7 @@ export default function Output() {
     const STUB_URL = `https://vulcan.development.local/api/${CONFIG.project_name}/workflows/umap/umap_data`;
 
     WORKFLOW.steps[0][5].data_url = STUB_URL;
-
+    console.log(UMAP_DATA);
     setWorkflow(WORKFLOW);
     setOutputData(UMAP_DATA);
   }, []);

--- a/vulcan/lib/client/jsx/components/workflow/output.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output.jsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useContext,
-  useEffect,
-  useRef,
-  forwardRef
-} from 'react';
+import React, {useState, useContext, useEffect, useRef} from 'react';
 
 import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
 import {showMessages} from 'etna-js/actions/message_actions';
@@ -106,10 +100,6 @@ export default function Output() {
   }
 
   if (!outputData) return loadingDiv;
-
-  // Can we assume that the "main" plot data belongs to the
-  //   same output variable as defined in the CWL, and any
-  //   other data in the consignment is secondary?
 
   return (
     <div className='output-wrapper'>

--- a/vulcan/lib/client/jsx/components/workflow/output.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output.jsx
@@ -63,7 +63,7 @@ export default function Output() {
     const STUB_URL = `https://vulcan.development.local/api/${CONFIG.project_name}/workflows/umap/umap_data`;
 
     WORKFLOW.steps[0][5].data_url = STUB_URL;
-    console.log(UMAP_DATA);
+
     setWorkflow(WORKFLOW);
     setOutputData(UMAP_DATA);
   }, []);

--- a/vulcan/lib/client/jsx/components/workflow/output.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output.jsx
@@ -55,7 +55,7 @@ export default function Output() {
   useEffect(() => {
     const STUB_URL = `https://vulcan.development.local/api/${CONFIG.project_name}/workflows/umap/umap_data`;
 
-    WORKFLOW.steps[0][4].data_url = STUB_URL;
+    WORKFLOW.steps[0][5].data_url = STUB_URL;
 
     setWorkflow(WORKFLOW);
     setOutputData(UMAP_DATA);

--- a/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
@@ -58,7 +58,7 @@ export default function Plot({md5sum, parentRef}) {
 function browserStateOf(md5sum) {
   return (state) => {
     let consignment = selectConsignment(state, md5sum);
-
+    console.log(consignment);
     return {consignment};
   };
 }

--- a/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
@@ -58,7 +58,7 @@ export default function Plot({md5sum, parentRef}) {
 function browserStateOf(md5sum) {
   return (state) => {
     let consignment = selectConsignment(state, md5sum);
-    console.log(consignment);
+
     return {consignment};
   };
 }

--- a/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
@@ -146,7 +146,7 @@ function browserStateOf(md5sum, step, dimensions) {
           variables: {
             x: vectorize(xValues),
             y: vectorize(yValues),
-            labels: vectorize(labels)
+            label: vectorize(labels)
           }
         }
       ]

--- a/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/output_renderers/plot.jsx
@@ -5,32 +5,45 @@ import {VulcanContext} from '../../../contexts/vulcan';
 import {selectConsignment} from 'etna-js/plots/selectors/consignment_selector';
 import XYPlot from 'etna-js/plots/components/xy_plot/xy_plot';
 import CategoryPlot from 'etna-js/plots/components/category_plot/category_plot';
-import Vector from 'etna-js/plots/models/vector';
+
+import {plotDataForStep} from '../../../selectors/workflow_selector';
+import {plotData} from '../../../../../../../etna/packages/etna-js/plots/plot_script';
 
 export default function Plot({md5sum}) {
   const parentRef = useRef();
-  const [parentDims, setParentDims] = useState({width: 1600, height: 1200});
+  const [parentDims, setParentDims] = useState({width: 0, height: 0});
+  const [plot, setPlot] = useState(null);
+  const [data, setData] = useState(null);
 
   useEffect(() => {
+    console.log(parentRef);
     if (parentRef.current) {
       setParentDims({
         width: parentRef.current.offsetWidth,
         height: parentRef.current.offsetHeight
       });
     }
-  }, []);
+  }, [parentRef]);
 
   const {workflow, pathIndex, stepIndex, setData, setWorkflow} = useContext(
     VulcanContext
   );
 
   // The md5sum may come from the workflow step at some point?
-  const browserState = useReduxState(
-    browserStateOf(md5sum, workflow.steps[0][5], parentDims)
+  let browserState = useReduxState(
+    browserStateOf(md5sum, workflow.steps[0][5])
   );
 
-  let {plot, data} = browserState;
+  useEffect(() => {
+    browserState = useReduxState(
+      browserStateOf(md5sum, workflow.steps[0][5], parentDims)
+    );
+  }, [parentDims]);
 
+  let {consignment} = browserState;
+
+  console.log(plot);
+  console.log(data);
   if (!plot || !data) return null;
 
   let {
@@ -62,96 +75,14 @@ export default function Plot({md5sum}) {
   );
 }
 
-function padInt(arrayValues, func) {
-  const margin = 1.2;
-  return Math.round(margin * func(...arrayValues));
-}
-
-function vectorize(values) {
-  return new Vector(
-    values.map((val) => ({
-      label: null,
-      value: val
-    }))
-  );
-}
-
-function browserStateOf(md5sum, step, dimensions) {
+function browserStateOf(md5sum, step) {
   return (state) => {
-    // Will this be consistent?
-    const primaryOutputName = step.out[0];
+    console.log(step);
 
     let consignment = selectConsignment(state, md5sum);
 
-    if (!consignment) return {};
+    if (!consignment) return null;
 
-    let primaryConsignment = consignment[primaryOutputName];
-
-    if (!primaryConsignment) return {};
-    // Where can we get `plot` from?? -- possible to infer from
-    //   the consignment?
-    const x = primaryConsignment.col_names[0];
-    const y = primaryConsignment.col_names[1];
-    let xValues = primaryConsignment.rows.map((r) => r[0]);
-    let yValues = primaryConsignment.rows.map((r) => r[1]);
-    let plot = {
-      plot_type: 'xy',
-      configuration: {
-        layout: {
-          height: 400,
-          width: 600,
-          margin: {
-            bottom: 100,
-            left: 100,
-            top: 50,
-            right: 50
-          }
-        },
-        variables: {
-          x_label: x,
-          y_label: y,
-          x_min: Math.min(...xValues),
-          y_min: Math.min(...yValues),
-          x_max: Math.max(...xValues),
-          y_max: Math.max(...yValues)
-        },
-        xLabel: x,
-        yLabel: y,
-        plot_series: [
-          {
-            name: primaryOutputName,
-            series_type: 'scatter',
-            variables: {
-              x: x,
-              y: y
-            }
-          }
-        ],
-        access: 'view',
-        configuration: {
-          config: {}
-        }
-      }
-    };
-
-    let labels = primaryConsignment.row_names;
-
-    let data = {
-      xdomain: [padInt(xValues, Math.min), padInt(xValues, Math.max)],
-      ydomain: [padInt(yValues, Math.min), padInt(yValues, Math.max)],
-      plot_series: [
-        {
-          name: primaryOutputName,
-          series_type: 'scatter',
-          variables: {
-            x: vectorize(xValues),
-            y: vectorize(yValues),
-            label: vectorize(labels)
-          }
-        }
-      ]
-    };
-
-    return {plot, data};
+    return {consignment};
   };
 }

--- a/vulcan/lib/client/jsx/models/domain.js
+++ b/vulcan/lib/client/jsx/models/domain.js
@@ -1,0 +1,14 @@
+export default class Domain {
+  constructor(data) {
+    this.data = data;
+  }
+
+  get asArray() {
+    return [this.padInt(Math.min), this.padInt(Math.max)];
+  }
+
+  padInt(func) {
+    const margin = 1.2;
+    return Math.round(margin * func(...this.data));
+  }
+}

--- a/vulcan/lib/client/jsx/models/plot.js
+++ b/vulcan/lib/client/jsx/models/plot.js
@@ -1,0 +1,18 @@
+export default class Plot {
+  constructor(step, consignment, dimensions) {
+    this.step = step;
+    this.consignment = consignment;
+    this.dimensions = dimensions;
+
+    this.plotObj = {};
+    this.dataObj = {};
+  }
+
+  get plot() {
+    return this.plotObj;
+  }
+
+  get data() {
+    return this.dataObj;
+  }
+}

--- a/vulcan/lib/client/jsx/models/plot.js
+++ b/vulcan/lib/client/jsx/models/plot.js
@@ -1,8 +1,8 @@
 export default class Plot {
-  constructor(step, consignment, dimensions) {
+  constructor(step, consignment, parentWidth) {
     this.step = step;
     this.consignment = consignment;
-    this.dimensions = dimensions;
+    this.parentWidth = parentWidth;
 
     this.plotObj = {};
     this.dataObj = {};

--- a/vulcan/lib/client/jsx/models/series.js
+++ b/vulcan/lib/client/jsx/models/series.js
@@ -1,0 +1,53 @@
+// Series for the data object, not the plot definition
+import Vector from 'etna-js/plots/models/vector';
+
+export default class Series {
+  constructor() {
+    this.name = null;
+    this.type = null;
+    this.xValues = null;
+    this.yValues = null;
+    this.labels = null;
+  }
+
+  get asObj() {
+    return {
+      name: this.name,
+      series_type: this.type,
+      variables: {
+        x: this.vectorize(this.xValues),
+        y: this.vectorize(this.yValues),
+        label: this.vectorize(this.labels)
+      }
+    };
+  }
+
+  setName(name) {
+    this.name = name;
+  }
+
+  setType(type) {
+    this.type = type;
+  }
+
+  setXValues(xValues) {
+    this.xValues = xValues;
+  }
+
+  setYValues(yValues) {
+    this.yValues = yValues;
+  }
+
+  setLabels(labels) {
+    this.labels = labels;
+  }
+
+  vectorize(values) {
+    return new Vector(
+      values.map((val) => ({
+        label: null,
+        value: val
+      }))
+    );
+  }
+}

--- a/vulcan/lib/client/jsx/models/xy_plot.js
+++ b/vulcan/lib/client/jsx/models/xy_plot.js
@@ -1,14 +1,16 @@
+import XYPlot from 'etna-js/plots/components/xy_plot/xy_plot';
 import Plot from './plot';
 import Domain from './domain';
 import Series from './series';
 
 export default class XYPlotModel extends Plot {
-  constructor(step, consignment, dimensions) {
-    super(step, consignment, dimensions);
+  constructor(step, consignment, parentWidth) {
+    super(step, consignment, parentWidth);
     this.type = 'xy';
 
     this.plotObj = {
       plot_type: this.type,
+      component: XYPlot,
       configuration: {
         layout: {},
         variables: {
@@ -26,7 +28,8 @@ export default class XYPlotModel extends Plot {
         configuration: {
           config: {}
         }
-      }
+      },
+      parentWidth: this.parentWidth
     };
     this.dataObj = {
       xdomain: new Domain([0]).asArray,
@@ -138,8 +141,8 @@ export default class XYPlotModel extends Plot {
     // Calculate the plot layout given the dimensions
     //   of a parent container.
     this.plotObj.configuration.layout = {
-      height: Math.round((3 * this.dimensions.width) / 4),
-      width: this.dimensions.width,
+      height: Math.round((3 * this.parentWidth) / 4),
+      width: this.parentWidth,
       margin: {
         bottom: 100,
         left: 100,
@@ -148,7 +151,7 @@ export default class XYPlotModel extends Plot {
       }
     };
     console.log('here');
-    console.log(this.dimensions);
+    console.log(this.parentWidth);
     console.log(this.plotObj);
   }
 }

--- a/vulcan/lib/client/jsx/models/xy_plot.js
+++ b/vulcan/lib/client/jsx/models/xy_plot.js
@@ -44,6 +44,9 @@ export default class XYPlotModel extends Plot {
   }
 
   get validSeries() {
+    // Because we may have null series in the List,
+    //   we'll need to filter those out and only
+    //   use the "real" series.
     return this.series.filter((s) => null !== s);
   }
 
@@ -132,9 +135,7 @@ export default class XYPlotModel extends Plot {
     this.dataObj.xdomain = xDomain.asArray;
     this.dataObj.ydomain = yDomain.asArray;
 
-    this.validSeries.forEach((series) => {
-      this.dataObj.plot_series.push(series.asObj);
-    });
+    this.dataObj.plot_series = this.validSeries.map((s) => s.asObj);
   }
 
   calculateLayout() {
@@ -150,8 +151,5 @@ export default class XYPlotModel extends Plot {
         top: 100
       }
     };
-    console.log('here');
-    console.log(this.parentWidth);
-    console.log(this.plotObj);
   }
 }

--- a/vulcan/lib/client/jsx/models/xy_plot.js
+++ b/vulcan/lib/client/jsx/models/xy_plot.js
@@ -1,0 +1,154 @@
+import Plot from './plot';
+import Domain from './domain';
+import Series from './series';
+
+export default class XYPlotModel extends Plot {
+  constructor(step, consignment, dimensions) {
+    super(step, consignment, dimensions);
+    this.type = 'xy';
+
+    this.plotObj = {
+      plot_type: this.type,
+      configuration: {
+        layout: {},
+        variables: {
+          x_label: 'x', // ??
+          y_label: 'y', // ??
+          x_min: null,
+          y_min: null,
+          x_max: null,
+          y_max: null
+        },
+        xLabel: 'x', // ??
+        yLabel: 'y', // ??
+        plot_series: [], // I think this is only used to pull data out of the consignment
+        access: 'view',
+        configuration: {
+          config: {}
+        }
+      }
+    };
+    this.dataObj = {
+      xdomain: new Domain([0]).asArray,
+      ydomain: new Domain([0]).asArray,
+      plot_series: []
+    };
+
+    this.defineSeries();
+    this.calculatePlotObj();
+    this.calculateLayout();
+    this.calculateDataObj();
+  }
+
+  get validSeries() {
+    return this.series.filter((s) => null !== s);
+  }
+
+  get minsMaxes() {
+    // Calculate this across all series
+    let current = {
+      x_min: Math.min(), // Counterintuitively, returns Infinity
+      x_max: Math.max(), // Counterintuitively, returns -Infinity
+      y_min: Math.min(),
+      y_max: Math.max()
+    };
+    this.validSeries.forEach((series) => {
+      current.x_min = Math.min(...[...series.xValues, current.x_min]);
+      current.x_max = Math.max(...[...series.xValues, current.x_max]);
+      current.y_min = Math.min(...[...series.yValues, current.y_min]);
+      current.y_max = Math.max(...[...series.yValues, current.y_max]);
+    });
+    return current;
+  }
+
+  defineSeries() {
+    let seriesRegex = /^series(?<index>\d+)$/;
+    let groupRegex = /^group(?<index>\d+)$/;
+    let seriesTypeRegex = /^series(?<index>\d+)__type$/;
+
+    // Maximum number of series is # of inputs / 2,
+    //   since each step input needs at least series# and
+    //   series#__type.
+    let inputNames = Object.keys(this.step.in);
+    this.series = new Array(Math.round(inputNames.length / 2)).fill(null);
+
+    // First, let's get all the series names
+    //   and types set up.
+    inputNames.forEach((input) => {
+      let indexMatch;
+      let name;
+      let type;
+      let xValues;
+      let yValues;
+      let labels;
+      if (input.match(seriesRegex)) {
+        indexMatch = input.match(seriesRegex).groups.index;
+        name = this.step.in[input].split('/')[1];
+
+        let consignmentData = this.consignment[name];
+
+        if (consignmentData) {
+          xValues = consignmentData.rows.map((r) => r[0]);
+          yValues = consignmentData.rows.map((r) => r[1]);
+          labels = consignmentData.row_names;
+        }
+      } else if (input.match(groupRegex)) {
+        indexMatch = input.match(groupRegex).groups.index;
+        // Don't know how to add this in to the Series yet...
+      } else if (input.match(seriesTypeRegex)) {
+        indexMatch = input.match(seriesTypeRegex).groups.index;
+        type = this.step.in[input];
+      }
+
+      if (!indexMatch) return;
+
+      if (!this.series[indexMatch]) {
+        this.series[indexMatch] = new Series();
+      }
+
+      if (name) this.series[indexMatch].setName(name);
+      if (type) this.series[indexMatch].setType(type);
+      if (xValues) this.series[indexMatch].setXValues(xValues);
+      if (yValues) this.series[indexMatch].setYValues(yValues);
+      if (labels) this.series[indexMatch].setLabels(labels);
+    });
+  }
+
+  calculatePlotObj() {
+    this.plotObj.configuration.variables = {
+      ...this.plotObj.configuration.variables,
+      ...this.minsMaxes
+    };
+  }
+
+  calculateDataObj() {
+    let minMax = {...this.minsMaxes};
+    let xDomain = new Domain([minMax.x_min, minMax.x_max]);
+    let yDomain = new Domain([minMax.y_min, minMax.y_max]);
+
+    this.dataObj.xdomain = xDomain.asArray;
+    this.dataObj.ydomain = yDomain.asArray;
+
+    this.validSeries.forEach((series) => {
+      this.dataObj.plot_series.push(series.asObj);
+    });
+  }
+
+  calculateLayout() {
+    // Calculate the plot layout given the dimensions
+    //   of a parent container.
+    this.plotObj.configuration.layout = {
+      height: Math.round((3 * this.dimensions.width) / 4),
+      width: this.dimensions.width,
+      margin: {
+        bottom: 100,
+        left: 100,
+        right: 100,
+        top: 100
+      }
+    };
+    console.log('here');
+    console.log(this.dimensions);
+    console.log(this.plotObj);
+  }
+}

--- a/vulcan/lib/client/jsx/selectors/__tests__/workflow.spec.js
+++ b/vulcan/lib/client/jsx/selectors/__tests__/workflow.spec.js
@@ -1,0 +1,91 @@
+import XYPlot from 'etna-js/plots/components/xy_plot/xy_plot';
+
+import {plotDataForStep} from '../workflow_selector';
+
+describe('Workflow Selector', () => {
+  it('correctly returns plot and data for XY plot', () => {
+    const step = {
+      name: 'ui_plot',
+      run: 'xy.cwl',
+      in: {
+        series0: 'umap/umap_data',
+        group0: 'umap/expression_matrix',
+        series0__type: 'scatter',
+        series1: 'umap/pca_data',
+        series1__type: 'scatter'
+      },
+      out: []
+    };
+
+    const consignment = {
+      umap_data: {
+        rows: [
+          [1, 2],
+          [2, 1]
+        ],
+        num_rows: 2,
+        num_cols: 2,
+        col_names: ['x', 'y'],
+        row_names: ['test1', 'test2']
+      },
+      pca_data: {
+        rows: [
+          [-10, 22],
+          [24, 11]
+        ],
+        num_rows: 2,
+        num_cols: 2,
+        col_names: ['x', 'y'],
+        row_names: ['pca1', 'pca2']
+      },
+      expression_matrix: {
+        rows: [
+          [21.3, -40.2, 99.9],
+          [-100.1, 42.2, 74.21]
+        ],
+        num_rows: 2,
+        num_cols: 3,
+        col_names: ['gene1', 'gene2', 'gene3'],
+        row_names: ['test1', 'test2']
+      }
+    };
+
+    const parentWidth = 40;
+
+    let {plot, data} = plotDataForStep(step, consignment, parentWidth);
+
+    expect(plot.component).toEqual(XYPlot);
+    expect(plot.plot_type).toEqual('xy');
+
+    let {
+      configuration: {layout}
+    } = plot;
+
+    expect(layout.width).toEqual(parentWidth);
+    expect(layout.height).toEqual(30);
+
+    expect(data.plot_series.length).toEqual(2);
+
+    expect(data.plot_series.map((s) => s.name)).toEqual([
+      'umap_data',
+      'pca_data'
+    ]);
+    expect(data.plot_series.map((s) => s.series_type)).toEqual([
+      'scatter',
+      'scatter'
+    ]);
+
+    expect(data.plot_series[0].variables.x.values).toEqual([1, 2]);
+    expect(data.plot_series[0].variables.y.values).toEqual([2, 1]);
+    expect(data.plot_series[0].variables.label.values).toEqual([
+      'test1',
+      'test2'
+    ]);
+    expect(data.plot_series[1].variables.x.values).toEqual([-10, 24]);
+    expect(data.plot_series[1].variables.y.values).toEqual([22, 11]);
+    expect(data.plot_series[1].variables.label.values).toEqual([
+      'pca1',
+      'pca2'
+    ]);
+  });
+});

--- a/vulcan/lib/client/jsx/selectors/workflow_selector.js
+++ b/vulcan/lib/client/jsx/selectors/workflow_selector.js
@@ -12,3 +12,17 @@ export const stepOutputs = (workflow, pathIndex, stepIndex) => {
 
   return workflow.steps[pathIndex][stepIndex].out;
 };
+
+export const plotDataForStep = (step, consignment) => {
+  // Take a consignment and step, and generate
+  //   the plot config and data objects
+  //   needed to generate a plot.
+  // This should mostly be reverse-engineering the
+  //   series, data, and label values from the step +
+  //   consignment.
+};
+
+export const plotLayout = (plot, dimensions) => {
+  // Calculate the plot layout given the dimensions
+  //   of a parent container.
+};

--- a/vulcan/lib/client/jsx/selectors/workflow_selector.js
+++ b/vulcan/lib/client/jsx/selectors/workflow_selector.js
@@ -1,3 +1,5 @@
+import XYPlotModel from '../models/xy_plot';
+
 export const stepDataUrls = ({workflow, pathIndex, stepIndex}) => {
   return workflow.steps[pathIndex][stepIndex].out.map((s) => s.data_url);
 };
@@ -13,16 +15,28 @@ export const stepOutputs = (workflow, pathIndex, stepIndex) => {
   return workflow.steps[pathIndex][stepIndex].out;
 };
 
-export const plotDataForStep = (step, consignment) => {
+const plotType = (step) => {
+  return step.run.replace(/\.cwl/g, '');
+};
+
+export const plotDataForStep = (step, consignment, dimensions) => {
   // Take a consignment and step, and generate
   //   the plot config and data objects
   //   needed to generate a plot.
   // This should mostly be reverse-engineering the
   //   series, data, and label values from the step +
   //   consignment.
-};
+  const type = plotType(step);
 
-export const plotLayout = (plot, dimensions) => {
-  // Calculate the plot layout given the dimensions
-  //   of a parent container.
+  let plot;
+  if ('xy' === type) {
+    plot = new XYPlotModel(step, consignment, dimensions);
+  }
+
+  if (!plot) return null;
+
+  return {
+    plot: plot.plot,
+    data: plot.data
+  };
 };

--- a/vulcan/lib/client/jsx/selectors/workflow_selector.js
+++ b/vulcan/lib/client/jsx/selectors/workflow_selector.js
@@ -19,7 +19,7 @@ const plotType = (step) => {
   return step.run.replace(/\.cwl/g, '');
 };
 
-export const plotDataForStep = (step, consignment, dimensions) => {
+export const plotDataForStep = (step, consignment, parentWidth) => {
   // Take a consignment and step, and generate
   //   the plot config and data objects
   //   needed to generate a plot.
@@ -30,7 +30,7 @@ export const plotDataForStep = (step, consignment, dimensions) => {
 
   let plot;
   if ('xy' === type) {
-    plot = new XYPlotModel(step, consignment, dimensions);
+    plot = new XYPlotModel(step, consignment, parentWidth);
   }
 
   if (!plot) return null;


### PR DESCRIPTION
This PR is my initial attempt to mimic the work done in the old PlotConfig / PlotScript classes, except from the standpoint of CWL steps. Because there isn't an explicit user-definition of variables for each series as in the Timur plotting model, we infer or calculate the series information from the consignment itself and some user-defined series data in the CWL. Similarly, layout is calculated from the rendered components.

I'm not sure if these models are too tightly coupled to the UMAP example we're working through...

