### PR TITLE
also include active record

### DIFF
--- a/magma/Gemfile
+++ b/magma/Gemfile
@@ -9,6 +9,7 @@ gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/arti
 gem 'pg'
 gem 'sequel', '5.28.0'
 gem 'mini_magick'
+gem 'activerecord'
 gem 'activesupport', '>= 4.2.6'
 gem 'spreadsheet'
 gem 'puma', '5.0.2'

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -13,6 +13,11 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    activemodel (6.1.0)
+      activesupport (= 6.1.0)
+    activerecord (6.1.0)
+      activemodel (= 6.1.0)
+      activesupport (= 6.1.0)
     activesupport (6.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -100,6 +105,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord
   activesupport (>= 4.2.6)
   curb
   database_cleaner (= 1.8.0)

--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -1,4 +1,5 @@
 require 'sequel'
+require 'active_record'
 require 'active_support'
 require "active_support/core_ext/class/subclasses"
 


### PR DESCRIPTION
Seems like Magma also has a dependency on ActiveRecord that needs to be explicitly declared now that we took out carrierwave.

This seems to work okay with Timur, so should solve @Gvaihir 's problem that he identified yesterday.