### PR TITLE
Magma search improvements

### DIFF
--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -26,6 +26,9 @@ class Magma
             alias_method "#{attribute.attribute_name}=", "#{attribute.column_name}="
           end
         end
+
+        # Table models should always have an identifier attribute
+        self.attributes[self.identity.name] = self.identity unless self.attributes.key?(self.identity.name)
       end
 
       def project_name

--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -279,6 +279,24 @@ EOT
       )
     end
 
+    def double_cast_constraint column_name, operator, value
+      Magma::Constraint.new(
+        alias_name,
+        Sequel.lit(
+          "CAST(? as DOUBLE PRECISION) #{operator.sub(/::/,'')} ?",
+          Sequel.qualify(alias_name, column_name),
+          value
+        )
+      )
+    end
+
+    def is_numeric_constraint column_name      
+      Magma::Constraint.new(
+        alias_name,
+        Sequel.qualify(alias_name, column_name) => Regexp.new(/\d+/)
+      )
+    end
+
     def invalid_argument! argument
       raise QuestionError, "Expected an argument to #{self.class.name}" if argument.nil?
       raise QuestionError, "#{argument} is not a valid argument to #{self.class.name}"

--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -279,7 +279,7 @@ EOT
       )
     end
 
-    def double_cast_constraint column_name, operator, value
+    def double_cast_comparison_constraint column_name, operator, value
       Magma::Constraint.new(
         alias_name,
         Sequel.lit(

--- a/magma/lib/magma/query/predicate/string.rb
+++ b/magma/lib/magma/query/predicate/string.rb
@@ -43,5 +43,18 @@ class Magma
         not_constraint(@column_name, @arguments[1])
       end
     end
+
+    verb [ '::<=', '::<', '::>=', '::>' ], String do
+      child TrueClass
+
+      constraint do
+        and_constraint(
+          [
+            is_numeric_constraint(@column_name),
+            double_cast_constraint(@column_name, @arguments[0], @arguments[1].to_f)
+          ]
+        )
+      end
+    end
   end
 end

--- a/magma/lib/magma/query/predicate/string.rb
+++ b/magma/lib/magma/query/predicate/string.rb
@@ -51,7 +51,7 @@ class Magma
         and_constraint(
           [
             is_numeric_constraint(@column_name),
-            double_cast_constraint(@column_name, @arguments[0], @arguments[1].to_f)
+            double_cast_comparison_constraint(@column_name, @arguments[0], @arguments[1].to_f)
           ]
         )
       end

--- a/magma/lib/magma/retrieval.rb
+++ b/magma/lib/magma/retrieval.rb
@@ -207,6 +207,8 @@ class Magma
           return "::equals"
         when "~"
           return "::matches"
+        when "<=", ">=", ">", "<"
+          return "::#{operator}"
         else
           raise ArgumentError, "Invalid operator #{operator} for string attribute!"
         end

--- a/magma/lib/magma/retrieval.rb
+++ b/magma/lib/magma/retrieval.rb
@@ -160,17 +160,7 @@ class Magma
       end
     end
 
-    class StringFilter
-      def initialize filter
-        @filter = filter || ""
-      end
-
-      def apply(attributes)
-        @filter.split(/\s/).map do |term|
-          filter_term(term, attributes)
-        end.compact
-      end
-
+    class Filter
       FILTER_TERM = /^
         ([\w]+)
         (=|<|>|>=|<=|~)
@@ -231,6 +221,30 @@ class Magma
         when "false"
           return "::false"
         end
+      end
+    end
+
+    class StringFilter < Magma::Retrieval::Filter
+      def initialize filter
+        @filter = filter || ""
+      end
+
+      def apply(attributes)
+        @filter.split(/\s/).map do |term|
+          filter_term(term, attributes)
+        end.compact
+      end
+    end
+
+    class JsonFilter < Magma::Retrieval::Filter
+      def initialize filters
+        @filters = filters || []
+      end
+
+      def apply(attributes)
+        @filters.map do |term|
+          filter_term(term, attributes)
+        end.compact
       end
     end
   end

--- a/magma/lib/magma/server/retrieve.rb
+++ b/magma/lib/magma/server/retrieve.rb
@@ -110,7 +110,7 @@ class RetrieveController < Magma::Controller
         Magma.instance.get_model(@project_name, @model_name),
         @record_names,
         @attribute_names,
-        [ Magma::Retrieval::StringFilter.new(@filter) ],
+        filter,
         true,
         !@collapse_tables
       )
@@ -126,7 +126,7 @@ class RetrieveController < Magma::Controller
       model,
       @record_names,
       @attribute_names,
-      filters: [ Magma::Retrieval::StringFilter.new(@filter) ],
+      filters: filter,
       collapse_tables: true,
       show_disconnected: @show_disconnected,
       user: @user,
@@ -185,5 +185,11 @@ class RetrieveController < Magma::Controller
         false
       )
     end
+  end
+
+  def filter
+    @filter.is_a?(Array) ?
+      [ Magma::Retrieval::JsonFilter.new(@filter) ] :
+      [ Magma::Retrieval::StringFilter.new(@filter) ]
   end
 end

--- a/magma/spec/fixtures/labors_model_attributes.yml
+++ b/magma/spec/fixtures/labors_model_attributes.yml
@@ -41,6 +41,8 @@ labor:
     type: matrix
     validation: '{"type":"Array", "value":["Athens","Sparta","Sidon","Thebes"]}'
     column_name: old_contributions
+  characteristic:
+    type: table
 monster:
   labor:
     type: parent
@@ -88,6 +90,14 @@ prize:
   worth:
     type: integer
     column_name: old_worth
+characteristic:
+  labor:
+    type: parent
+    column_name: labor_id
+  name:
+    type: string
+  value:
+    type: string
 project:
   name:
     type: identifier

--- a/magma/spec/labors/migrations/20_add_characteristic_table.rb
+++ b/magma/spec/labors/migrations/20_add_characteristic_table.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table(Sequel[:labors][:characteristics]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      foreign_key :labor_id, Sequel[:labors][:labors]
+      index :labor_id
+      String :name
+      String :value
+    end
+  end
+end

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -360,7 +360,7 @@ describe QueryController do
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
-    it 'ignores ::> for strings' do
+    it 'ignores ::> for non-numeric strings' do
       query(
         [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::>", "5"], '::all', '::identifier' ]
       )
@@ -378,7 +378,7 @@ describe QueryController do
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
-    it 'ignores ::>= for strings' do
+    it 'ignores ::>= for non-numeric strings' do
       query(
         [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::>=", "5"], '::all', '::identifier' ]
       )
@@ -396,7 +396,7 @@ describe QueryController do
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
-    it 'ignores ::< for strings' do
+    it 'ignores ::< for non-numeric strings' do
       query(
         [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::<", "5"], '::all', '::identifier' ]
       )
@@ -414,7 +414,7 @@ describe QueryController do
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
-    it 'ignores ::<= for strings' do
+    it 'ignores ::<= for non-numeric strings' do
       query(
         [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::<=", "5"], '::all', '::identifier' ]
       )

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -296,6 +296,14 @@ describe QueryController do
       lion = create(:labor, name: 'Nemean Lion', number: 1, completed: true, project: @project)
       hydra = create(:labor, name: 'Lernean Hydra', number: 2, completed: false, project: @project)
       stables = create(:labor, name: 'Augean Stables', number: 5, completed: false, project: @project)
+
+      @lion_difficulty = create(:characteristic, labor: lion, name: "difficulty", value: "10" )
+      @hydra_difficulty = create(:characteristic, labor: hydra, name: "difficulty", value: "2" )
+      @stables_difficulty = create(:characteristic, labor: stables, name: "difficulty", value: "5" )
+    
+      lion_stance = create(:characteristic, labor: lion, name: "stance", value: "wrestling" )
+      hydra_stance = create(:characteristic, labor: hydra, name: "stance", value: "hacking" )
+      stables_stance = create(:characteristic, labor: stables, name: "stance", value: "shoveling" )
     end
 
     it 'supports ::matches' do
@@ -341,6 +349,78 @@ describe QueryController do
 
       expect(json_body[:answer].first.last).to eq('Augean Stables')
       expect(json_body[:format]).to eq(['labors::labor#name', 'labors::labor#name'])
+    end
+
+    it 'supports ::> for numeric strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@lion_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'ignores ::> for strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::>", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer]).to eq([])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'supports ::>= for numeric strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>=", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@lion_difficulty.id, @stables_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'ignores ::>= for strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::>=", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer]).to eq([])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'supports ::< for numeric strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@hydra_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'ignores ::< for strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::<", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer]).to eq([])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'supports ::<= for numeric strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<=", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@hydra_difficulty.id, @stables_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+    end
+
+    it 'ignores ::<= for strings' do
+      query(
+        [ 'characteristic', [ "name", "::matches", "stance" ], ["value", "::<=", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer]).to eq([])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
   end
 

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -299,7 +299,7 @@ describe QueryController do
 
       @lion_difficulty = create(:characteristic, labor: lion, name: "difficulty", value: "10" )
       @hydra_difficulty = create(:characteristic, labor: hydra, name: "difficulty", value: "2" )
-      @stables_difficulty = create(:characteristic, labor: stables, name: "difficulty", value: "5" )
+      @stables_difficulty = create(:characteristic, labor: stables, name: "difficulty", value: "5.1" )
     
       lion_stance = create(:characteristic, labor: lion, name: "stance", value: "wrestling" )
       hydra_stance = create(:characteristic, labor: hydra, name: "stance", value: "hacking" )
@@ -353,10 +353,17 @@ describe QueryController do
 
     it 'supports ::> for numeric strings' do
       query(
-        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>", "5"], '::all', '::identifier' ]
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>", "5.1"], '::all', '::identifier' ]
       )
 
       expect(json_body[:answer].map { |a| a.last }).to eq([@lion_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>", "5"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@lion_difficulty.id, @stables_difficulty.id])
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
@@ -371,7 +378,7 @@ describe QueryController do
 
     it 'supports ::>= for numeric strings' do
       query(
-        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>=", "5"], '::all', '::identifier' ]
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::>=", "5.1"], '::all', '::identifier' ]
       )
 
       expect(json_body[:answer].map { |a| a.last }).to eq([@lion_difficulty.id, @stables_difficulty.id])
@@ -389,10 +396,17 @@ describe QueryController do
 
     it 'supports ::< for numeric strings' do
       query(
-        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<", "5"], '::all', '::identifier' ]
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<", "5.1"], '::all', '::identifier' ]
       )
 
       expect(json_body[:answer].map { |a| a.last }).to eq([@hydra_difficulty.id])
+      expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
+
+      query(
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<", "5.2"], '::all', '::identifier' ]
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq([@hydra_difficulty.id, @stables_difficulty.id])
       expect(json_body[:format]).to eq(['labors::characteristic#id', 'labors::characteristic#id'])
     end
 
@@ -407,7 +421,7 @@ describe QueryController do
 
     it 'supports ::<= for numeric strings' do
       query(
-        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<=", "5"], '::all', '::identifier' ]
+        [ 'characteristic', [ "name", "::matches", "difficulty" ], ["value", "::<=", "5.1"], '::all', '::identifier' ]
       )
 
       expect(json_body[:answer].map { |a| a.last }).to eq([@hydra_difficulty.id, @stables_difficulty.id])

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -520,6 +520,35 @@ describe RetrieveController do
       expect(json_body[:models][:labor][:documents].count).to eq(2)
     end
 
+    it 'can use a JSON filter' do
+      lion = create(:labor, :lion, completed: true, project: @project)
+      hydra = create(:labor, :hydra, completed: false, project: @project)
+      stables = create(:labor, :stables, completed: true, project: @project)
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: ['name~L']
+      )
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:labor][:documents].count).to eq(2)
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: ['name~L', 'completed=true']
+      )
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:labor][:documents].count).to eq(1)
+    end
+
+
     it 'can filter numeric strings' do
       lion = create(:labor, :lion, project: @project)
       hydra = create(:labor, :hydra, project: @project)

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -546,6 +546,17 @@ describe RetrieveController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:models][:labor][:documents].count).to eq(1)
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'labor',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: ['name=Lernean Hydra']
+      )
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:labor][:documents].count).to eq(1)
     end
 
 

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -546,6 +546,12 @@ describe RetrieveController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:models][:labor][:documents].count).to eq(1)
+    end
+
+    it 'can have spaces when using a JSON filter' do
+      lion = create(:labor, :lion, completed: true, project: @project)
+      hydra = create(:labor, :hydra, completed: false, project: @project)
+      stables = create(:labor, :stables, completed: true, project: @project)
 
       retrieve(
         project_name: 'labors',

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -520,6 +520,42 @@ describe RetrieveController do
       expect(json_body[:models][:labor][:documents].count).to eq(2)
     end
 
+    it 'can filter numeric strings' do
+      lion = create(:labor, :lion, project: @project)
+      hydra = create(:labor, :hydra, project: @project)
+      stables = create(:labor, :stables, project: @project)
+
+      lion_difficulty = create(:characteristic, labor: lion, name: "difficulty", value: "10" )
+      hydra_difficulty = create(:characteristic, labor: hydra, name: "difficulty", value: "2" )
+      stables_difficulty = create(:characteristic, labor: stables, name: "difficulty", value: "5" )
+    
+      lion_stance = create(:characteristic, labor: lion, name: "stance", value: "wrestling" )
+      hydra_stance = create(:characteristic, labor: hydra, name: "stance", value: "hacking" )
+      stables_stance = create(:characteristic, labor: stables, name: "stance", value: "shoveling" )
+    
+      retrieve(
+        project_name: 'labors',
+        model_name: 'characteristic',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: 'name~difficulty value>5'
+      )
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:characteristic][:documents].count).to eq(1)
+
+
+      retrieve(
+        project_name: 'labors',
+        model_name: 'characteristic',
+        record_names: 'all',
+        attribute_names: 'all',
+        filter: 'name~stance value>5'
+      )
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:models][:characteristic][:documents].count).to eq(0)
+    end
+
     it 'can filter on numbers' do
       stables = create(:labor, :stables, project: @project)
       poison = create(:prize, name: 'poison', worth: 5, labor: stables)

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -283,7 +283,7 @@ FactoryBot.define do
 
   factory :characteristic, class: Labors::Characteristic do
     to_create(&:save)
-    sequence(:name) { |n| "favorite#{n}" }
+    sequence(:name) { |n| "characteristic#{n}" }
   end
 end
 

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -257,6 +257,7 @@ FactoryBot.define do
     to_create(&:save)
     sequence(:name) { |n| "prize#{n}" }
   end
+
   factory :codex, class: Labors::Codex do
     to_create(&:save)
 
@@ -278,6 +279,11 @@ FactoryBot.define do
 
   factory :habitat, class: Labors::Habitat do
     to_create(&:save)
+  end
+
+  factory :characteristic, class: Labors::Characteristic do
+    to_create(&:save)
+    sequence(:name) { |n| "favorite#{n}" }
   end
 end
 


### PR DESCRIPTION
This PR implements some small search improvements:

- Adds support for `<`, `>`, `<=`, and `>=` for string predicates. They will only return values where the value is inherently a "numeric string" and can be cast to a numeric value, i.e. works for `"20"` but not for `"platypus"`. Works for both `/query` and `/retrieve`. This should let folks use the Search page to filter table columns that are numeric but typed as strings.
- Updates the `/retrieve` `filter` param to also accept a JSON array of filters. This means that we can support spaces in any filter to that endpoint -- will require changes to the front-end (future PR).