### PR TITLE
Graft/update redcap etl

### DIFF
--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -125,7 +125,9 @@ EOM
       # Set some default methods for each model
       Kernel.const_set(model_name, Class.new(Redcap::Model) {
         def identifier(record_name, event_name)
-          "::temp-#{record_name}-#{rand(36**8).to_s(36)}"
+          [
+              "::temp", record_name, event_name, rand(36**8).to_s(36)
+          ].compact.join('-')
         end
 
         def patch(id, record)


### PR DESCRIPTION
This PR standardizes the default temporary ID format that is generated for REDCap loading. Should be used in conjunction with PR 27 out of the projects repo.