### PR TITLE
Bake magby into archimedes image.

### DIFF
--- a/archimedes/docker-compose.yml
+++ b/archimedes/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - archimedes-pycharm-opt:/opt/.pycharm_helpers
       - archimedes-exec:/archimedes-exec
       - ../vulcan/lib/server/workflows/scripts:/app/vulcan_scripts
-      - ../etna/packages/magby/magby:/app/magby/
+      - ../etna/packages/magby/:/magby/
     environment:
       HOST_DIR: $PWD
     entrypoint: /entrypoints/development.sh

--- a/archimedes/poetry.lock
+++ b/archimedes/poetry.lock
@@ -63,6 +63,31 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
+name = "betamax"
+version = "0.8.1"
+description = "A VCR imitation for python-requests"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=2.0"
+
+[[package]]
+name = "betamax-serializers"
+version = "0.2.1"
+description = "A set of third-party serializers for Betamax"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+betamax = ">=0.3.2"
+
+[package.extras]
+yaml11 = ["pyyaml"]
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -311,6 +336,25 @@ description = "lightweight wrapper around basic LLVM functionality"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "magby"
+version = "0.0.1"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.6"
+develop = false
+
+[package.dependencies]
+betamax = "*"
+betamax_serializers = "*"
+pandas = "*"
+requests = "*"
+
+[package.source]
+type = "directory"
+url = "../magby"
 
 [[package]]
 name = "markupsafe"
@@ -648,17 +692,6 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
-name = "retrying"
-version = "1.3.3"
-description = "Retrying"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = ">=1.7.0"
-
-[[package]]
 name = "rpy2"
 version = "3.4.2"
 description = "Python interface to the R language (embedded R)"
@@ -966,7 +999,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b2e9d9475b4fef03942538c8410983e1cd83617cfaa7403b776bec600581eca4"
+content-hash = "066f56cf9677e6317045140cd4728ea76a2d06c1573842195e14af3f75fb7f97"
 
 [metadata.files]
 anndata = [
@@ -988,6 +1021,14 @@ atomicwrites = [
 attrs = [
     {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+betamax = [
+    {file = "betamax-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa5ad34cc8d018b35814fb0557d15c78ced9ac56fdc43ccacdb882aa7a5217c1"},
+    {file = "betamax-0.8.1.tar.gz", hash = "sha256:5bf004ceffccae881213fb722f34517166b84a34919b92ffc14d1dbd050b71c2"},
+]
+betamax-serializers = [
+    {file = "betamax-serializers-0.2.1.tar.gz", hash = "sha256:345c419b1b73171f2951c62ac3c701775ac4b76e13e86464ebf0ff2a978e4949"},
+    {file = "betamax_serializers-0.2.1-py2.py3-none-any.whl", hash = "sha256:1b23c46429c40a8873682854c88d805c787c72d252f3fa0c858e9c300682ceac"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -1184,6 +1225,7 @@ llvmlite = [
     {file = "llvmlite-0.34.0-cp38-cp38-win_amd64.whl", hash = "sha256:964f8f7a2184963cb3617d057c2382575953e488b7bb061b632ee014cfef110a"},
     {file = "llvmlite-0.34.0.tar.gz", hash = "sha256:f03ee0d19bca8f2fe922bb424a909d05c28411983b0c2bc58b020032a0d11f63"},
 ]
+magby = []
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
     {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
@@ -1556,9 +1598,6 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
-]
-retrying = [
-    {file = "retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"},
 ]
 rpy2 = [
     {file = "rpy2-3.4.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:dd2d1e9b4733a449f5c48e2f1da165bf77bc33c43ffcf9dacf051c6eb9a417d7"},

--- a/archimedes/pyproject.toml
+++ b/archimedes/pyproject.toml
@@ -17,6 +17,7 @@ black = "^20.8b1"
 docker = "^4.4.1"
 dataclasses-json = "^0.5.2"
 scanpy = "^1.7.0"
+magby = {path = "../magby"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/docker/archimedes-base/Dockerfile
+++ b/docker/archimedes-base/Dockerfile
@@ -65,4 +65,5 @@ RUN mv /tmp/docker/* /usr/local/bin/
 
 # Copy entrypoint scripts
 COPY src/entrypoints /entrypoints
+COPY magby /magby
 

--- a/docker/archimedes-base/Makefile
+++ b/docker/archimedes-base/Makefile
@@ -3,5 +3,5 @@ baseTag:=$(shell basename "$$(pwd)")
 fullTag:=$(IMAGES_PREFIX)$(baseTag)$(IMAGES_POSTFIX)
 
 image:
-	../build_image Dockerfile $(CERTS)
+	../build_image Dockerfile $(CERTS) ../../etna/packages/magby
 	if [ -n "$$PUSH_IMAGES" ]; then docker push $(fullTag); fi

--- a/vulcan/config.yml.template
+++ b/vulcan/config.yml.template
@@ -25,7 +25,6 @@ default: &default
   :token_name: JANUS_DEV_TOKEN
   :log_level: info
   :archimedes_run_image: etnaagent/archimedes
-  :archimedes_image:     etnaagent/archimedes
   :archimedes_exec_volume: archimedes-exec
   :log_file: /dev/stdout
   :rsa_public: |
@@ -56,7 +55,6 @@ default: &default
   :data_folder: /app/spec/data
   :workflows_folder: /app/spec/fixtures
   :archimedes_run_image: etnaagent/archimedes
-  :archimedes_image:     etnaagent/archimedes
   :log_file: /dev/stdout
   :log_level: info
   :archimedes_exec_volume: archimedes-exec

--- a/vulcan/lib/orchestration.rb
+++ b/vulcan/lib/orchestration.rb
@@ -67,6 +67,7 @@ class Vulcan
       :development == Vulcan.instance.environment
     end
 
+    # Will go away when we get hmacs for inter service.
     def dev_options
       [
         "--network=monoetna_edge_net",
@@ -86,8 +87,6 @@ class Vulcan
           "-v",
           "/var/run/docker.sock:/var/run/docker.sock:ro",
           "-v",
-          "/etna/packages/magby/magby/:/app/magby/:ro",
-          "-v",
           "#{Vulcan.instance.config(:archimedes_exec_volume)}:/archimedes-exec",
           Vulcan.instance.config(:archimedes_run_image),
           "poetry",
@@ -95,12 +94,11 @@ class Vulcan
           "archimedes-run",
           "--isolator=docker"
       ] + (is_dev? ? dev_options : []) + [
-          "--local-package=#{local_package_path('magby', '/app/../etna/packages/magby/magby/')}",
           "-e",
           "MAGMA_HOST=#{Vulcan.instance.config(:magma)&.dig(:host)}",
           "-e",
           "TOKEN=#{token}",
-          "--image=" + Vulcan.instance.config(:archimedes_image),
+          "--image=" + Vulcan.instance.config(:archimedes_run_image),
       ] + output_files.map do |sf|
         "--output=#{sf.to_archimedes_storage_file(storage)}"
       end + input_files.map do |sf|


### PR DESCRIPTION
Simplification by building magby into the archimedes image directly.  Future other libraries can also be included in a similar fashion.  This ensures no struggling with extra mounts.