### PR TITLE
Etna gem load tables

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.34'
+  spec.version           = '0.1.35'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -339,7 +339,7 @@ class EtnaApp
             request = Etna::Clients::Magma::RetrievalRequest.new(project_name: project_name)
             request.model_name = model_name
             request.attribute_names = 'all'
-            request.record_names = 'all'
+            request.record_names = []
             model = magma_client.retrieve(request).models.model(model_name)
             model_parent_name = model.template.attributes.all.select do |attribute|
               attribute.attribute_type == Etna::Clients::Magma::AttributeType::PARENT

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post
@@ -43,7 +43,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.2)
+    jwt (2.2.3)
     method_source (1.0.0)
     mini_magick (4.11.0)
     minitest (5.14.4)

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post
@@ -55,7 +55,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
-    jwt (2.2.2)
+    jwt (2.2.3)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post
@@ -34,7 +34,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.2)
+    jwt (2.2.3)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.2)

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.34)
+    etna (0.1.35)
       concurrent-ruby
       jwt
       multipart-post
@@ -35,7 +35,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.2)
+    jwt (2.2.3)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.1)


### PR DESCRIPTION
This PR fixes a performance issue when loading tables via the gem. When many records are already populated, trying to do an initial fetch of the templates would time out / fail, because of the large number of existing records. By not fetching all records (which aren't needed anyways for table loading), the process does not time out and runs more smoothly.