### PR TITLE
Polyphemus patch IPI pop loading

### DIFF
--- a/polyphemus/lib/etls/ipi_load_magma_population_tables_etl.rb
+++ b/polyphemus/lib/etls/ipi_load_magma_population_tables_etl.rb
@@ -53,8 +53,12 @@ class Polyphemus::IpiLoadMagmaPopulationTablesEtl < Polyphemus::MagmaRecordEtl
       elsif !cursor_record
         record_name
       else
-        cursor_record_updated_at = Time.at(cursor_record[1])
-        record_name if Time.parse(record_file_updated_at) >= cursor_record_updated_at
+        # Note that in Magma, the patient record is updated
+        #   slightly after the file is updated on Metis,
+        #   so we're conservative and compare against
+        #   the min of the cursor's updated_at or the seen_id record.
+        last_updated_at = [Time.at(cursor_record[1]), cursor.updated_at].min
+        record_name if Time.parse(record_file_updated_at) >= last_updated_at
       end
     end.compact
   end

--- a/polyphemus/lib/etls/ipi_load_magma_population_tables_etl.rb
+++ b/polyphemus/lib/etls/ipi_load_magma_population_tables_etl.rb
@@ -57,6 +57,8 @@ class Polyphemus::IpiLoadMagmaPopulationTablesEtl < Polyphemus::MagmaRecordEtl
         #   slightly after the file is updated on Metis,
         #   so we're conservative and compare against
         #   the min of the cursor's updated_at or the seen_id record.
+        # This lets updated files be identified both for the initial
+        #   run of this ETL as well as subsequent runs.
         last_updated_at = [Time.at(cursor_record[1]), cursor.updated_at].min
         record_name if Time.parse(record_file_updated_at) >= last_updated_at
       end

--- a/polyphemus/lib/etls/magma/magma_etl_script_runner.rb
+++ b/polyphemus/lib/etls/magma/magma_etl_script_runner.rb
@@ -23,11 +23,17 @@ class Polyphemus
       @magma_client = magma_client
       @update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: project_name)
 
-      run_script(self.__binding__)
+      # In production, seems like we can't pass
+      #   self.__binding__ here -- throws an UndefinedMethod exception.
+      run_script(self.get_binding)
 
       if commit
         magma_client.update_json(update_request)
       end
+    end
+
+    def get_binding
+      binding
     end
   end
 


### PR DESCRIPTION
I ran into a couple of small issues when trying to run the IPI Population loading manually, this PR addresses those.

* ETL was not catching the updated population records on initial run, only subsequent runs. This was because the time comparison was returning `false` on the first run, since the record's `updated_at` in the seen_ids list was more recent than the file's `updated_at`. I've changed the comparison to also look at the cursor's own updated_at, to see which is older and take that time. Should work for both initial and subsequent runs, now.
* Running the MagmaETLScriptRunner in production throws exception on use of `self.__binding__`, so slight refactor there.