### PR TITLE
Upgrade puma, do not query all attributes from polyphemus job.

### DIFF
--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -8,7 +8,7 @@ gem 'pg'
 gem 'sequel'
 gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/c953534aeaeb22cccf0f3004ed7b21d4d73d7686'
 gem 'jwt'
-gem 'puma', '5.0.2'
+gem 'puma', '>=5.0.2'
 gem 'concurrent-ruby'
 
 group :test do

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     multipart-post (2.1.1)
-    nio4r (2.5.5)
+    nio4r (2.5.7)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -47,7 +47,7 @@ GEM
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    puma (5.0.2)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -94,7 +94,7 @@ DEPENDENCIES
   jwt
   pg
   pry
-  puma (= 5.0.2)
+  puma (>= 5.0.2)
   rack
   rack-test
   rack-throttle
@@ -107,4 +107,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.2.11
+   2.2.13

--- a/magma/Gemfile
+++ b/magma/Gemfile
@@ -12,7 +12,7 @@ gem 'mini_magick'
 gem 'activerecord'
 gem 'activesupport', '>= 4.2.6'
 gem 'spreadsheet'
-gem 'puma', '5.0.2'
+gem 'puma', '>=5.0.2'
 gem 'curb' # used by ipi project.
 gem 'concurrent-ruby'
 

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -69,7 +69,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.2)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -127,7 +127,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (= 5.0.2)
+  puma (>= 5.0.2)
   rack-test
   rspec
   sequel (= 5.28.0)
@@ -140,4 +140,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.2.11
+   2.2.13

--- a/metis/Gemfile
+++ b/metis/Gemfile
@@ -6,7 +6,7 @@ gem 'rack'
 gem 'pg'
 gem 'sequel'
 gem 'fog-aws'
-gem 'puma', '5.0.2'
+gem 'puma', '>=5.0.2'
 gem 'etna', path: '/etna'
 gem 'concurrent-ruby'
 

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     minitest (5.14.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -81,7 +81,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.2)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -131,7 +131,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (= 5.0.2)
+  puma (>= 5.0.2)
   rack
   rack-test
   rspec

--- a/polyphemus/Gemfile
+++ b/polyphemus/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rack'
 gem 'sequel'
 gem 'pg'
-gem 'puma', '5.0.2'
+gem 'puma', '>=5.0.2'
 gem 'etna', git: 'https://github.com/mountetna/monoetna.git', branch: 'refs/artifacts/gem-etna/c953534aeaeb22cccf0f3004ed7b21d4d73d7686'
 gem 'actionpack' # For streaming the job controller results back...
 gem 'aspera-cli'

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     minitest (5.14.2)
     multipart-post (2.1.1)
     net-ssh (4.2.0)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -89,7 +89,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.2)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -153,7 +153,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (= 5.0.2)
+  puma (>= 5.0.2)
   rack
   rack-test
   rspec
@@ -163,4 +163,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.11
+   2.2.13

--- a/polyphemus/lib/commands.rb
+++ b/polyphemus/lib/commands.rb
@@ -213,7 +213,7 @@ class Polyphemus
     def execute
       request = Etna::Clients::Magma::RetrievalRequest.new(project_name: project)
       request.model_name = 'patient'
-      request.attribute_names = 'all'
+      request.attribute_names = ['name', 'consent', 'restricted']
       request.record_names = 'all'
       patient_documents = magma_client.retrieve(request).models.model('patient').documents
 

--- a/polyphemus/spec/spec_helper.rb
+++ b/polyphemus/spec/spec_helper.rb
@@ -141,7 +141,7 @@ end
 def stub_magma_setup(patient_documents)
   stub_request(:post, "#{MAGMA_HOST}/retrieve")
     .with(body: hash_including({ project_name: 'mvir1', model_name: 'patient',
-                                attribute_names: 'all', record_names: 'all' }))
+                                attribute_names: ['name', 'consent', 'restricted'], record_names: 'all' }))
     .to_return({ body: {
         'models': { 'patient': { 'documents': patient_documents } }
     }.to_json })

--- a/timur/Gemfile
+++ b/timur/Gemfile
@@ -13,7 +13,7 @@ gem 'pg', '~> 0.21'
 # provides database models
 gem 'sequel', '4.49.0'
 
-gem 'puma', '5.0.2'
+gem 'puma', '>=5.0.2'
 gem 'concurrent-ruby'
 
 group :development, :test do

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.2)
     multipart-post (2.1.1)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -58,7 +58,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.0.2)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -109,7 +109,7 @@ DEPENDENCIES
   pg (~> 0.21)
   pry
   pry-byebug
-  puma (= 5.0.2)
+  puma (>= 5.0.2)
   rack-test
   rltk
   rspec
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.11
+   2.2.13


### PR DESCRIPTION
This should, at the very least, make the issue go away for now.  Figuring out why certain queries cause the ruby process to spin out is important, but it will take some more instrumentation to narrow down.  For now, I just want the existing parts to work better.