### PR TITLE
skip unparseable dates from redcap

### DIFF
--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -116,7 +116,11 @@ module Redcap
         # eventually, we hope, magma will do this
         return nil if value.empty?
 
-        return (DateTime.parse(value) - offset_days(id)).iso8601[0..9]
+        begin
+          return (DateTime.parse(value) - offset_days(id)).iso8601[0..9]
+        rescue ArgumentError
+          return nil
+        end
       when "float"
         return value.to_f
       when "integer"


### PR DESCRIPTION
Sometimes dates are not written as dates (I encountered "NR", not sure what this means); this is a bugfix to optimistically parse a date but bail with a nil if there is a problem, same as the behavior if the value is empty.