### PR TITLE
Add super viewer editor

### DIFF
--- a/etna/lib/etna/user.rb
+++ b/etna/lib/etna/user.rb
@@ -58,12 +58,20 @@ module Etna
       has_roles(:administration, :admin)
     end
 
+    def is_supereditor? project=nil
+      has_roles(:administration, :admin, :editor)
+    end
+
+    def is_superviewer? project=nil
+      has_roles(:administration, :admin, :editor, :viewer)
+    end
+
     def can_edit? project
-      is_superuser? || has_roles(project, :admin, :editor)
+      is_supereditor? || has_roles(project, :admin, :editor)
     end
 
     def can_view? project
-      is_superuser? || has_roles(project, :admin, :editor, :viewer)
+      is_superviewer? || has_roles(project, :admin, :editor, :viewer)
     end
 
     # superusers - administrators of the Administration group - cannot

--- a/etna/lib/etna/user.rb
+++ b/etna/lib/etna/user.rb
@@ -46,7 +46,7 @@ module Etna
       viewer: /[Vv]/,
       restricted: /[AEV]/,
     }
-    def has_roles(project, *roles)
+    def has_any_role?(project, *roles)
       perm = permissions[project.to_s]
 
       return false unless perm
@@ -55,23 +55,23 @@ module Etna
     end
 
     def is_superuser? project=nil
-      has_roles(:administration, :admin)
+      has_any_role?(:administration, :admin)
     end
 
     def is_supereditor? project=nil
-      has_roles(:administration, :admin, :editor)
+      has_any_role?(:administration, :admin, :editor)
     end
 
     def is_superviewer? project=nil
-      has_roles(:administration, :admin, :editor, :viewer)
+      has_any_role?(:administration, :admin, :editor, :viewer)
     end
 
     def can_edit? project
-      is_supereditor? || has_roles(project, :admin, :editor)
+      is_supereditor? || has_any_role?(project, :admin, :editor)
     end
 
     def can_view? project
-      is_superviewer? || has_roles(project, :admin, :editor, :viewer)
+      is_superviewer? || has_any_role?(project, :admin, :editor, :viewer)
     end
 
     # superusers - administrators of the Administration group - cannot
@@ -83,7 +83,7 @@ module Etna
     end
 
     def is_admin? project
-      is_superuser? || has_roles(project, :admin)
+      is_superuser? || has_any_role?(project, :admin)
     end
 
     def active? project=nil

--- a/etna/packages/etna-js/components/Nav.jsx
+++ b/etna/packages/etna-js/components/Nav.jsx
@@ -1,11 +1,13 @@
 import React, {useState} from 'react';
 require('./Nav.css');
-import { isSuperuser } from '../utils/janus';
+import { isSuperuser, isSuperEditor, isSuperViewer } from '../utils/janus';
 
 import Icon from './icon';
 
 const ICONS = {
   superuser: 'user-ninja',
+  supereditor: 'user-nurse',
+  superviewer: 'user-tie',
   administrator: 'user-astronaut',
   editor: 'user-edit',
   viewer: 'user'
@@ -19,6 +21,8 @@ const Login = ({user}) => {
   let role = (permissions[CONFIG.project_name] || {}).role;
 
   if (isSuperuser(user)) role = 'superuser';
+  else if (isSuperEditor(user)) role = 'supereditor';
+  else if (isSuperViewer(user)) role = 'superviewer';
 
   return (
     <div className='etna-login' title={role}>

--- a/etna/packages/etna-js/selectors/user-selector.jsx
+++ b/etna/packages/etna-js/selectors/user-selector.jsx
@@ -1,4 +1,5 @@
 import * as Reselect from 'reselect';
+import { isEditor } from '../utils/janus';
 
 export const selectUser = ({user})=>( user || {} );
 
@@ -18,6 +19,6 @@ export const selectUserProjectRole = Reselect.createSelector(
 );
 
 export const selectIsEditor = Reselect.createSelector(
-  selectUserProjectRole,
-  role => role && (role === 'administrator' || role === 'editor')
+  selectUser,
+  user => user.permissions && isEditor(user)
 );

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -1,7 +1,9 @@
 const ROLES = {a: 'administrator', e: 'editor', v: 'viewer'};
 
 export const isSuperuser = ({permissions}) => (permissions.administration && permissions.administration.role == ROLES.a)
-export const isEditor = ({permissions}, project_name) => (permissions[project_name] && [ ROLES.a, ROLES.e ].includes(permissions[project_name].role)) || isSuperuser({permissions})
+export const isSuperEditor = ({permissions}) => (permissions.administration && [ ROLES.a, ROLES.e ].includes(permissions.administration.role))
+export const isSuperViewer = ({permissions}) => (permissions.administration && [ ROLES.a, ROLES.e, ROLES.v ].includes(permissions.administration.role))
+export const isEditor = ({permissions}, project_name) => (permissions[project_name] && [ ROLES.a, ROLES.e ].includes(permissions[project_name].role)) || isSuperEditor({permissions})
 export const isAdmin = ({permissions}, project_name) => (permissions[project_name] && permissions[project_name].role == ROLES.a) || isSuperuser({permissions})
 
 const parsePermissions = (perms) => {

--- a/etna/spec/user_spec.rb
+++ b/etna/spec/user_spec.rb
@@ -30,10 +30,20 @@ describe Etna::User do
 
   context "permissions" do
     before(:each) do
-      @overlord = Etna::User.new(
+      @superuser = Etna::User.new(
         email: 'janus@two-faces.org',
         name: 'Janus Bifrons',
         perm: 'a:administration'
+      )
+      @supereditor = Etna::User.new(
+        email: 'portunus@two-faces.org',
+        name: 'Portunus',
+        perm: 'e:administration'
+      )
+      @superviewer = Etna::User.new(
+        email: 'lar@two-faces.org',
+        name: 'Lar Familiaris',
+        perm: 'v:administration'
       )
       @admin = Etna::User.new(
         email: 'polyphemus@etna.org',
@@ -53,37 +63,49 @@ describe Etna::User do
     end
 
     it 'checks if the user can edit a project' do
-      expect(@overlord.can_edit?(:labors)).to be_truthy
+      expect(@superuser.can_edit?(:labors)).to be_truthy
+      expect(@supereditor.can_edit?(:labors)).to be_truthy
+      expect(@superviewer.can_edit?(:labors)).to be_falsy
       expect(@admin.can_edit?(:labors)).to be_truthy
       expect(@editor.can_edit?(:labors)).to be_truthy
       expect(@viewer.can_edit?(:labors)).to be_falsy
     end
     it 'checks if the user can view a project' do
-      expect(@overlord.can_view?(:labors)).to be_truthy
+      expect(@superuser.can_view?(:labors)).to be_truthy
+      expect(@supereditor.can_view?(:labors)).to be_truthy
+      expect(@superviewer.can_view?(:labors)).to be_truthy
       expect(@admin.can_view?(:labors)).to be_truthy
       expect(@editor.can_view?(:labors)).to be_truthy
       expect(@viewer.can_view?(:labors)).to be_truthy
     end
     it 'checks if the user is an admin on the project' do
-      expect(@overlord.is_admin?(:labors)).to be_truthy
+      expect(@superuser.is_admin?(:labors)).to be_truthy
+      expect(@supereditor.is_admin?(:labors)).to be_falsy
+      expect(@superviewer.is_admin?(:labors)).to be_falsy
       expect(@admin.is_admin?(:labors)).to be_truthy
       expect(@editor.is_admin?(:labors)).to be_falsy
       expect(@viewer.is_admin?(:labors)).to be_falsy
     end
     it 'checks if the user can see restricted data' do
-      expect(@overlord.can_see_restricted?(:labors)).to be_falsy
+      expect(@superuser.can_see_restricted?(:labors)).to be_falsy
+      expect(@supereditor.can_see_restricted?(:labors)).to be_falsy
+      expect(@superviewer.can_see_restricted?(:labors)).to be_falsy
       expect(@admin.can_see_restricted?(:labors)).to be_truthy
       expect(@editor.can_see_restricted?(:labors)).to be_truthy
       expect(@viewer.can_see_restricted?(:labors)).to be_falsy
     end
     it 'gives a list of user projects' do
-      expect(@overlord.projects).to eq(['administration'])
+      expect(@superuser.projects).to eq(['administration'])
+      expect(@supereditor.projects).to eq(['administration'])
+      expect(@superviewer.projects).to eq(['administration'])
       expect(@admin.projects).to eq(['labors'])
       expect(@editor.projects).to eq(['labors'])
       expect(@viewer.projects).to eq(['labors'])
     end
     it 'gives a list of user permissions' do
-      expect(@overlord.permissions).to eq( 'administration' => { role: :admin, restricted: false } )
+      expect(@superuser.permissions).to eq( 'administration' => { role: :admin, restricted: false } )
+      expect(@supereditor.permissions).to eq( 'administration' => { role: :editor, restricted: false } )
+      expect(@superviewer.permissions).to eq( 'administration' => { role: :viewer, restricted: false } )
       expect(@admin.permissions).to eq( 'labors' => { role: :admin, restricted: true } )
       expect(@editor.permissions).to eq( 'labors' => { role: :editor, restricted: true } )
       expect(@viewer.permissions).to eq( 'labors' => { role: :viewer, restricted: false } )


### PR DESCRIPTION
This adds a few roles (superviewer, supereditor) to the mix, corresponding to viewers and editors in the "administration" group, giving users broad "edit" and "view" privileges. Superusers remain the same as before, able to perform any operation.