### PR TITLE
Allow flexibility in the number of model#attribute features to use for UMAP workflow record selection

### DIFF
--- a/vulcan/lib/server/workflows/scripts/parse_record_selections.py
+++ b/vulcan/lib/server/workflows/scripts/parse_record_selections.py
@@ -4,28 +4,19 @@ from archimedes.functions.list import unique, flatten
 from archimedes.functions.environment import project_name
 
 pdat = input_json("project_data")[project_name]
-selection_options = list(pdat['selection_options'].values())
+selection_atts = pdat['selection_options']
+
+selected = input_json('selected_options')
 
 magma = connect()
 
-select1 = input_json('select1')
-select2 = input_json('select2')
-select3 = input_json('select3')
-
 # Experiment and Tissue (AND logic)
 filters = []
-if len(select1) > 0:
-    filters.append(
-        buildTargetPath( selection_options[0], pdat ) + ['::in', select1]
-    )
-if len(select2) > 0:
-    filters.append(
-        buildTargetPath( selection_options[1], pdat ) + ['::in', select2]
-    )
-if len(select3) > 0:
-    filters.append(
-        buildTargetPath( selection_options[2], pdat ) + ['::in', select3]
-    )
+for set in list(selected.keys()):
+    if len(selected[set]) > 0:
+        filters.append(
+            buildTargetPath( selection_atts[set], pdat ) + ['::in', selected[set]]
+        )
 
 seq_target = parseModelAttr(pdat['seq_h5_counts_data'])
 

--- a/vulcan/lib/server/workflows/scripts/retrieve_selection_options.py
+++ b/vulcan/lib/server/workflows/scripts/retrieve_selection_options.py
@@ -4,7 +4,7 @@ from archimedes.functions.list import unique, flatten
 from archimedes.functions.environment import project_name
 
 pdat = input_json("project_data")[project_name]
-selection_options = list(pdat['selection_options'].values())
+selection_options = pdat['selection_options']
 
 seq_target = parseModelAttr(pdat['seq_h5_counts_data'])
 q_start = [
@@ -15,21 +15,13 @@ q_start = [
 
 magma = connect()
 
-select1 = question(
-    magma,
-    q_start + buildTargetPath( selection_options[0], pdat )
-)
+options = dict([
+    [ 
+        key,
+        unique(flatten(question(
+            magma,
+            q_start + buildTargetPath( selection_options[key], pdat )
+        )))
+    ] for key in list(selection_options.keys()) ])
 
-select2 = question(
-    magma,
-    q_start + buildTargetPath( selection_options[1], pdat )
-)
-
-select3 = question(
-    magma,
-    q_start + buildTargetPath( selection_options[2], pdat )
-)
-
-output_json(unique(select1), 'select1')
-output_json(unique(select2), 'select2')
-output_json(unique(select3), 'select3')
+output_json(options, 'selection_options')

--- a/vulcan/lib/server/workflows/umap.cwl
+++ b/vulcan/lib/server/workflows/umap.cwl
@@ -117,36 +117,20 @@ steps:
     label: 'Fetch selection options'
     in:
       project_data: projectData/project_data
-    out: [select1, select2, select3]
-  Select_Records__selection1:
+    out: [selection_options]
+  Select_Records__selectOnFeatures:
     run: ui-queries/multiselect-string-all.cwl
-    label: 'Select on feature 1'
-    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Feature1. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
+    label: 'Record Selection (fill out all options)'
+    doc: 'Selections here pick the subset of tube records to process and analyze. Select the values of the given features that you would like to target. The union of single-cell tube records that meet these criteria will be presented for confirmation, in the next step, based on the union of ALL feature selections here. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
-      a: queryMagma/select1
-    out: [options]
-  Select_Records__selection2:
-    run: ui-queries/multiselect-string-all.cwl
-    label: 'Select on feature 2'
-    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Featur2. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
-    in:
-      a: queryMagma/select2
-    out: [options]
-  Select_Records__selection3:
-    run: ui-queries/multiselect-string-all.cwl
-    label: 'Select on feature 3'
-    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Featur2. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
-    in:
-      a: queryMagma/select3
-    out: [options]
+      a: queryMagma/selection_options
+    out: [selected_options]
   parse_record_selections:
     run: scripts/parse_record_selections.cwl
     label: 'Interpret record selection inputs.'
     in:
       project_data: projectData/project_data
-      select1: Select_Records__selection1/options
-      select2: Select_Records__selection2/options
-      select3: Select_Records__selection3/options
+      select1: Select_Records__selectOnFeatures/selected_options
     out: [tube_recs]
   verifyRecordNames:
     run: ui-queries/checkboxes.cwl

--- a/vulcan/lib/server/workflows/umap.cwl
+++ b/vulcan/lib/server/workflows/umap.cwl
@@ -118,24 +118,24 @@ steps:
     in:
       project_data: projectData/project_data
     out: [select1, select2, select3]
-  Select_Records__pickExperiments:
+  Select_Records__selection1:
     run: ui-queries/multiselect-string-all.cwl
-    label: 'Select Experiments'
-    doc: 'Picks the set of experiment:alias options to use. These selections get combined with Tissue and Cell Fraction selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
+    label: 'Select on feature 1'
+    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Feature1. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
       a: queryMagma/select1
     out: [options]
-  Select_Records__pickTissues:
+  Select_Records__selection2:
     run: ui-queries/multiselect-string-all.cwl
-    label: 'Select Tissues'
-    doc: 'Picks the set of biospecimen_group:biospecimen_type options to use. These selections get combined with Experiment and Cell Fraction selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
+    label: 'Select on feature 2'
+    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Featur2. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
       a: queryMagma/select2
     out: [options]
-  Select_Records__pickFractions:
+  Select_Records__selection3:
     run: ui-queries/multiselect-string-all.cwl
-    label: 'Select Sort Fractions'
-    doc: 'Picks the set of sc_seq:cell_faction options to use. These selections get combined with Experiment and Tissue selections with AND logic. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
+    label: 'Select on feature 3'
+    doc: 'Among the data pointed to, for this project, in the overall documentation, selections here pick the subset of values from Featur2. The union of records indicated for inclusion by ALL selection sets here, Feature1 & Feature2 & Feature3, are what will be presenting for confimation in the next step. If you want to just select tube records directly, pick the `All` option for all dropdowns here.'
     in:
       a: queryMagma/select3
     out: [options]
@@ -144,9 +144,9 @@ steps:
     label: 'Interpret record selection inputs.'
     in:
       project_data: projectData/project_data
-      select1: Select_Records__pickExperiments/options
-      select2: Select_Records__pickTissues/options
-      select3: Select_Records__pickFractions/options
+      select1: Select_Records__selection1/options
+      select2: Select_Records__selection2/options
+      select3: Select_Records__selection3/options
     out: [tube_recs]
   verifyRecordNames:
     run: ui-queries/checkboxes.cwl


### PR DESCRIPTION
Adjusts:
- the output of `retrieve_selection_options.py` to be a JSON hash, which can have any number of keys, instead of being exactly 3 separate lists. output here => input of the widget in which users make selections
- the expected input of `parse_record_selections.py` to be a similarly structured JSON hash.
- the CWL accordingly for these and the selection widget in between them

These changes would be in anticipation of a `multi-multiselect` widget in which:
- CWL `label` encodes a main title & `doc` encodes a single (?) hover-button
- input and output could both look like this for HuMu (output might often be just a subset of these values for each hash element, but the keys will always match between in and out!) :
```
{
  "Experiment": [
    "NMR2",
    "PyMT3",
    "Gnoto 1 - 4T1",
    "B16F10 ABx vs HFD",
    "10X GRN NINA",
    "LLC ABx vs HFD",
    "MC38 ABx vs HFD",
    "B78mChOVA with Kelly",
    "RENCA ABx vs HFD",
    "4T1 ABx vs HFD",
    "CT26 ABx vs HFD",
    "PDAC 6",
    "PyMT1",
    "PyMT2"
  ],
  "Tissue": [
    "Spleen",
    "Tumor",
    "Blood",
    "dLN"
  ],
  "Fraction": [
    "lymphoid",
    "myeloid",
    "tumor associated macrophages 1",
    "tumor associated macrophages 2"
  ]
}
```

That's to go along with the HuMu selection_options project-data which looks like:
```
{
  'Experiment': 'experiment#alias',
  'Tissue': 'biospecimen_group#biospecimen_type',
  'Fraction': 'sc_seq#cell_fraction'
}
```