### PR TITLE
trying to fix rbuf_fill error

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.30'
+  spec.version           = '0.1.31'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/etna/client.rb
+++ b/etna/lib/etna/client.rb
@@ -165,6 +165,7 @@ module Etna
           OpenSSL::SSL::VERIFY_NONE :
           OpenSSL::SSL::VERIFY_PEER
         Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode) do |http|
+          http.use_ssl = true
           http.request(data) do |response|
             status_check!(response)
             yield response
@@ -175,6 +176,7 @@ module Etna
           OpenSSL::SSL::VERIFY_NONE :
           OpenSSL::SSL::VERIFY_PEER
         Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode) do |http|
+          http.use_ssl = true
           response = http.request(data)
           status_check!(response)
           return response


### PR DESCRIPTION
When using the etna gem against REDCap, we occassionally run into this exception:

```
2.7.2/lib/ruby/2.7.0/net/protocol.rb:225:in `rbuf_fill’: end of file reached (EOFError)
```

Unsure if it's related to [this post](https://stackoverflow.com/a/9227933), so trying to re-explicitly set the `use_ssl` flag to `true` and see if it re-occurs.

I'm unsure if the issue is also just a long connection with REDCap itself causes this, i.e. the form is huge or there are many forms, so the connection from the gem to polyphemus somehow dies? I did see this error as well when we were using net-http-persistent, but that shouldn'thave been purged everywhere...

