### PR TITLE
make tsv filename more specific

### DIFF
--- a/magma/lib/magma/server/retrieve.rb
+++ b/magma/lib/magma/server/retrieve.rb
@@ -137,7 +137,9 @@ class RetrieveController < Magma::Controller
       Magma::TSVWriter.new(model, retrieval, @payload).write_tsv{ |lines| stream << lines }
     end
 
-    return [ 200, { 'Content-Type' => 'text/tsv', 'Content-Disposition' => 'inline; filename="results.tsv' }, tsv_stream ]
+    filename = "#{@project_name}_#{@model_name}_results_#{DateTime.now.strftime("%Y_%m_%d_%H_%M_%S")}.tsv"
+
+    return [ 200, { 'Content-Type' => 'text/tsv', 'Content-Disposition' => "inline; filename=\"#{filename}\"" }, tsv_stream ]
   end
 
   def retrieve_model(model, record_names, attribute_names, filters, use_pages, get_tables)


### PR DESCRIPTION
This is a small PR to make the Magma TSV download filename include more data, so it's a bit clearer to the user what they downloaded. Filename now includes project name, model name, and a date / timestamp.