### PR TITLE
Better handling of the problematic project_path configuration, which …

### DIFF
--- a/docker/archimedes-base/entrypoints/build.sh
+++ b/docker/archimedes-base/entrypoints/build.sh
@@ -14,7 +14,9 @@ fi
 
 if [ -e /app/build ]; then
   for hook in /app/build/*; do
-    [ -x "$hook" ] && $hook
+    if stat -c  %A $hook | grep x &>/dev/null; then
+      $hook
+    fi
   done
 fi
 

--- a/docker/etna-base-dev/entrypoints/build.sh
+++ b/docker/etna-base-dev/entrypoints/build.sh
@@ -36,7 +36,9 @@ rm -rf /usr/opt/httpd.conf.d/*.include
 
 if [ -e /app/build ]; then
   for hook in /app/build/*; do
-    [ -x "$hook" ] && $hook
+    if stat -c  %A $hook | grep x &>/dev/null; then
+      $hook
+    fi
   done
 fi
 

--- a/docker/etna-base-dev/entrypoints/build.sh
+++ b/docker/etna-base-dev/entrypoints/build.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+
 set -e
+
 #if [ -n "$VERBOSE" ]; then
   set -x
 #fi
+
 # Default directories
 mkdir -p /app/tmp/pids
 mkdir -p /app/public/js
@@ -11,21 +14,26 @@ mkdir -p /app/public/images
 mkdir -p /app/log
 mkdir -p /app/vendor/bundle
 mkdir -p /app/data/
+
 shopt -s globstar
+
 if [ -z "$SKIP_RUBY_SETUP" ]; then
   bundle install -j "$(nproc)"
 fi
+
 if [ -n "$RUN_NPM_INSTALL" ]; then
   # The images tend to build as root, which for host systems is unsafe,
   # but in containers is fine.
   npm install --unsafe-perm
 fi
+
 # Prepare the httpd conf hooks.  These are shared from the app images to the app_fe image.
 # This allows individual apps to package their frontend configuration but run them
 # as a separate docker container.
 mkdir -p /usr/opt/httpd.conf.d
 echo "@app_name = '${APP_NAME}'" > /usr/opt/vars.rb
 rm -rf /usr/opt/httpd.conf.d/*.include
+
 if [ -e /app/build ]; then
   for hook in /app/build/*; do
     if stat -c  %A $hook | grep x &>/dev/null; then
@@ -33,3 +41,23 @@ if [ -e /app/build ]; then
     fi
   done
 fi
+
+# Not all apache directives support environment variable interpolation, so the best way to hook in
+# certain per app variables is via a template.
+erb -r /usr/opt/vars.rb -- /opt/fe.conf.erb > /usr/opt/httpd.conf.d/main.conf
+
+if ! [ -e config.yml ] && [ -e config.yml.template ]; then
+  cp config.yml.template config.yml
+fi
+
+if [ -n "$RELEASE_TEST" ]; then
+  # TODO: Find a better test harness for this.  In release tests, let's also ensure that in the resulting
+  # setup, the app_fe comes up successfully.
+  dockerize -wait tcp://${APP_NAME}_app_fe:80 -timeout 300s
+fi
+
+echo 'for file in /app/*.completion; do source $file || true; done' >> /root/.bashrc
+echo 'export PATH="/app/bin:$PATH"' >> /root/.bashrc
+# Allow other users to use the root bash setup
+
+chmod -R 744 /root

--- a/magma/lib/magma/commands.rb
+++ b/magma/lib/magma/commands.rb
@@ -72,8 +72,23 @@ class Magma
       Sequel.extension(:migration)
       db = Magma.instance.db
 
-      Magma.instance.config(:project_path).split(/\s+/).each do |project_dir|
+      project_path = Magma.instance.config(:project_path)
+      project_paths = project_path&.split(/\s+/) || []
+      project_paths = project_paths.select { |p| !p.nil? && !p.empty? }
+
+      project_paths.each do |project_dir|
         table = "schema_info_#{project_dir.gsub(/[^\w]+/,'_').sub(/^_/,'').sub(/_$/,'')}"
+
+        unless ::File.exists?(File.join(path, 'migrations'))
+          if Magma.instance.environment == :development || Magma.instance.environment == :test
+            puts "Project #{project_dir} is listed in your config.yml, but it does not exist in your magma directory.  Ignoring.."
+          else
+            raise "Project #{project_dir} does not exist in the magma app directory, perhaps it is not checked out."
+          end
+
+          next
+        end
+
         if version
           puts "Migrating to version #{version}"
           Sequel::Migrator.run(db, File.join(project_dir, 'migrations'), table: table, target: version.to_i)

--- a/magma/lib/magma/commands.rb
+++ b/magma/lib/magma/commands.rb
@@ -79,7 +79,7 @@ class Magma
       project_paths.each do |project_dir|
         table = "schema_info_#{project_dir.gsub(/[^\w]+/,'_').sub(/^_/,'').sub(/_$/,'')}"
 
-        unless ::File.exists?(File.join(path, 'migrations'))
+        unless ::File.exists?(File.join(project_dir, 'migrations'))
           if Magma.instance.environment == :development || Magma.instance.environment == :test
             puts "Project #{project_dir} is listed in your config.yml, but it does not exist in your magma directory.  Ignoring.."
           else


### PR DESCRIPTION
…will eventually be deprecated anyways.

@dtm2451 Is experiencing lots of issues with this, even though he doesn't even use the ipi project in development.

1.  Provide better messaging which project_path points to a wrong directory
2.  Provide better handling when project_path is empty or nil
3.  Ignore project paths that do not exist in development with a warning message, as mostly that is probably a copy over from the config.yml.template which not all users have access to the original project repos and because all of this will go away once I complete moving to database backed models, it's just easier to do this and not be blocked over and over on it.