### PR TITLE
Add minimum number requests post submit

### DIFF
--- a/vulcan/lib/client/jsx/contexts/session_sync.tsx
+++ b/vulcan/lib/client/jsx/contexts/session_sync.tsx
@@ -74,7 +74,7 @@ export function useSessionSync(
     if (!post &&
         hasNoRunningSteps(state.current.status) &&
         lastCompletedPollingRequest === state.current.session.inputs &&
-        currentRequestNumber > minimumNumberRequests) {
+        currentRequestNumber >= minimumNumberRequests) {
       setCurrentRequestNumber(0);
       return;
     }

--- a/vulcan/lib/client/jsx/contexts/session_sync.tsx
+++ b/vulcan/lib/client/jsx/contexts/session_sync.tsx
@@ -4,6 +4,7 @@ import {VulcanState} from "../reducers/vulcan_reducer";
 import {setSession, setStatus, VulcanAction} from "../actions/vulcan";
 import {SessionStatusResponse, VulcanSession} from "../api_types";
 import {Cancellable} from "etna-js/utils/cancellable";
+import {hasNoRunningSteps} from '../selectors/workflow_selectors';
 
 export const defaultSessionSyncHelpers = {
   statusIsFresh: true,
@@ -25,6 +26,21 @@ export function useSessionSync(
 ): typeof defaultSessionSyncHelpers {
   const [lastPollingRequest, setPollingRequest] = useState([false] as [boolean]);
   const [lastCompletedPollingRequest, setCompletedRequest] = useState(null as null | VulcanSession['inputs']);
+  
+
+  // We want to guarantee a minimum number of status polls,
+  //   to make sure we get accurate status from the server.
+  // Sometimes a status or submit POST will receive a response
+  //   from the server where all steps show as PENDING,
+  //   because the request just happened to catch the scheduler
+  //   between tasks.
+  // In that scenario, the UI will stop polling because there
+  //   are no RUNNING steps, when in reality it just missed
+  //   seeing a status update with RUNNING steps. By ensuring
+  //   a set of status requests spread out over time, we
+  //   catch this corner case and make the UI appear more responsive.
+  const minimumNumberRequests = 3;
+  const [currentRequestNumber, setCurrentRequestNumber] = useState(0 as number);
 
   // Note -- this will 'cancel' processing the result of previous requests when a new polling request is made, but
   // it does not actually cancel the underlying request.  Posts will thus complete just fine, although the result may
@@ -43,11 +59,23 @@ export function useSessionSync(
       setCompletedRequest(state.current.session.inputs);
     })
 
+    // Reset our counter for each postInputs call
+    if (doPost) setCurrentRequestNumber(0);
+
     return () => cancellable.cancel();
   }, [lastPollingRequest]);
 
   const requestPoll = useCallback((post = false) => {
-    if (!post && state.current.status[0].every(s => s.status !== "running") && lastCompletedPollingRequest === state.current.session.inputs) {
+    // Increment our request counter once all steps stop running
+    if (hasNoRunningSteps(state.current.status)) {
+      setCurrentRequestNumber(currentRequestNumber + 1);
+    }
+
+    if (!post &&
+        hasNoRunningSteps(state.current.status) &&
+        lastCompletedPollingRequest === state.current.session.inputs &&
+        currentRequestNumber > minimumNumberRequests) {
+      setCurrentRequestNumber(0);
       return;
     }
 

--- a/vulcan/lib/client/jsx/contexts/session_sync.tsx
+++ b/vulcan/lib/client/jsx/contexts/session_sync.tsx
@@ -27,7 +27,6 @@ export function useSessionSync(
   const [lastPollingRequest, setPollingRequest] = useState([false] as [boolean]);
   const [lastCompletedPollingRequest, setCompletedRequest] = useState(null as null | VulcanSession['inputs']);
   
-
   // We want to guarantee a minimum number of status polls,
   //   to make sure we get accurate status from the server.
   // Sometimes a status or submit POST will receive a response

--- a/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
+++ b/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
@@ -270,6 +270,10 @@ export function pendingSteps(workflow: Workflow, status: VulcanState['status']):
       .filter(({step}) => statusOfStep(step, status)?.status === 'pending');
 }
 
+export function hasNoRunningSteps(status: VulcanState['status']): boolean {
+  return status[0].every(s => s.status !== "running");
+}
+
 export const inputGroupName = (name: string) => {
   let groupName = name.split('__')[0];
   if (groupName === name) groupName = 'Inputs';


### PR DESCRIPTION
This PR addresses the "need to refresh to see UMAP" issue in #329. I saw this consistently with the final UMAP steps, but also saw it happen randomly, a couple times with other steps in the workflow. The root cause I think, is a timing / race condition where the returned status just happens to be between steps in the async scheduler, so all steps are either PENDING or COMPLETE -- none are RUNNING. Under these conditions the UI stops polling, even though work is happening on the server (you can track the logs and see this). You can then click Run or refresh the page and immediately see progress being updated.

This PR basically adds a counter to make sure that each "submit" request is followed by a minimum number of "poll status" requests (currently set to 3, which covers 3 seconds and seems to work). The poll-status requests only increment if there are no running steps, and should bridge any gap or lag between async tasks. The theory is that you shouldn't hit that same time-gap 3 times in a row.