### PR TITLE
REDCap timout

### DIFF
--- a/edge-apache/development-edge-httpd.conf
+++ b/edge-apache/development-edge-httpd.conf
@@ -43,6 +43,8 @@ LoadModule ssl_module modules/mod_ssl.so
 </VirtualHost>
 
 <VirtualHost *:443>
+    TimeOut 300
+    ProxyTimeout 300
     ProxyPass / http://magma_app_fe/ disablereuse=on
     ProxyPassReverse / http://magma_app_fe/
 
@@ -54,6 +56,8 @@ LoadModule ssl_module modules/mod_ssl.so
 </VirtualHost>
 
 <VirtualHost *:443>
+    TimeOut 300
+    ProxyTimeout 300
     ProxyPass / http://polyphemus_app_fe/ disablereuse=on
     ProxyPassReverse / http://polyphemus_app_fe/
 

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.37'
+  spec.version           = '0.1.36'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.35'
+  spec.version           = '0.1.36'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.36'
+  spec.version           = '0.1.37'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/etna/client.rb
+++ b/etna/lib/etna/client.rb
@@ -173,7 +173,7 @@ module Etna
         verify_mode = @ignore_ssl ?
           OpenSSL::SSL::VERIFY_NONE :
           OpenSSL::SSL::VERIFY_PEER
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode) do |http|
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode, read_timeout: 300) do |http|
           http.request(data) do |response|
             status_check!(response)
             yield response
@@ -183,7 +183,7 @@ module Etna
         verify_mode = @ignore_ssl ?
           OpenSSL::SSL::VERIFY_NONE :
           OpenSSL::SSL::VERIFY_PEER
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode) do |http|
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: verify_mode, read_timeout: 300) do |http|
           response = http.request(data)
           status_check!(response)
           return response

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jwt (2.2.2)
     method_source (1.0.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
     nio4r (2.5.7)

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -60,7 +60,6 @@ module Redcap
     end
 
     def offset_id(record_id)
-      puts record_id
       record_id
     end
 

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -60,6 +60,7 @@ module Redcap
     end
 
     def offset_id(record_id)
+      puts record_id
       record_id
     end
 

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post
@@ -36,7 +36,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     method_source (1.0.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.2)
     multipart-post (2.1.1)
     nio4r (2.5.7)

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.35)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post
@@ -37,7 +37,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     method_source (1.0.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.1)
     multipart-post (2.1.1)
     nio4r (2.5.4)

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.37)
+    etna (0.1.36)
       concurrent-ruby
       jwt
       multipart-post

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post


### PR DESCRIPTION
For deployed versions, I think we actually need the changes as noted in the Chef PR. I've deployed those changes to staging, but not production yet.

In any case, this PR includes two changes that I think will help with the REDCap timeouts. I was seeing `edge-apache` indicate that the timeout was exceeded from the FE app containers, so increasing the timeouts in its `httpd.conf` file (plus in Chef for deployments). I also increased the Magma timeouts because the table update took a bit over one minute, so was being killed sometimes in my local dev testing for large updates.

I feel like REDCap caches API responses, because when I've been testing this morning, typically the first request for a large table fails, and subsequent ones succeed in fetching data. I haven't seen that again after tweaking the timeouts in edge-apache and the etna gem...will try to wait awhile before trying again (seems to at least be more than an hour before it expires...will try again later this afternoon).