### PR TITLE
Magma search UI spaces

### DIFF
--- a/timur/lib/client/jsx/components/search/query_builder.jsx
+++ b/timur/lib/client/jsx/components/search/query_builder.jsx
@@ -56,7 +56,7 @@ export function QueryBuilder({ display_attributes, setFilterString, selectedMode
       }
 
       return `${attribute}${operator}${operand}`;
-    }).join(" "))
+    }))
   }, [setFilterString, filtersState]);
 
   const onOpenAttributeFilter = () => {

--- a/timur/lib/client/jsx/components/search/search.jsx
+++ b/timur/lib/client/jsx/components/search/search.jsx
@@ -13,7 +13,6 @@ import {
 import {
   selectSearchCache,
   selectSearchAttributeNames,
-  selectSearchFilterParams,
   selectSearchFilterString,
   selectSearchShowDisconnected,
   selectSelectedModel,
@@ -163,7 +162,6 @@ export default connect(
     display_attributes: selectSortedDisplayAttributeNames(state),
     filter_string: selectSearchFilterString(state),
     show_disconnected: selectSearchShowDisconnected(state),
-    filter_params: selectSearchFilterParams(state),
     magma_state: state.magma
   }),
   {

--- a/timur/lib/client/jsx/reducers/search_reducer.js
+++ b/timur/lib/client/jsx/reducers/search_reducer.js
@@ -62,19 +62,14 @@ const searchReducer = (search, action) => {
         attribute_names: action.attribute_names
       };
     case SET_SHOW_DISCONNECTED:
-      // User is using advanced filtering, so make sure to clear out
-      //   any (basic) filter_params
       return {
         ...search,
         show_disconnected: action.show_disconnected
       };
     case SET_FILTER_STRING:
-      // User is using advanced filtering, so make sure to clear out
-      //   any (basic) filter_params
       return {
         ...search,
-        filter_string: action.filter_string,
-        filter_params: null
+        filter_string: action.filter_string
       };
     case CLEAR_FILTER_STRING:
       return {

--- a/timur/lib/client/jsx/selectors/search.js
+++ b/timur/lib/client/jsx/selectors/search.js
@@ -101,8 +101,3 @@ export const selectSearchShowDisconnected = createSelector(
   selectSearchData,
   (search) => search.show_disconnected
 );
-
-export const selectSearchFilterParams = createSelector(
-  selectSearchData,
-  (search) => search.filter_params
-);

--- a/timur/test/javascript/reducers/search.test.js
+++ b/timur/test/javascript/reducers/search.test.js
@@ -6,7 +6,7 @@ import {
   SET_SEARCH_PAGE_SIZE,
   SET_SEARCH_ATTRIBUTE_NAMES,
   SET_FILTER_STRING,
-  CLEAR_FILTER_STRING,
+  CLEAR_FILTER_STRING
 } from '../../../lib/client/jsx/actions/search_actions';
 
 describe('search reducer', () => {
@@ -153,13 +153,12 @@ describe('search reducer', () => {
     expect(
       reducer(
         {
-          filter_params: [{attribute: 'species', operator: '==', value: 'lion'}]
+          filter_string: ['something=else']
         },
         {type: SET_FILTER_STRING, filter_string: 'all'}
       )
     ).toEqual({
-      filter_string: 'all',
-      filter_params: null
+      filter_string: 'all'
     });
   });
 

--- a/timur/test/javascript/selectors/search.test.js
+++ b/timur/test/javascript/selectors/search.test.js
@@ -1,6 +1,5 @@
 import {
   selectSearchAttributeNames,
-  selectSearchFilterParams,
   selectSearchFilterString,
   selectSortedDisplayAttributeNames
 } from '../../../lib/client/jsx/selectors/search';
@@ -25,29 +24,11 @@ describe('selectSearchAttributeNames', () => {
   });
 });
 
-describe('selectSearchFilterParams', () => {
-  it('returns the filter_params from the search state', () => {
-    let state = {
-      search: {
-        attribute_names: ['name', 'stats', 'species'],
-        filter_params: [{attribute: 'species', operator: '=', value: 'lion'}]
-      }
-    };
-
-    let filter_params = selectSearchFilterParams(state);
-
-    expect(filter_params).toEqual([
-      {attribute: 'species', operator: '=', value: 'lion'}
-    ]);
-  });
-});
-
 describe('selectSearchFilterString', () => {
   it('returns the filter_string from the search state', () => {
     let state = {
       search: {
         attribute_names: ['name', 'stats', 'species'],
-        filter_params: [{attribute: 'species', operator: '=', value: 'lion'}],
         filter_string: 'all'
       }
     };


### PR DESCRIPTION
This PR cleans up a little bit of old search code and updates the basic filtering to send back a JSON array of filters, which means that you can use spaces in search strings under basic filtering.

Note, I didn't enable this for advanced filtering on the assumption that most folks are using basic.