### PR TITLE
fixes the dropdown CSS for Chrome so that the list is visible

### DIFF
--- a/vulcan/lib/client/scss/workflow.scss
+++ b/vulcan/lib/client/scss/workflow.scss
@@ -242,7 +242,7 @@
             }
 
             .dd-list {
-              position: revert;
+              position: static;
             }
           }
 


### PR DESCRIPTION
This is a small Vulcan PR that tweaks the CSS for the drop-down options list (i.e. Select Experiment). In Chrome that was being hidden and not re-sizing the parent container. This should now work in FF and Chrome.