### PR TITLE
Deployment script to replace watchtower

### DIFF
--- a/deployer/.dockerignore
+++ b/deployer/.dockerignore
@@ -1,0 +1,1 @@
+# Add project specific dockerignore items.  Base is taken from docker/.dockerignore

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,5 +1,4 @@
 FROM deployer
 
-COPY deployer.sh /bin/deployer
+COPY src/deployer.sh /bin/deployer
 RUN chmod +x /bin/deployer
-ENTRYPOINT /bin/deployer

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,0 +1,5 @@
+FROM deployer
+
+COPY deployer.sh /bin/deployer
+RUN chmod +x /bin/deployer
+ENTRYPOINT /bin/deployer

--- a/deployer/Makefile
+++ b/deployer/Makefile
@@ -5,3 +5,6 @@ include ../make-base/docker-compose.mk
 
 test::
 	docker-compose run deployer_app /test.sh
+
+release-test::
+	docker run --rm --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly --mount type=bind,source=${PWD}/test.sh,target=/test.sh,readonly --mount type=bind,source=${PWD}/TestDockerFile,target=/TestDockerFile,readonly deployer /test.sh

--- a/deployer/Makefile
+++ b/deployer/Makefile
@@ -1,0 +1,7 @@
+app_name=deployer
+
+include ../make-base/stubs.mk
+include ../make-base/docker-compose.mk
+
+test::
+	docker-compose run deployer_app /test.sh

--- a/deployer/TestDockerFile
+++ b/deployer/TestDockerFile
@@ -1,0 +1,3 @@
+FROM busybox:latest
+ARG FILE
+RUN touch $FILE

--- a/deployer/TestDockerFile
+++ b/deployer/TestDockerFile
@@ -1,3 +1,4 @@
 FROM busybox:latest
 ARG FILE
-RUN touch $FILE
+RUN mkdir /$FILE
+RUN touch /$FILE/$FILE

--- a/deployer/deployer.sh
+++ b/deployer/deployer.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -e
+
+prog=$0
+error() {
+   echo "Whoops!  Looks like $1:$2 failed."
+   exit 1
+}
+trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
+
+echoRun() {
+  echo "$@"
+  $@
+}
+
+postToSlack() {
+  post-to-slack "deployer on $(hostname)" "watchtower-ping" "$1"
+}
+
+findContainers() {
+  while read -r line; do
+    set -- $line
+    containerId="$1"
+    labels="$2"
+
+    if echo "$labels" | grep -v "edu.ucsf.mountetna.deployer.disable=true" &>/dev/null; then
+      echo "$containerId"
+    fi
+  done < <(docker ps --format "table {{.ID}}\t{{.Labels}}" $@ | tail -n+2)
+}
+
+findImages() {
+  docker inspect $(findContainers) | jq '[.[].Image | sub("sha256:"; "")] | unique | .[]' -r
+}
+
+findRepoTags() {
+  docker inspect $(findImages) | jq '.[] | select(.RepoTags | length > 0) | .RepoTags[]' -r
+}
+
+findNonRepoTaggedImages() {
+  docker inspect $(findImages) | jq '.[] | select(.RepoTags | length == 0) | .Id' -r
+}
+
+pullImages() {
+  while read -r line; do
+    set -- $line
+    if [[ $1 =~ .*/.*:.* ]]; then
+      echoRun docker pull $1
+    else
+      echo "Skipping $1, not remote image"
+    fi
+  done < <(findRepoTags)
+}
+
+linksForContainer() {
+  docker inspect  $(docker ps -aq) | jq -r "select(.[].NetworkSettings.Networks | map(.Links[]?) | any(match(\"${1}:\")))"
+}
+
+stopNonRepoTaggedImages() {
+  while read line; do
+    set -- $line
+    imageId=$1
+    while read line; do
+      set -- $line
+      containerId=$1
+      linkedFailed=0
+
+      postToSlack "Newer version found, attempting to stop $containerId"
+
+      while read line; do
+        set -- $line
+        linkedContainer=$1
+        set +e
+        echoRun docker stop $linkedContainer
+        if [[ $? -ne 0 ]]; then
+          echo "Stopping $linkedContainer failed, skipping stop for $containerId"
+          linkedFailed=1
+        fi
+        set -e
+      done < <(linksForContainer $containerId)
+
+      if [[ $linkedFailed -eq 0 ]]; then
+        echoRun docker stop $containerId || postToSlack "Could not stop container $containerId, check logs."
+      else
+        postToSlack "Linked containers failed to be stopped, not stopping $containerId."
+      fi
+    done < <(findContainers --filter "ancestor=$imageId")
+  done < <(findNonRepoTaggedImages)
+}
+
+# no while loop here
+# allow systemd to kick this process back up automatically, so that we can test it as a single
+# iteration.
+pullImages
+stopNonRepoTaggedImages
+docker container prune --force
+docker image prune --force
+[[ -z "$IS_TEST" ]] && sleep 300 || true

--- a/deployer/docker-compose.yml
+++ b/deployer/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+services:
+  deployer_app:
+    image: deployer
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./deployer.sh:/bin/deployer
+      - ./test.sh:/test.sh
+      - ./TestDockerFile:/TestDockerFile
+

--- a/deployer/test.sh
+++ b/deployer/test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+error() {
+   echo "Whoops!  Looks testing failed at $1:$2"
+   exit 1
+}
+trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
+
+assertRunning() {
+  if docker ps --filter name=$1 | grep $1 &>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+assertNotRunning() {
+  if docker ps --filter name=$1 | grep -v $1 &>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+docker kill test_a || true
+docker kill test_b || true
+docker kill test_c || true
+docker kill test_d || true
+
+docker image rm image_a:latest || true
+docker image rm image_b:latest || true
+
+docker build --rm --force-rm --tag image_a:latest --build-arg FILE=a -f TestDockerFile /root
+docker build --rm --force-rm --tag image_b:latest --build-arg FILE=b -f TestDockerFile /root
+
+docker run -d --name test_a --rm image_a sleep 100
+docker run -d --name test_b --rm image_a sleep 100
+docker run -d --name test_c --rm image_b sleep 100
+docker run -d --name test_d --rm image_b sleep 100
+
+assertRunning test_a
+assertRunning test_b
+assertRunning test_c
+assertRunning test_d
+
+export IS_TEST=1
+deployer
+
+# Does not stop any containers with up to date images.
+assertRunning test_a
+assertRunning test_b
+assertRunning test_c
+assertRunning test_d
+
+docker build --rm --force-rm --tag image_a:latest  --build-arg FILE=c -f TestDockerFile /root
+
+deployer
+
+# Does not stop any containers with up to date images.
+assertNotRunning test_a
+assertNotRunning test_b
+assertRunning test_c
+assertRunning test_d
+
+docker run -d --name test_a --rm --link test_c:somename image_a sleep 100
+
+deployer
+
+assertRunning test_a
+assertNotRunning test_b
+assertRunning test_c
+assertRunning test_d
+
+docker build --rm --force-rm --tag image_b:latest  --build-arg FILE=d -f TestDockerFile /root
+
+deployer
+
+assertNotRunning test_a
+assertNotRunning test_b
+assertNotRunning test_c
+assertNotRunning test_d

--- a/docker/build_image
+++ b/docker/build_image
@@ -104,6 +104,14 @@ function findNewest() {
    fi
 }
 
+function considerNewest() {
+if [ "$1" -nt "$newestFile" ]; then
+    newestFile="$1"
+fi
+}
+
+considerNewest $DIR/post-to-slack.sh
+
 #- Any FROM clause in the given Dockerfile is processed as a potential dependency to be built before this image.
 while read depImage; do
   baseDepImage=$depImage
@@ -163,8 +171,6 @@ $foundMounts"
     [[ -z "$skipLocalRebuild" ]] && findNewest "$mountPath"
     shift
 done
-
-
 
 #- The build process also combines the docker/.dockerignore file with the Dockerfile project's own for a combined
 #- filtering.

--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+RUN apk add --no-cache bash curl git openssh-client jq
+
+ENV DOCKER_VERSION 19.03.12
+
+# Add the docker client
+RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz > /tmp/docker.tgz
+RUN tar -xf /tmp/docker.tgz -C /tmp/
+RUN mv /tmp/docker/* /usr/local/bin/

--- a/docker/deployer/Makefile
+++ b/docker/deployer/Makefile
@@ -1,0 +1,2 @@
+image:
+	../build_image Dockerfile

--- a/docker/post-to-slack.sh
+++ b/docker/post-to-slack.sh
@@ -16,5 +16,7 @@ MSG=${MSG//^H/\\\b}
 
 if ! [[ -z "$SLACK_WEBHOOK_URL" ]]; then
   curl -X POST --data-urlencode "payload={\"channel\": \"#${CHANNEL}\", \"username\": \"$NAME\", \"text\": \"${MSG}\", \"icon_emoji\": \":ghost:\"}" "$SLACK_WEBHOOK_URL"
+else
+  echo "$MSG > #${CHANNEL}"
 fi
 

--- a/docker/post-to-slack.sh
+++ b/docker/post-to-slack.sh
@@ -14,5 +14,7 @@ MSG=${MSG//^M/\\\r}
 MSG=${MSG//^L/\\\f}
 MSG=${MSG//^H/\\\b}
 
-curl -X POST --data-urlencode "payload={\"channel\": \"#${CHANNEL}\", \"username\": \"$NAME\", \"text\": \"${MSG}\", \"icon_emoji\": \":ghost:\"}" "$SLACK_WEBHOOK_URL"
+if ! [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+  curl -X POST --data-urlencode "payload={\"channel\": \"#${CHANNEL}\", \"username\": \"$NAME\", \"text\": \"${MSG}\", \"icon_emoji\": \":ghost:\"}" "$SLACK_WEBHOOK_URL"
+fi
 


### PR DESCRIPTION
Bash + jq + docker

systemd runs the script every, X minutes (5)
Script pulls each image associated with a running container that does not have disable label set.
Script checks each container to ensure that its current image has a repo tag (would be up to date), and stops any that do not (have updated already from the pull.  they get restarted by systemd)
Script checks each container to ensure that, if it uses a volumes from clause, it contains all the mounts of the most up to date version of that container.  If not, it stops that contain.  (This is how app_fe containers pull updated static assets from updated app containers).

Also notifies slack at every step.

Why hand roll over watchtower?
To be honest, watchtower has way too many features, and the interactivity of those features causes all kinds of strange behavior that is frustrating to deal with.  Here, I hand rolled because what we wanted was _less features_ and a more grok-able behavior.

There will be some small chef changes to compliment.