### PR TITLE
Vulcan fixes

### DIFF
--- a/vulcan/lib/server/workflows/scripts/plot_umap.py
+++ b/vulcan/lib/server/workflows/scripts/plot_umap.py
@@ -30,6 +30,7 @@ def get(ids, value):
 pdat = input_json("project_data")[project_name]
 color_options = pdat['color_options']
 
+custom_tooltip = False
 if color_by == 'Cluster':
     color = leiden
     custom_tooltip = True


### PR DESCRIPTION
This will be a PR aiming to fix issues noted during / shortly after the HuMu team was onboarded to test the Vulcan system.  Goal will be to unblock anything requiring a *simple* fix in order to maximize what is test / feedback -able.  I'll add to this comment if/when more needs are fleshed out.

- [x] Address bug blocking coloring by non Cluster
Addresses error message "NameError: name ‘custom_tooltip’ is not defined" reported https://immunox.slack.com/archives/C022Q94E96W/p1621628254004900
- [ ] Bug: sometimes the system comes back to the "Confirm record names" step, after all steps had been completed, and then cannot be brought to actually show the umap or download buttons.
- [ ] Bug: sometimes the system does not Run past the "Record Selection" step.  With selections made for all needed choices, POSTs get returned with 200 statuses after the `Run` button is clicked, but then nothing happens