### PR TITLE
Adding the runner user to the apache images

### DIFF
--- a/docker/etna-apache/Dockerfile
+++ b/docker/etna-apache/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 ENV DOCKERIZE_VERSION 0.6.1
 ENV DOCKERIZE_URL https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 
+RUN groupadd -g 1002 runner
+RUN useradd -ms /bin/bash -u 1002 -g 1002 runner
 RUN apt-get update -y
 RUN apt-get install -y libapache2-mod-xsendfile libapache2-mod-shib2 xmlsec1 curl
 RUN curl -o /tmp/dockerize.tgz -L $DOCKERIZE_URL && ( cd /usr/bin && tar xzf /tmp/dockerize.tgz )


### PR DESCRIPTION
Apache enforces running its httpd subprocesses as some non root user.  By default it selects one based on the users available in the image of the container itself (which don't map to the permissions on the host).

To fix this, we add the `runner` user to the image.  Currently, this id (1002) is reserved and configured in production for the same purpose.

Unfortunately, there doesn't seem to be a good option other than the enforce a consistent id for the user and share that, since the kernel file system permissions model is actually in terms of user ids, not user names.  We must ensure then that the production user ids of the hosts line up with the user ids of the inner http process.

I'll ponder if there is any more creative solution, but this has to work for now.