### PR TITLE
Vulcan UI bug fixes

### DIFF
--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
@@ -25,10 +25,13 @@ export default function DropdownAutocomplete({
 
   function filterTheList(value) {
     let re = new RegExp(value);
-    setFilteredList(sortedList.filter((item) => item.match(re)));
+    setFilteredList(
+      sortedList.filter((item) => item.match(re)).slice(0, maxItems || 10)
+    );
   }
 
   function onSelectItem(value) {
+    console.log('on select', value);
     onSelect(value);
     setSelectedValue(value);
     setShowList(false);
@@ -55,11 +58,7 @@ export default function DropdownAutocomplete({
   function onChange(value) {
     filterTheList(value);
     setSelectedValue(value);
-    if (sortedList.indexOf(value) === -1) {
-      onSelect(null);
-    } else {
-      onSelect(value);
-    }
+    setShowList(true);
   }
 
   function handleChange(e) {
@@ -78,13 +77,7 @@ export default function DropdownAutocomplete({
   return (
     <div className='dropdown-autocomplete-input'>
       <div className='dropdown-autocomplete-input-field'>
-        <input
-          type='text'
-          onChange={handleChange}
-          value={selectedValue}
-          onBlur={closeList}
-          onFocus={openList}
-        />
+        <input type='text' onChange={handleChange} value={selectedValue} />
         <div className='icon-wrapper' onClick={toggleList}>
           <Icon icon={`${showList ? 'caret-up' : 'caret-down'}`}></Icon>
         </div>
@@ -92,13 +85,8 @@ export default function DropdownAutocomplete({
       {showList ? (
         <ul className={`dropdown-autocomplete-options`}>
           {filteredList && filteredList.length > 0 ? (
-            filteredList.map((item, index) => (
-              <li
-                onClick={() => {
-                  onSelectItem(item);
-                }}
-                key={index}
-              >
+            filteredList.slice(0, maxItems || 10).map((item, index) => (
+              <li onClick={() => onSelectItem(item)} key={index}>
                 {item}
               </li>
             ))

--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
@@ -10,7 +10,8 @@ export default function DropdownAutocomplete({
   list,
   onSelect,
   defaultValue,
-  waitTime
+  waitTime,
+  maxItems
 }) {
   var collator = new Intl.Collator(undefined, {
     numeric: true,
@@ -31,7 +32,6 @@ export default function DropdownAutocomplete({
   }
 
   function onSelectItem(value) {
-    console.log('on select', value);
     onSelect(value);
     setSelectedValue(value);
     setShowList(false);

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/nested_select_autocomplete.jsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/nested_select_autocomplete.jsx
@@ -87,10 +87,6 @@ export default function NestedSelectAutocompleteInput({input, onChange}) {
   }
 
   function handleSelect(value, depth) {
-    // User has not selected something...perhaps
-    //   still typing?
-    if (null == value) return;
-
     let updatedPath;
     if (depth <= currentDepth) {
       updatedPath = path.slice(0, depth);
@@ -98,7 +94,13 @@ export default function NestedSelectAutocompleteInput({input, onChange}) {
       updatedPath = [...path];
     }
 
-    updatedPath.push(value);
+    // User has deselected something if null
+    if (null == value) {
+      depth = depth - 1;
+    } else {
+      updatedPath.push(value);
+    }
+
     setCurrentDepth(depth);
     setPath(updatedPath);
     setOptions(getOptions(updatedPath));

--- a/vulcan/lib/client/jsx/utils/workflow.jsx
+++ b/vulcan/lib/client/jsx/utils/workflow.jsx
@@ -91,15 +91,19 @@ export const uiStepInputDataLink = ({step, pathIndex, status}) => {
 
 export const uiInputDataReady = ({step, pathIndex, status}) => {
   // Check if data has been set for a UI Input step
-  let previousStepName = step.in[0].source[0];
-  let outputKey = step.in[0].source[1];
+  return step.in.every((input) => {
+    let previousStepName = input.source[0];
+    let outputKey = input.source[1];
 
-  let previousStep = status[pathIndex].find((s) => s.name === previousStepName);
+    let previousStep = status[pathIndex].find(
+      (s) => s.name === previousStepName
+    );
 
-  if (!previousStep || !previousStep.data || !previousStep.data[outputKey])
-    return null;
+    if (!previousStep || !previousStep.data || !previousStep.data[outputKey])
+      return false;
 
-  return previousStep.data[outputKey];
+    return previousStep.data[outputKey];
+  });
 };
 
 export const uiStepInputDataRaw = ({step, pathIndex, status}) => {

--- a/vulcan/lib/server/workflows/umap.cwl
+++ b/vulcan/lib/server/workflows/umap.cwl
@@ -101,12 +101,6 @@ steps:
     in:
       a: queryMagma/tissues
     out: [options]
-  select_color_by_option:
-    run: ui-queries/nested-select-autocomplete.cwl
-    label: 'Color Options'
-    in:
-      a: queryMagma/color_options
-    out: [color_by]
   parse_record_selections:
     run: scripts/parse_record_selections.cwl
     label: 'Interpret record selection inputs.'
@@ -175,6 +169,13 @@ steps:
       nn_anndata.h5ad: neighbors/nn_anndata.h5ad
       leiden_resolution: UMAP_Calculation__leiden_resolution
     out: [leiden.json]
+  select_color_by_option:
+    run: ui-queries/nested-select-autocomplete.cwl
+    label: 'Color Options'
+    in:
+      a: queryMagma/color_options
+      b: calc_leiden/leiden.json
+    out: [color_by]
   plot_umap:
     run: scripts/plot_umap.cwl
     label: 'Create UMAP plot'


### PR DESCRIPTION
This PR addresses two UX issues identified by @graft :+1: 

* The dropdown autocomplete now is not greedy, so you can type into it and it won't pick the first matching entry. However, I had to remove some features to get this to work in an okay fashion. Namely, currently the dropdown list will not auto-close on blur, and also there isn't a "send a null event" if you type an invalid entry. The logic seems convoluted and not quite straightforward to implement with the current component, so I think that has to be a user-beware situation for now. For example, if you selected an item from the dropdown and go back later to type into the box, but don't select a new item, the text in the box won't reset to empty string, and the "input" component value is still the first selected value. I feel like it's not very intuitive, but it is also fairly convoluted to get different behavior.
* Color-by step now correctly appears later. All input sources are checked before a step renders in the UI.


I'll keep testing tomorrow, but I think both of these things will work as expected for the demo.