### PR TITLE
Vulcan now returns a linear, serialized path as the first result

### DIFF
--- a/docker/etna-apache/bin/httpd_with_shibd.sh
+++ b/docker/etna-apache/bin/httpd_with_shibd.sh
@@ -3,5 +3,5 @@
 set -e
 
 /etc/init.d/shibd start
-httpd -DFOREGROUND
+exec httpd -DFOREGROUND
 

--- a/etna/lib/etna/directed_graph.rb
+++ b/etna/lib/etna/directed_graph.rb
@@ -18,6 +18,35 @@ class DirectedGraph
     parents[parent] = parent_parents
   end
 
+  def serialized_path_from(root)
+    seen = Set.new
+    [].tap do |result|
+      result << root
+      seen.add(root)
+      path_q = paths_from(root)
+
+      until path_q.empty?
+        next_path = path_q.shift
+        next if next_path.nil?
+
+        until next_path.empty?
+          next_n = next_path.shift
+          next if next_n.nil?
+          next if seen.include?(next_n)
+
+          if @parents[next_n].keys.any? { |p| !seen.include?(p) }
+            next_path.unshift(next_n)
+            path_q.push(next_path)
+            break
+          else
+            result << next_n
+            seen.add(next_n)
+          end
+        end
+      end
+    end
+  end
+
   def paths_from(root)
     [].tap do |result|
       parents_of_map = descendants(root)

--- a/etna/spec/directed_graph_spec.rb
+++ b/etna/spec/directed_graph_spec.rb
@@ -41,4 +41,24 @@ describe DirectedGraph do
       end
     end
   end
+
+  describe '#serialized_path_from' do
+    it 'generates a linear serialization of convergent and divergent paths' do
+      graph = DirectedGraph.new
+      graph.add_connection('a', 'b')
+      graph.add_connection('a', 'c')
+      graph.add_connection('c', 'd')
+      graph.add_connection('b', 'd')
+      graph.add_connection('d', 'e')
+      graph.add_connection('d', 'f')
+      graph.add_connection('e', 'g')
+      graph.add_connection('f', 'g')
+      graph.add_connection('g', 'h')
+      graph.add_connection('g', 'i')
+
+      expect(graph.serialized_path_from('a')).to eql([
+          "a", "c", "b", "d", "f", "e", "g", "h", "i"
+      ])
+    end
+  end
 end

--- a/vulcan/lib/orchestration.rb
+++ b/vulcan/lib/orchestration.rb
@@ -133,8 +133,15 @@ class Vulcan
     end
 
     # Returns a list of lists, describing the dependency between steps, primary inputs, and primary outputs.
-    # Each inner list is a unique path in side of the workflow starting a primary_inputs and terminating
-    # at either a primary_output or a step that is not used as an input the workflow
+    # The first inner list is a serialized path traversing all nodes in a strictly linear fashion.
+    # Note that this ordering is NOT Guaranteed to be the execution order; tasks that exist on divergent paths
+    # might be run in parallel, and thus may complete in a non deterministic ordering.  But this serialized
+    # ordering will, nonetheless, occur in an order such that an strict dependency is always before
+    # convergent nodes.
+    # After the first inner list, each other inner list is a unique path in side of the workflow starting
+    # a primary_inputs and terminating at either a primary_output or a step that is not used as an input the workflow
+    # Each path represents a potential divergent -> convergent ordering that has strict execution ordering.  The
+    # first node and last node of each of these paths _may_ be shared with other paths as part of convergence.
     def self.unique_paths(workflow)
       directed_graph = ::DirectedGraph.new
 
@@ -148,7 +155,7 @@ class Vulcan
         directed_graph.add_connection(output.outputSource.first, :primary_outputs)
       end
 
-      directed_graph.paths_from(:primary_inputs)
+      [ directed_graph.serialized_path_from(:primary_inputs) ] + directed_graph.paths_from(:primary_inputs)
     end
 
     def unique_paths

--- a/vulcan/spec/orchestration_spec.rb
+++ b/vulcan/spec/orchestration_spec.rb
@@ -43,8 +43,9 @@ describe Vulcan::Orchestration do
   describe '#unique_paths' do
     it 'works' do
       expect(unique_paths).to eql([
+          [:primary_inputs, "firstAdd", "pickANum", "finalStep", :primary_outputs],
           [:primary_inputs, "firstAdd", "finalStep", :primary_outputs],
-          [:primary_inputs, "firstAdd", "pickANum", "finalStep"]
+          [:primary_inputs, "firstAdd", "pickANum", "finalStep"],
       ])
     end
   end
@@ -55,6 +56,7 @@ describe Vulcan::Orchestration do
         orchestration.load_json_inputs!(storage)
 
         expect(should_builds).to eql([
+            [false, false, false, false, false],
             [false, false, false, false],
             [false, false, false, false],
         ])
@@ -65,6 +67,7 @@ describe Vulcan::Orchestration do
         orchestration.load_json_inputs!(storage)
 
         expect(should_builds).to eql([
+            [true, false, false, false, false],
             [true, false, false, false],
             [true, false, false, false],
         ])
@@ -77,6 +80,7 @@ describe Vulcan::Orchestration do
         orchestration.run!(storage: storage, build_target: next_buildable)
 
         expect(should_builds).to eql([
+            [false, true, false, false, false],
             [false, true, false, false],
             [false, true, false, false],
         ])
@@ -90,6 +94,7 @@ describe Vulcan::Orchestration do
         prev_cell_hashes = cell_hashes
         session.define_user_input([:primary_inputs, "someIntWithoutDefault"], 123)
         expect(cell_hashes_same(prev_cell_hashes)).to eql([
+            [false, false, false, false, false],
             [false, false, false, false],
             [false, false, false, false]
         ])
@@ -98,6 +103,7 @@ describe Vulcan::Orchestration do
         # does not work.
         prev_cell_hashes = cell_hashes
         expect(cell_hashes_same(prev_cell_hashes)).to eql([
+            [true, true, true, true, true],
             [true, true, true, true],
             [true, true, true, true]
         ])
@@ -105,6 +111,7 @@ describe Vulcan::Orchestration do
         prev_cell_hashes = cell_hashes
         session.define_user_input(["primary_inputs", "notARealInput"], 123)
         expect(cell_hashes_same(prev_cell_hashes)).to eql([
+            [true, true, true, true, true],
             [true, true, true, true],
             [true, true, true, true]
         ])
@@ -112,6 +119,7 @@ describe Vulcan::Orchestration do
         prev_cell_hashes = cell_hashes
         session.define_user_input([:primary_inputs, "alsoNotAnInput"], 123)
         expect(cell_hashes_same(prev_cell_hashes)).to eql([
+            [true, true, true, true, true],
             [true, true, true, true],
             [true, true, true, true]
         ])
@@ -120,6 +128,7 @@ describe Vulcan::Orchestration do
         prev_cell_hashes = cell_hashes
         session.define_user_input(["pickANum", "num"], 543)
         expect(cell_hashes_same(prev_cell_hashes)).to eql([
+            [true, true, false, false, false],
             [true, true, false, false],
             [true, true, false, false]
         ])

--- a/vulcan/spec/session_spec.rb
+++ b/vulcan/spec/session_spec.rb
@@ -72,6 +72,11 @@ describe SessionsController do
       expect(last_json_response['status']).to eql([
           [
               {'downloads' => nil, 'name' => 'firstAdd', 'status' => 'pending'},
+              {'downloads' => nil, 'name' => 'pickANum', 'status' => 'pending'},
+              {'downloads' => nil, 'name' => 'finalStep', 'status' => 'pending'},
+          ],
+          [
+              {'downloads' => nil, 'name' => 'firstAdd', 'status' => 'pending'},
               {'downloads' => nil, 'name' => 'finalStep', 'status' => 'pending'},
           ],
           [
@@ -102,12 +107,12 @@ describe SessionsController do
       response = last_json_response
 
       expect(response['session']['inputs']).to eql(inputs)
-      check_url_for(response['status'].first[0]['downloads']['sum'], orchestration.build_target_for('firstAdd').build_outputs['sum'])
-      check_url_for(response['status'].first[1]['downloads']['sum'], orchestration.build_target_for('finalStep').build_outputs['sum'])
-
       check_url_for(response['status'][1][0]['downloads']['sum'], orchestration.build_target_for('firstAdd').build_outputs['sum'])
-      check_url_for(response['status'][1][1]['downloads']['num'], orchestration.build_target_for('pickANum').build_outputs['num'])
-      check_url_for(response['status'][1][2]['downloads']['sum'], orchestration.build_target_for('finalStep').build_outputs['sum'])
+      check_url_for(response['status'][1][1]['downloads']['sum'], orchestration.build_target_for('finalStep').build_outputs['sum'])
+
+      check_url_for(response['status'][2][0]['downloads']['sum'], orchestration.build_target_for('firstAdd').build_outputs['sum'])
+      check_url_for(response['status'][2][1]['downloads']['num'], orchestration.build_target_for('pickANum').build_outputs['num'])
+      check_url_for(response['status'][2][2]['downloads']['sum'], orchestration.build_target_for('finalStep').build_outputs['sum'])
 
       check_url_for(response['outputs']['downloads']['the_result'],
           orchestration.build_target_for(:primary_outputs).build_outputs['the_result'])

--- a/vulcan/spec/workflows_spec.rb
+++ b/vulcan/spec/workflows_spec.rb
@@ -54,6 +54,31 @@ describe WorkflowsController do
           [
               {
                   "in" => [{"id"=>"a", "source"=>["primary_inputs", "someInt"]},
+                      {"id"=>"b", "source"=>["primary_inputs", "someIntWithoutDefault"]}],
+                  "label"=>nil,
+                  "out" => ["sum"],
+                  "name" => "firstAdd",
+                  "run" => "scripts/add.cwl",
+              },
+              {
+                  "in" => [{"id"=>"num", "source"=>["firstAdd", "sum"]}],
+                  "label"=>nil,
+                  "out" => ["num"],
+                  "name" => "pickANum",
+                  "run" => "ui-queries/pick-a-number.cwl",
+              },
+              {
+                  "in" => [{"id"=>"a", "source"=>["firstAdd", "sum"]},
+                      {"id"=>"b", "source"=>["pickANum", "num"]}],
+                  "label"=>nil,
+                  "out" => ["sum"],
+                  "name" => "finalStep",
+                  "run" => "scripts/add.cwl",
+              },
+          ],
+          [
+              {
+                  "in" => [{"id"=>"a", "source"=>["primary_inputs", "someInt"]},
                            {"id"=>"b", "source"=>["primary_inputs", "someIntWithoutDefault"]}],
                   "label"=>nil,
                   "out" => ["sum"],


### PR DESCRIPTION
As per @coleshaw request, vulcan now returns, as the first path in workflows and sessions output, a single linear path that traverses all nodes in one ordering that ensures all dependencies occur before and convergent graph points.  Worth noting, in the future when we have async processes, there is no guarantee that downloads are available in a strictly linear fashion -- divergent paths will execute in a non deterministic order and thus this 'flattened' graph cannot plan for the true ordering.

However, it is sufficient, for the sake of gathering  input from the user in a linear fashion, to find the longest path where all previous steps are complete, to 'estimate' the progress of divergent parallel paths.