### PR TITLE
archimedes runner handles steps with no inputs or outputs gracefully

### DIFF
--- a/archimedes/archimedes/runner.py
+++ b/archimedes/archimedes/runner.py
@@ -329,8 +329,8 @@ def main():
 
     request: RunRequest = RunRequest(
         isolator=args.isolator,
-        input_files=[make_storage_file(s) for s in args.inputs],
-        output_files=[make_storage_file(s) for s in args.outputs],
+        input_files=[make_storage_file(s) for s in args.inputs] if args.inputs else [],
+        output_files=[make_storage_file(s) for s in args.outputs] if args.outputs else [],
         environment=args.env or [],
         script=(args.file and open(args.file, 'r').read()) or sys.stdin.read(),
         image=args.image

--- a/archimedes/archimedes/runner.py
+++ b/archimedes/archimedes/runner.py
@@ -321,16 +321,16 @@ def main():
     parser.add_argument('--file', help="The script file to run")
     parser.add_argument('--isolator', default='local', choices=['docker', 'local'])
     parser.add_argument('--image', default='etnaagent/archimedes:latest')
-    parser.add_argument('--input', dest='inputs', action='append', help="input files of the form name:/path/on/host")
-    parser.add_argument('--output', dest='outputs', action='append', help="output files of the form name:/path/on/host")
+    parser.add_argument('--input', dest='inputs', default=[], action='append', help="input files of the form name:/path/on/host")
+    parser.add_argument('--output', dest='outputs', default=[], action='append', help="output files of the form name:/path/on/host")
     parser.add_argument('-e', '--env', dest='env', action='append', help="environment variables of the form ABC=abc")
     
     args = parser.parse_args()
 
     request: RunRequest = RunRequest(
         isolator=args.isolator,
-        input_files=[make_storage_file(s) for s in args.inputs] if args.inputs else [],
-        output_files=[make_storage_file(s) for s in args.outputs] if args.outputs else [],
+        input_files=[make_storage_file(s) for s in args.inputs],
+        output_files=[make_storage_file(s) for s in args.outputs],
         environment=args.env or [],
         script=(args.file and open(args.file, 'r').read()) or sys.stdin.read(),
         image=args.image

--- a/vulcan/lib/server/workflows/umap.cwl
+++ b/vulcan/lib/server/workflows/umap.cwl
@@ -98,19 +98,7 @@ steps:
   projectData:
     run: scripts/umap-projects.cwl
     label: 'Fetch project settings'
-    in:
-      a: 1_Cell_Filtering__min_nCounts
-      b: 1_Cell_Filtering__max_nCounts
-      c: 1_Cell_Filtering__min_nFeatures
-      d: 1_Cell_Filtering__max_per_mito
-      e: 1_Cell_Filtering__max_per_ribo
-      f: 2_Regress_by__regress_counts
-      g: 2_Regress_by__regress_genes
-      h: 2_Regress_by__regress_pct_mito
-      i: 2_Regress_by__regress_pct_ribo
-      j: 2_Regress_by__regress_tube_id
-      k: 3_For_UMAP_and_Clustering__max_pc
-      l: 5_Cluster_Calculation__leiden_resolution
+    in: []
     out: [project_data]
   queryMagma:
     run: scripts/retrieve_selection_options.cwl


### PR DESCRIPTION
This PR allows the Archimedes runner to handle commands when no inputs or outputs are specified. This can happen if a CWL step in Vulcan does not have any listed. Related to #382, but does not actually fix the root cause of that issue. There still seems to be an implied "when a single primary input changes, all steps dependent on any primary input re-runs" instead of "when a single primary input changes, only steps dependent on that specific primary input re-run". I think this is because primary inputs are treated collectively when we construct the directed graph + dependencies -- not sure if we can break those up.