### PR TITLE
Timur view editor fixes

### DIFF
--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -60,7 +60,7 @@ export const deleteView = (view, success) => (dispatch) =>
     .then(
       () => {
         dispatch(removeView(view.id));
-        tryCallback(success, view);
+        tryCallback(success);
       }
     )
     .catch(showErrors(dispatch));

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -3,7 +3,7 @@ import {fetchAllViews, getView, updateView, createView, destroyView} from '../ap
 import {Exchange} from 'etna-js/actions/exchange_actions';
 import {showErrors, tryCallback} from 'etna-js/actions/action_helpers';
 
-const addView = (view_name, view) => ({type: 'ADD_VIEW', view_name, view});
+const addView = (view_id, view) => ({type: 'ADD_VIEW', view_id, view});
 const loadViews = (allViews) => ({type: 'LOAD_VIEWS', allViews});
 const editView = (view) => ({type: 'UPDATE_VIEW', view});
 const removeView = (id)=>({ type: 'REMOVE_VIEW', id });
@@ -49,7 +49,7 @@ export const saveNewView = (view, success) => (dispatch) =>
   createView(view, new Exchange(dispatch, 'save-new-view'))
     .then(
       (view) => {
-        dispatch(addView(view));
+        dispatch(addView(view.view.id, view.view));
         tryCallback(success, view);
       }
     )
@@ -60,7 +60,7 @@ export const deleteView = (view, success) => (dispatch) =>
     .then(
       () => {
         dispatch(removeView(view.id));
-        tryCallback(success,manifest);
+        tryCallback(success, view);
       }
     )
     .catch(showErrors(dispatch));

--- a/timur/lib/client/jsx/components/document/document_view.jsx
+++ b/timur/lib/client/jsx/components/document/document_view.jsx
@@ -8,10 +8,12 @@ import { buttonsWithCallbacks } from 'etna-js/components/button_bar';
 
 export default class DocumentView extends React.Component {
   getButtons() {
-    let { editing } = this.props;
+    let { editing, canSave } = this.props;
 
     return buttonsWithCallbacks(editing ?
-      [ 'run', 'save', 'cancel' ]
+      canSave ?
+        [ 'run', 'save', 'cancel' ]
+        : [ 'run', 'cancel' ]
       :
       [ 'run', 'remove', 'copy', 'edit' ],
       this.props

--- a/timur/lib/client/jsx/components/document/document_window.jsx
+++ b/timur/lib/client/jsx/components/document/document_window.jsx
@@ -19,7 +19,8 @@ const DocumentWindow = (props) => {
     documentType, document, documents, editing, children,
     onCreate, onSelect, onEdit, onCancel,
     onRun, onSave, onCopy, onRemove, onUpdate,
-    documentTitle, documentId, documentName
+    documentTitle, documentId, documentName,
+    canSave
   } = props;
   let groupKey;
 
@@ -59,7 +60,8 @@ const DocumentWindow = (props) => {
             onCopy={ onCopy }
             onRemove={ onRemove }
             onUpdate={ onUpdate }
-            document={ document } >
+            document={ document }
+            canSave={ null == canSave ? true : canSave } >
             { children }
           </DocumentView>
         </div>

--- a/timur/lib/client/jsx/components/timur_nav.jsx
+++ b/timur/lib/client/jsx/components/timur_nav.jsx
@@ -6,7 +6,7 @@ import Nav from 'etna-js/components/Nav';
 import IdentifierSearch from './identifier_search';
 import Link from 'etna-js/components/link';
 import {selectUser} from 'etna-js/selectors/user-selector';
-import {isAdmin, parseToken} from 'etna-js/utils/janus';
+import {isAdmin} from 'etna-js/utils/janus';
 
 const Halo = ({radius}) =>
   <div className="halo">

--- a/timur/lib/client/jsx/components/timur_nav.jsx
+++ b/timur/lib/client/jsx/components/timur_nav.jsx
@@ -6,7 +6,7 @@ import Nav from 'etna-js/components/Nav';
 import IdentifierSearch from './identifier_search';
 import Link from 'etna-js/components/link';
 import {selectUser} from 'etna-js/selectors/user-selector';
-import {useReduxState} from 'etna-js/hooks/useReduxState';
+import {isAdmin, parseToken} from 'etna-js/utils/janus';
 
 const Halo = ({radius}) =>
   <div className="halo">
@@ -33,20 +33,27 @@ const Logo = connect(({exchanges}) => ({exchanges}))(({exchanges}) =>
   </div>
 );
 
-const getTabs = () => ({
-  browse: Routes.browse_path(CONFIG.project_name),
-  search: Routes.search_path(CONFIG.project_name),
-  map: Routes.map_path(CONFIG.project_name),
-  manifests: Routes.manifests_path(CONFIG.project_name),
-  plots: Routes.plots_path(CONFIG.project_name),
-  'views': Routes.views_path(CONFIG.project_name),
-  help: 'https://mountetna.github.io/timur.html'
-});
+const getTabs = (user) => {
+  let tabs = {
+    browse: Routes.browse_path(CONFIG.project_name),
+    search: Routes.search_path(CONFIG.project_name),
+    map: Routes.map_path(CONFIG.project_name),
+    manifests: Routes.manifests_path(CONFIG.project_name),
+    plots: Routes.plots_path(CONFIG.project_name),
+    help: 'https://mountetna.github.io/timur.html'
+  }
 
-const ModeBar = ({mode}) =>
+  if (isAdmin(user, CONFIG.project_name)) {
+    tabs['views'] = Routes.views_path(CONFIG.project_name);
+  }
+
+  return tabs;
+};
+
+const ModeBar = ({mode, user}) =>
   <div id='nav'>
     {
-      Object.entries(getTabs()).map(([tab_name, route]) =>
+      Object.entries(getTabs(user)).map(([tab_name, route]) =>
         <div key={tab_name}
           className={`nav_tab ${mode == tab_name ? 'selected' : ''}`}>
           <Link link={route}>{tab_name}</Link>
@@ -58,7 +65,7 @@ const ModeBar = ({mode}) =>
 const TimurNav = ({mode, user}) =>
   <Nav user={user} logo={Logo} app='timur'>
     {mode !== 'home' && <IdentifierSearch />}
-    {mode !== 'home' && <ModeBar mode={mode}/>}
+    {mode !== 'home' && <ModeBar mode={mode} user={user} />}
   </Nav>;
 
 export default connect((state) => ({

--- a/timur/lib/client/jsx/components/view_editor/view_editor.jsx
+++ b/timur/lib/client/jsx/components/view_editor/view_editor.jsx
@@ -86,9 +86,13 @@ const ViewEditor = ({view_id}) => {
 
   const create = () => selectView('new', true);
 
-  const numberLintingErrors = (value) => {
+  const hasLintingErrors = (value) => {
     window.JSHINT(value);
-    return JSHINT.data().errors.filter((e) => 'E' === e.code[0]).length;
+
+    return (
+      JSHINT.data().errors &&
+      JSHINT.data().errors.length > 0
+    );
   }
 
   const updateField = (field_name) => (event) => {
@@ -96,8 +100,7 @@ const ViewEditor = ({view_id}) => {
       // the code editor does not emit an event, just the new value
       view.document = event;
       
-      // Let you save with warnings...
-      setCanSave(numberLintingErrors(event) === 0);
+      setCanSave(!hasLintingErrors(event));
     } else {
       view[field_name] = event.target.value;
     }

--- a/timur/lib/client/jsx/components/view_editor/view_editor.jsx
+++ b/timur/lib/client/jsx/components/view_editor/view_editor.jsx
@@ -113,7 +113,7 @@ const ViewEditor = ({view_id}) => {
 
   const onDelete = () => {
     if(confirm('Are you sure you want to remove this view?')){
-      deleteView(view, () => selectView(0))(dispatch);
+      deleteView(view, () => selectView(null))(dispatch);
     }
   }
   const toggleEdit = () => {

--- a/timur/lib/client/jsx/components/view_editor/view_editor.jsx
+++ b/timur/lib/client/jsx/components/view_editor/view_editor.jsx
@@ -23,6 +23,7 @@ const ViewEditor = ({view_id}) => {
   let [editing, setEditing] = useState(useSelector(state => state.editing));
   const dispatch = useDispatch();
   let [view, setActualView] = useState(null);
+  const [canSave, setCanSave] = useState(true);
   let views = useSelector(state => state.views);
 
   let setView = useCallback(
@@ -85,10 +86,18 @@ const ViewEditor = ({view_id}) => {
 
   const create = () => selectView('new', true);
 
+  const numberLintingErrors = (value) => {
+    window.JSHINT(value);
+    return JSHINT.data().errors.filter((e) => 'E' === e.code[0]).length;
+  }
+
   const updateField = (field_name) => (event) => {
     if (field_name === 'document') {
       // the code editor does not emit an event, just the new value
       view.document = event;
+      
+      // Let you save with warnings...
+      setCanSave(numberLintingErrors(event) === 0);
     } else {
       view[field_name] = event.target.value;
     }
@@ -134,6 +143,7 @@ const ViewEditor = ({view_id}) => {
       onSave={onSave}
       onRemove={onDelete}
       documentName='model_name'
+      canSave={canSave}
     >
       <ViewScript
         script={view && view.document}

--- a/timur/lib/client/jsx/components/view_editor/views_script.jsx
+++ b/timur/lib/client/jsx/components/view_editor/views_script.jsx
@@ -2,6 +2,13 @@
 import React from 'react';
 import { Controlled as CodeMirror } from 'react-codemirror2';
 
+import { JSHINT } from 'jshint';
+window.JSHINT = JSHINT;
+
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/lint/lint';
+import 'codemirror/addon/lint/javascript-lint';
 
 function ViewScript(props) {
 
@@ -15,7 +22,11 @@ function ViewScript(props) {
               readOnly: is_editing ? false : 'no-cursor',
               lineNumbers: is_editing,
               lineWrapping: true,
-              mode: 'json'
+              mode: 'application/json',
+              autoCloseBrackets: true,
+              gutters: ['CodeMirror-lint-markers'],
+              lint: is_editing ? true : false,
+              tabSize: 2
             }}
             value={script}
             onBeforeChange={(editor, data, value) => {

--- a/timur/lib/client/jsx/components/view_editor/views_script.jsx
+++ b/timur/lib/client/jsx/components/view_editor/views_script.jsx
@@ -6,7 +6,7 @@ import { Controlled as CodeMirror } from 'react-codemirror2';
 function ViewScript(props) {
 
   let { is_editing, onChange, script } = props;
-  let className = is_editing ? 'manifest-script editing' : 'manifest-script';
+  let className = is_editing ? 'manifest-script editing view-editor' : 'manifest-script view-editor';
   return (
       <div className={className}>
 

--- a/timur/lib/client/jsx/reducers/view_reducer.js
+++ b/timur/lib/client/jsx/reducers/view_reducer.js
@@ -17,7 +17,7 @@ const views = (oldViews = {}, action) => {
     case 'ADD_VIEW':
       return {
         ...oldViews,
-        [action.view_name]: action.view
+        [action.view_id]: action.view
       };
     case 'LOAD_VIEWS':
       return loadViews(oldViews, action.allViews);

--- a/timur/lib/client/scss/application.scss
+++ b/timur/lib/client/scss/application.scss
@@ -40,6 +40,7 @@
 @import "toggle";
 @import "predicate";
 @import "list";
+@import "view_editor";
 
 body {
   padding: 0px;

--- a/timur/lib/client/scss/view_editor.scss
+++ b/timur/lib/client/scss/view_editor.scss
@@ -1,3 +1,6 @@
+@import '~codemirror/lib/codemirror.css';
+@import '~codemirror/addon/lint/lint.css';
+
 .view-editor {
   .CodeMirror {
     height: 75vh;

--- a/timur/lib/client/scss/view_editor.scss
+++ b/timur/lib/client/scss/view_editor.scss
@@ -1,0 +1,5 @@
+.view-editor {
+  .CodeMirror {
+    height: 75vh;
+  }
+}

--- a/timur/package-lock.json
+++ b/timur/package-lock.json
@@ -3780,6 +3780,15 @@
         "uniq": "^1.0.1"
       }
     },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -4691,6 +4700,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4893,7 +4907,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -4908,8 +4921,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -4941,7 +4953,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -5104,8 +5115,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "enzyme": {
       "version": "3.11.0",
@@ -13092,8 +13102,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -17123,6 +17132,87 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "jshint": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.19",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "console-browserify": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+        }
+      }
     },
     "json-loader": {
       "version": "0.5.7",

--- a/timur/package.json
+++ b/timur/package.json
@@ -17,6 +17,7 @@
     "etna-js": "file:/etna/packages/etna-js",
     "identity-obj-proxy": "^3.0.0",
     "js-cookie": "^2.2.0",
+    "jshint": "^2.12.0",
     "json2csv": "^4.0.1",
     "lodash": "^4.17.15",
     "marked": "^0.3.17",

--- a/timur/webpack.config.js
+++ b/timur/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env) => ({
       'code-mirror': path.join(__dirname, 'node_modules/codemirror/lib'),
       react: path.join(__dirname, 'node_modules/react'),
       'react-dom': path.join(__dirname, 'node_modules/react-dom'),
-      'react-redux': path.join(__dirname, 'node_modules/react-redux'),
+      'react-redux': path.join(__dirname, 'node_modules/react-redux')
     },
     symlinks: false
   },
@@ -29,7 +29,7 @@ module.exports = (env) => ({
         include: [
           path.resolve(__dirname, 'lib/client/jsx'),
           path.resolve(__dirname, 'node_modules/etna-js/'),
-          '/etna/packages/etna-js',
+          '/etna/packages/etna-js'
         ],
 
         // Only run `.js` and `.jsx` files through Babel
@@ -42,6 +42,7 @@ module.exports = (env) => ({
           path.resolve(__dirname, 'node_modules/etna-js/'),
           path.resolve(__dirname, 'node_modules/animate.css/'),
           path.resolve(__dirname, 'node_modules/react-notifications-component'),
+          path.resolve(__dirname, 'node_modules/codemirror/'),
           '/etna/packages/etna-js'
         ],
         test: /\.css$/


### PR DESCRIPTION
This PR fixes a couple of small issues I had when using the view editor in Timur:

* Creating a new view correctly adds it to the menu. Previous behavior was to throw an error and present a blank page.
* Deleting a view blanks out the main pane (previously it kept the just-deleted view).
* Updates the CSS so that the view document takes up most of the vertical space ... a bit nicer when editing long views.
* Only displays the view for Admin users for a given project. For simplicity's sake, this now appears to the right of "Help", but if anyone feels strongly about it appearing to the left of "Help", I can move it back.
