### PR TITLE
use non-rails methods for finding user

### DIFF
--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -18,5 +18,6 @@ group :test do
   gem 'factory_bot'
   gem 'simplecov'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'database_cleaner', '1.8.5'
 end

--- a/janus/Gemfile
+++ b/janus/Gemfile
@@ -10,6 +10,7 @@ gem 'etna', path: '/etna'
 gem 'jwt'
 gem 'puma', '>=5.0.2'
 gem 'concurrent-ruby'
+gem 'activesupport', '>= 4.2.6'
 
 group :test do
   gem 'rspec'

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -12,12 +12,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     database_cleaner (1.8.5)
@@ -25,12 +26,12 @@ GEM
     docile (1.3.5)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jwt (2.2.2)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multipart-post (2.1.1)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -39,9 +40,12 @@ GEM
     nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     pg (1.2.3)
-    pry (0.14.0)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -65,7 +69,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    sequel (5.41.0)
+    sequel (5.43.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -89,6 +93,7 @@ DEPENDENCIES
   jwt
   pg
   pry
+  pry-byebug
   puma (>= 5.0.2)
   rack
   rack-test

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -86,6 +86,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (>= 4.2.6)
   concurrent-ruby
   database_cleaner (= 1.8.5)
   etna!
@@ -107,4 +108,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.2.15
+   2.2.16

--- a/janus/lib/janus.rb
+++ b/janus/lib/janus.rb
@@ -1,4 +1,5 @@
 require 'sequel'
+require 'active_support/all'
 
 class Janus
   include Etna::Application

--- a/janus/lib/models/user.rb
+++ b/janus/lib/models/user.rb
@@ -33,8 +33,7 @@ class User < Sequel::Model
   def self.from_token(token)
     payload, header = Janus.instance.sign.jwt_decode(token)
 
-    payload = payload.transform_keys(&:to_sym)
-    payload.delete(:exp)
+    payload = payload.symbolize_keys.except(:exp)
 
     user = User[email: payload[:email]]
 

--- a/janus/lib/models/user.rb
+++ b/janus/lib/models/user.rb
@@ -33,7 +33,8 @@ class User < Sequel::Model
   def self.from_token(token)
     payload, header = Janus.instance.sign.jwt_decode(token)
 
-    payload = payload.symbolize_keys.except(:exp)
+    payload = payload.transform_keys(&:to_sym)
+    payload.delete(:exp)
 
     user = User[email: payload[:email]]
 


### PR DESCRIPTION
This PR fixes instantiating a user from a token in Janus, which is used by the task token API. I was getting this exception:

```
Caught unspecified error
docker[26165]: ERROR:2021-04-13T13:53:37+00:00 9hwba4 undefined method `symbolize_keys' for #<Hash:0x0000555581ab1220>
docker[26165]: ERROR:2021-04-13T13:53:37+00:00 9hwba4 /app/lib/models/user.rb:36:in `from_token'
docker[26165]: ERROR:2021-04-13T13:53:37+00:00 9hwba4 /app/lib/server/controllers/authorization_controller.rb:75:in `generate'
docker[26165]: ERROR:2021-04-13T13:53:37+00:00 9hwba4 /etna/lib/etna/controller.rb:25:in `response'
```

Because `symbolize_keys` and `except` are Rails / ActiveSupport methods. The tests pass because `factory_bot` includes `active_support` as a dependency, but in the deployed version of the app, task token generation fails (locally and in production).

The alternative approach to this PR, if you prefer, is that we just include `active_support` as a production dependency in the Gemfile and app.

~~Note that I'm working on the Vulcan select-a-project work, and that requires this feature to be working in production, first.~~