### PR TITLE
add file delete method to etna metis client

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -69,6 +69,11 @@ module Etna
           @etna_client.folder_remove(delete_folder_request.to_h))
       end
 
+      def delete_file(delete_file_request)
+        FilesResponse.new(
+          @etna_client.file_remove(delete_file_request.to_h))
+      end
+
       def find(find_request)
         FoldersAndFilesResponse.new(
           @etna_client.bucket_find(find_request.to_h))

--- a/etna/lib/etna/clients/metis/models.rb
+++ b/etna/lib/etna/clients/metis/models.rb
@@ -95,6 +95,21 @@ module Etna
         end
       end
 
+      class DeleteFileRequest < Struct.new(:project_name, :bucket_name, :file_path, keyword_init: true)
+        include JsonSerializableStruct
+
+        def initialize(**params)
+          super({}.update(params))
+        end
+
+        def to_h
+          # The :project_name comes in from Polyphemus as a symbol value,
+          #   we need to make sure it's a string because it's going
+          #   in the URL.
+          super().compact.transform_values(&:to_s)
+        end
+      end
+
       class FindRequest < Struct.new(:project_name, :bucket_name, :limit, :offset, :params, keyword_init: true)
         include JsonSerializableStruct
 


### PR DESCRIPTION
This is a small PR that adds in a `delete_file` method to the etna gem's Metis client. Useful for scripting clean-up when bulk upload goes awry.