### PR TITLE
Update magmaR for CRAN resubmission, v1.01

### DIFF
--- a/etna/packages/magmaR/DESCRIPTION
+++ b/etna/packages/magmaR/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: magmaR
 Type: Package
 Title: R-Client for 'Magma' of the 'UCSF Mount Etna Data Library'
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(person("Daniel", "Bunis", email = "daniel.bunis@ucsf.edu", role=c("aut", "cre")))
 Description: A client for interacting with 'magma', the data warehouse of the 'UCSF
     Mount Etna Data Library'. 'magmaR' includes functions for querying and
     downloading data from 'magma', in order to enable working with such data in R,
     as well as for uploading local data to 'magma'.
+Depends: R (>= 4.0)
 Imports: crul,
     jsonlite,
     utils

--- a/etna/packages/magmaR/vignettes/Download.Rmd
+++ b/etna/packages/magmaR/vignettes/Download.Rmd
@@ -417,9 +417,13 @@ Specific Details: The function first determines the model -> model path for navi
 
 In our example code for `retrieveMatrix()` and `retrieveMetadata()`, we obtained RNAseq data from the example project, and the linked metadata from the subject-model level. Now that we have these metadata for our rna_seq records, we could use them to start exploring our rna_seq data:
 
-```{r}
+```{r, eval=TRUE, include=FALSE}
+ditto_available <- requireNamespace("dittoSeq")
+```
+
+```{r, eval = ditto_available}
 library(dittoSeq)
-# Make plot with dittoSeq
+# Explore RNAseq data with dittoSeq
 sce <- importDittoBulk(
   list(tpm = mat), # mat was obtained with retrieveMatrix()
   metadata = meta # meta was obtained with retrieveMetadata()


### PR DESCRIPTION
magmaR is back in CRAN.

The CRAN team requested that all code utilizing [`Suggests:`](https://github.com/mountetna/monoetna/blob/master/etna/packages/magmaR/DESCRIPTION) packages be made conditional upon package availability, even if it was only in the vignette.

I'd missed their deadline for addressing that issue, :facepalm:, but it's corrected, resubmitted, re-accepted, and fully back https://CRAN.R-project.org/package=magmaR.

Additionally, I'd noted that some of the functions failed when tests were run in earlier versions of R, so I have added an `R (>=4.0)` version requirement to ensure they don't pester about that next.  Might be worth addressing the code to remove that requirement, but I'd rather focus elsewhere for now.