### PR TITLE
Remove list styling in Metis drop-down menus

### DIFF
--- a/metis/lib/client/css/list/menu-control.scss
+++ b/metis/lib/client/css/list/menu-control.scss
@@ -26,6 +26,7 @@
     z-index: 2000;
     padding: 5px;
     background: white;
+    list-style-type: none;
 
     &.up {
       top: 22px;


### PR DESCRIPTION
This PR fixes the metis file / folder drop-down list styling. When deploying #254, I noticed that the styling on the Metis drop-down lists had reverted somehow (they were showing the bullet icons). This removes those bullets.