### PR TITLE
Adds cell_fraction multi-selection selection option

### DIFF
--- a/vulcan/lib/server/workflows/scripts/parse_record_selections.py
+++ b/vulcan/lib/server/workflows/scripts/parse_record_selections.py
@@ -9,6 +9,7 @@ magma = connect()
 
 experiments = input_json('experiments')
 tissues = input_json('tissues')
+fractions = input_json('fractions')
 
 # Experiment and Tissue (AND logic)
 filters = []
@@ -17,6 +18,9 @@ if len(experiments) > 0:
 #### NEED TO TEST TISSUES BETTER ONCE ADDED
 if len(tissues) > 0:
     filters.append( ['biospecimen_group', 'biospecimen_type', '::in', tissues] )
+
+if len(fractions) > 0:
+    filters.append( ['cell_fraction', '::in', fractions] )
 
 tube_records = unique(question(
     magma,

--- a/vulcan/lib/server/workflows/scripts/retrieve_selection_options.py
+++ b/vulcan/lib/server/workflows/scripts/retrieve_selection_options.py
@@ -28,6 +28,16 @@ tissues = question(
     ]
 )
 
+fractions = question(
+    magma,
+    [
+        seq_model_name,
+        [ '::has', 'raw_counts_h5'],
+        '::all',
+        'cell_fraction'
+    ]
+)
+
 color_options = {
     'Cluster': None,
     'Experiment': None,
@@ -40,3 +50,4 @@ color_options = {
 output_json(color_options, 'color_options')
 output_json(unique(experiments), 'experiments')
 output_json(unique(tissues), 'tissues')
+output_json(unique(fractions), 'fractions')

--- a/vulcan/lib/server/workflows/umap.cwl
+++ b/vulcan/lib/server/workflows/umap.cwl
@@ -86,20 +86,27 @@ steps:
       j: Regress__regress_tube_id
       k: UMAP_Calculation__max_pc
       l: UMAP_Calculation__leiden_resolution
-    out: [experiments, tissues, color_options]
+    out: [experiments, tissues, fractions, color_options]
   Select_Records__pickExperiments:
     run: ui-queries/multiselect-string.cwl
     label: 'Select Experiments'
-    doc: 'Subset  of experiments to use, based on their `alias`. These selections get combined with Tissue selections with AND logic. If you want to just select tube records directly, pick No Selections for all dropdowns here.'
+    doc: 'Picks the set of experiment:alias options to use. These selections get combined with Tissue and Cell Fraction selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
       a: queryMagma/experiments
     out: [options]
   Select_Records__pickTissues:
     run: ui-queries/multiselect-string.cwl
     label: 'Select Tissues'
-    doc: 'Subset of biospecimen_types to use. These selections get combined with Experiment selections with AND logic. If you want to just select tube records directly, pick No Selections for all dropdowns here.'
+    doc: 'Picks the set of biospecimen_group:biospecimen_type options to use. These selections get combined with Experiment and Cell Fraction selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
       a: queryMagma/tissues
+    out: [options]
+  Select_Records__pickFractions:
+    run: ui-queries/multiselect-string.cwl
+    label: 'Select Sort Fractions'
+    doc: 'Picks the set of sc_seq:cell_faction options to use. These selections get combined with Experiment and Tissue selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
+    in:
+      a: queryMagma/fractions
     out: [options]
   parse_record_selections:
     run: scripts/parse_record_selections.cwl
@@ -107,6 +114,7 @@ steps:
     in:
       experiments: Select_Records__pickExperiments/options
       tissues: Select_Records__pickTissues/options
+      fractions: Select_Records__pickFractions/options
     out: [tube_recs]
   verifyRecordNames:
     run: ui-queries/checkboxes.cwl


### PR DESCRIPTION
Adds a third option for sc_seq record selection.
Also adjusts the 'doc' value for this multi-select as well as for Experiments and Tissues per these 3 options & per the expectation that there will be an "All" option added in the ui.

Does not adjust option pull or parse logic, just copies them targeted to this attribute. (Note though that I don't believe the `if len(experiments) > 0:` lines are needed as the ui piece does not empty selections.) 

Tested with achimedes bash > `archimedes-run`.  Can be either merged or `cherry-pick`ed =)