### PR TITLE
Vulcan minor UI updates

### DIFF
--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
@@ -1,4 +1,4 @@
-// Wraps the Dropdown component so it will work with the
+// Wraps the DropdownAutocomplete component so it will work with the
 // list_input to act as a multi-select.
 import React from 'react';
 

--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
@@ -1,0 +1,25 @@
+// Wraps the Dropdown component so it will work with the
+// list_input to act as a multi-select.
+import React from 'react';
+
+import DropdownAutocomplete from './dropdown_autocomplete';
+
+export default function DropdownAutocompleteInput({
+  onChange,
+  list,
+  onBlur,
+  ...otherProps
+}) {
+  function onChangeWrapper(value) {
+    onChange(value);
+    onBlur();
+  }
+
+  return (
+    <DropdownAutocomplete
+      {...otherProps}
+      list={list}
+      onSelect={onChangeWrapper}
+    />
+  );
+}

--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete_wrapper.jsx
@@ -1,6 +1,6 @@
 // Wraps the DropdownAutocomplete component so it will work with the
 // list_input to act as a multi-select.
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import DropdownAutocomplete from './dropdown_autocomplete';
 
@@ -10,10 +10,10 @@ export default function DropdownAutocompleteInput({
   onBlur,
   ...otherProps
 }) {
-  function onChangeWrapper(value) {
+  const onChangeWrapper = useCallback((value) => {
     onChange(value);
     onBlur();
-  }
+  });
 
   return (
     <DropdownAutocomplete

--- a/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/primary_inputs.spec.tsx.snap
+++ b/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/primary_inputs.spec.tsx.snap
@@ -33,7 +33,7 @@ exports[`PrimaryInputs renders each type of input 1`] = `
         <div
           className="item_name"
         >
-          anInt
+          aBool
         </div>
         <div
           className="item_view"
@@ -45,10 +45,48 @@ exports[`PrimaryInputs renders each type of input 1`] = `
               className="input-help-children-wrapper"
             >
               <input
+                className="text_box"
+                defaultChecked={true}
                 onChange={[Function]}
-                onKeyPress={[Function]}
-                type="text"
-                value={1}
+                type="checkbox"
+              />
+            </div>
+            <div
+              className="help-icon-wrapper"
+              title="help"
+            >
+              <span
+                className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+              >
+                <i
+                  className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="view_item"
+      >
+        <div
+          className="item_name"
+        >
+          aBoolWithoutDefault
+        </div>
+        <div
+          className="item_view"
+        >
+          <div
+            className="input-help"
+          >
+            <div
+              className="input-help-children-wrapper"
+            >
+              <input
+                className="text_box"
+                onChange={[Function]}
+                type="checkbox"
               />
             </div>
             <div
@@ -111,84 +149,6 @@ exports[`PrimaryInputs renders each type of input 1`] = `
         <div
           className="item_name"
         >
-          aBool
-        </div>
-        <div
-          className="item_view"
-        >
-          <div
-            className="input-help"
-          >
-            <div
-              className="input-help-children-wrapper"
-            >
-              <input
-                className="text_box"
-                defaultChecked={true}
-                onChange={[Function]}
-                type="checkbox"
-              />
-            </div>
-            <div
-              className="help-icon-wrapper"
-              title="help"
-            >
-              <span
-                className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-              >
-                <i
-                  className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                />
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="view_item"
-      >
-        <div
-          className="item_name"
-        >
-          anIntWithoutDefault
-        </div>
-        <div
-          className="item_view"
-        >
-          <div
-            className="input-help"
-          >
-            <div
-              className="input-help-children-wrapper"
-            >
-              <input
-                onChange={[Function]}
-                onKeyPress={[Function]}
-                type="text"
-                value=""
-              />
-            </div>
-            <div
-              className="help-icon-wrapper"
-              title="help"
-            >
-              <span
-                className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-              >
-                <i
-                  className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                />
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="view_item"
-      >
-        <div
-          className="item_name"
-        >
           aFloatWithoutDefault
         </div>
         <div
@@ -228,7 +188,7 @@ exports[`PrimaryInputs renders each type of input 1`] = `
         <div
           className="item_name"
         >
-          aBoolWithoutDefault
+          anInt
         </div>
         <div
           className="item_view"
@@ -240,9 +200,49 @@ exports[`PrimaryInputs renders each type of input 1`] = `
               className="input-help-children-wrapper"
             >
               <input
-                className="text_box"
                 onChange={[Function]}
-                type="checkbox"
+                onKeyPress={[Function]}
+                type="text"
+                value={1}
+              />
+            </div>
+            <div
+              className="help-icon-wrapper"
+              title="help"
+            >
+              <span
+                className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+              >
+                <i
+                  className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="view_item"
+      >
+        <div
+          className="item_name"
+        >
+          anIntWithoutDefault
+        </div>
+        <div
+          className="item_view"
+        >
+          <div
+            className="input-help"
+          >
+            <div
+              className="input-help-children-wrapper"
+            >
+              <input
+                onChange={[Function]}
+                onKeyPress={[Function]}
+                type="text"
+                value=""
               />
             </div>
             <div

--- a/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
@@ -6,7 +6,8 @@ import UserInput from '../user_interactions/inputs/user_input';
 import {
   completedSteps,
   inputGroupName, isPendingUiQuery,
-  pendingSteps, uiQueryOfStep
+  pendingSteps, uiQueryOfStep,
+  sortInputsByLabel
 } from '../../../selectors/workflow_selectors';
 import {InputSpecification} from "../user_interactions/inputs/input_types";
 
@@ -45,7 +46,7 @@ export default function InputGroup({inputs, onChange}: {inputs: InputSpecificati
           open ? 'open' : 'closed'
         }`}
       >
-        {inputs.map((input, index) => {
+        {sortInputsByLabel(inputs).map((input, index) => {
           return (
             <UserInput
               input={input}

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_drawer.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_drawer.tsx
@@ -7,7 +7,8 @@ import {
   stepInputDataRaw,
   stepOfSource,
   stepOfStatus,
-  uiQueryOfStep
+  uiQueryOfStep,
+  sortInputsByLabel
 } from "../../../selectors/workflow_selectors";
 
 export default function StepUserInputDrawer({
@@ -40,7 +41,7 @@ export default function StepUserInputDrawer({
 
   return (
       <React.Fragment>
-        {stepInputs.map((input, index) => {
+        {sortInputsByLabel(stepInputs).map((input, index) => {
           return (
               <UserInput
                   input={input}

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
@@ -21,6 +21,7 @@ function CheckboxInput({onChange, option, checked}: {onChange: (v: any) => void,
 const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
   const [selectedOptions, setSelectedOptions] = useState([] as any[]);
   const [initialized, setInitialized] = useState(false);
+  console.log('input', input);
   if (!input || !onChange) return null;
 
   const options = useMemo(() => getAllOptions(input.data).sort(), [input.data]);
@@ -29,7 +30,7 @@ const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
     // Setting any previously selected inputs (from storage or
     //   user interactions) takes precedence over setting
     //   all options as checked.
-    if (input.default !== [] && !initialized) {
+    if ((input.default && input.default !== []) && !initialized) {
       setSelectedOptions([...input.default]);
       setInitialized(true);
     } else if (options.length > selectedOptions.length && !initialized) {

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
@@ -21,7 +21,6 @@ function CheckboxInput({onChange, option, checked}: {onChange: (v: any) => void,
 const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
   const [selectedOptions, setSelectedOptions] = useState([] as any[]);
   const [initialized, setInitialized] = useState(false);
-  console.log('input', input);
   if (!input || !onChange) return null;
 
   const options = useMemo(() => getAllOptions(input.data).sort(), [input.data]);

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
@@ -29,7 +29,7 @@ const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
     // Setting any previously selected inputs (from storage or
     //   user interactions) takes precedence over setting
     //   all options as checked.
-    if ((input.default && input.default !== []) && !initialized) {
+    if (input.default && input.default !== [] && !initialized) {
       setSelectedOptions([...input.default]);
       setInitialized(true);
     } else if (options.length > selectedOptions.length && !initialized) {

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/checkboxes.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {InputBackendComponent} from "./input_types";
 import {getAllOptions} from "./multiselect_string";
 
-function CheckboxInput({onChange, option}: {onChange: (v: any) => void, option: any}) {
+function CheckboxInput({onChange, option, checked}: {onChange: (v: any) => void, option: any, checked: boolean}) {
   return (
     <label className='checkbox-input-option'>
       <input
@@ -11,7 +11,7 @@ function CheckboxInput({onChange, option}: {onChange: (v: any) => void, option: 
         onChange={() => {
           onChange(option);
         }}
-        defaultChecked={true}
+        checked={checked}
       />
       {option}
     </label>
@@ -26,8 +26,13 @@ const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
   const options = useMemo(() => getAllOptions(input.data).sort(), [input.data]);
 
   useEffect(() => {
-
-    if (options.length > selectedOptions.length && !initialized) {
+    // Setting any previously selected inputs (from storage or
+    //   user interactions) takes precedence over setting
+    //   all options as checked.
+    if (input.default !== [] && !initialized) {
+      setSelectedOptions([...input.default]);
+      setInitialized(true);
+    } else if (options.length > selectedOptions.length && !initialized) {
       setSelectedOptions([...options]);
       setInitialized(true);
     }
@@ -54,6 +59,7 @@ const CheckboxesInput: InputBackendComponent = ({input, onChange}) => {
           <CheckboxInput
             option={option}
             key={index}
+            checked={selectedOptions.includes(option)}
             onChange={handleClickOption}
           />
         );

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
@@ -1,26 +1,34 @@
 import React, {useMemo} from 'react';
 
 import ListInput from 'etna-js/components/inputs/list_input';
-import DropdownInput from 'etna-js/components/inputs/dropdown_input';
-import {InputBackendComponent, InputSpecification} from "./input_types";
+import DropdownAutocompleteInput from 'etna-js/components/inputs/dropdown_autocomplete_wrapper';
+import {InputBackendComponent, InputSpecification} from './input_types';
 
 export function getAllOptions(data: InputSpecification['data']): string[] {
   return Object.values(data || {}).reduce((acc, n) => {
     if (Array.isArray(n)) acc.push(...n);
-    else if (typeof n === "string") acc.push(n);
-    else acc.push(n + "");
+    else if (typeof n === 'string') acc.push(n);
+    else acc.push(n + '');
 
     return acc;
   }, []);
 }
 
-const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear, onAll}) => {
+const MultiselectStringInput: InputBackendComponent = ({
+  input,
+  onChange,
+  onClear,
+  onAll
+}) => {
   var collator = new Intl.Collator(undefined, {
     numeric: true,
     sensitivity: 'base'
   });
 
-  const options = useMemo(() => getAllOptions(input.data).sort(collator.compare), [input.data]);
+  const options = useMemo(
+    () => getAllOptions(input.data).sort(collator.compare),
+    [input.data]
+  );
 
   return (
     <ListInput
@@ -33,7 +41,7 @@ const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear
             : [input.default]
           : []
       }
-      itemInput={DropdownInput}
+      itemInput={DropdownAutocompleteInput}
       list={options}
       onChange={(e: any) => {
         onChange(input.name, e);
@@ -42,6 +50,6 @@ const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear
       onClear={onClear}
     />
   );
-}
+};
 
 export default MultiselectStringInput;

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
@@ -7,8 +7,8 @@ import {InputBackendComponent, InputSpecification} from './input_types';
 export function getAllOptions(data: InputSpecification['data']): string[] {
   return Object.values(data || {}).reduce((acc, n) => {
     if (Array.isArray(n)) acc.push(...n);
-    else if (typeof n === 'string') acc.push(n);
-    else acc.push(n + '');
+    else if (typeof n === "string") acc.push(n);
+    else acc.push(n + "");
 
     return acc;
   }, []);

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
@@ -14,8 +14,7 @@ export function getAllOptions(data: InputSpecification['data']): string[] {
   }, []);
 }
 
-const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear, onAll
-}) => {
+const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear, onAll}) => {
   var collator = new Intl.Collator(undefined, {
     numeric: true,
     sensitivity: 'base'

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/multiselect_string.tsx
@@ -14,21 +14,14 @@ export function getAllOptions(data: InputSpecification['data']): string[] {
   }, []);
 }
 
-const MultiselectStringInput: InputBackendComponent = ({
-  input,
-  onChange,
-  onClear,
-  onAll
+const MultiselectStringInput: InputBackendComponent = ({input, onChange, onClear, onAll
 }) => {
   var collator = new Intl.Collator(undefined, {
     numeric: true,
     sensitivity: 'base'
   });
 
-  const options = useMemo(
-    () => getAllOptions(input.data).sort(collator.compare),
-    [input.data]
-  );
+  const options = useMemo(() => getAllOptions(input.data).sort(collator.compare), [input.data]);
 
   return (
     <ListInput
@@ -50,6 +43,6 @@ const MultiselectStringInput: InputBackendComponent = ({
       onClear={onClear}
     />
   );
-};
+}
 
 export default MultiselectStringInput;

--- a/vulcan/lib/client/jsx/etna.d.ts
+++ b/vulcan/lib/client/jsx/etna.d.ts
@@ -84,6 +84,10 @@ declare module 'etna-js/components/inputs/dropdown_autocomplete' {
   export default function DropdownAutocomplete(...args: any[]): any;
 }
 
+declare module 'etna-js/components/inputs/dropdown_autocomplete_wrapper' {
+  export default function DropdownAutocompleteInput(...args: any[]): any;
+}
+
 declare module 'etna-js/components/inputs/slow_text_input' {
   export default function SlowTextInput(...args: any[]): any;
 }

--- a/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
+++ b/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
@@ -8,7 +8,7 @@ import {
   WorkflowStep,
 } from "../api_types";
 import {VulcanState} from "../reducers/vulcan_reducer";
-import {GroupedInputStep, UIStep} from "../components/workflow/user_interactions/inputs/input_types";
+import {GroupedInputStep, UIStep, InputSpecification} from "../components/workflow/user_interactions/inputs/input_types";
 
 export const workflowName = (workflow: Workflow | null | undefined) =>
     workflow && workflow.name ? workflow.name.replace('.cwl', '') : null;
@@ -357,4 +357,14 @@ export function unsetDependentInputs(
 export function findSourceDependencies(source: string, workflow: Workflow | null): string[] {
   if (!workflow) return [];
   return Object.keys(workflow.dependencies_of_outputs).filter(k => workflow.dependencies_of_outputs[k].includes(source));
+}
+
+export function sortInputsByLabel(inputs: InputSpecification[]): InputSpecification[] {
+  var collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: 'base'
+  });
+
+  return inputs.sort((a, b) => collator.compare(a.label || a.name, b.label || b.name))
+
 }

--- a/vulcan/lib/client/scss/workflow.scss
+++ b/vulcan/lib/client/scss/workflow.scss
@@ -352,6 +352,18 @@
       }
     }
 
+    .dropdown-autocomplete-input-field {
+      width: inherit;
+
+      input {
+        width: 90%;
+      }
+    }
+
+    .dropdown-autocomplete-options {
+      width: inherit;
+    }
+
     .input-help {
       display: flex;
       align-items: center;


### PR DESCRIPTION
This PR implements sime minor UI changes:

* #329 / #327, changed the multiselect component to use a dropdown with autocomplete.
* #326, inputs in a group or drawer are sorted alphabetically by label, so they shouldn't re-order if you change their values.
* #325, fixes the checkbox inputs to not reset to all-checked after you Run.