### PR TITLE
(WIP) Vulcan UI widget for single dropdown with checkboxes

### DIFF
--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/__tests__/single_dropdown_multicheckbox.spec.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/__tests__/single_dropdown_multicheckbox.spec.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
+import SingleDropdownMulticheckbox from '../single_dropdown_multicheckbox';
+import {InputSpecification} from '../input_types';
+
+describe('SingleDropdownMulticheckbox', () => {
+  let input: InputSpecification;
+  let onChange: jest.Mock;
+
+  function clickCheckbox(component: ReactWrapper, index: number) {
+    component
+      .find('.checkbox-input-option')
+      .at(index)
+      .find('input')
+      .simulate('change')
+      .update();
+  }
+
+  function renderedCheckboxesText(component: ReactWrapper) {
+    return component.find('.checkbox-input-option').map((n) => n.text());
+  }
+
+  function checkedCheckboxesText(component: ReactWrapper) {
+    return component
+      .find('.checkbox-input-option')
+      .filterWhere((n) => n.find('input').prop('checked') || false)
+      .map((n) => n.text());
+  }
+
+  function renderedDropdownValues(component: ReactWrapper) {
+    return component
+      .find('.dropdown-autocomplete-input')
+      .map((n) => n.find('input').first().props().value);
+  }
+
+  beforeEach(() => {
+    input = {
+      type: 'doesnotmatter',
+      default: null,
+      label: 'Abcdef',
+      name: 'test-input',
+      data: {
+        'options-a': {
+          option1: ['1', '2', '3'],
+          option2: ['x', 'y', 'z']
+        },
+        'options-b': {
+          option3: ['9', '8', '7'],
+          option4: ['a', 'b', 'c']
+        }
+      }
+    };
+
+    onChange = jest.fn();
+  });
+
+  it('correctly renders checkboxes as pre-selected', () => {
+    const component = mount(
+      <SingleDropdownMulticheckbox input={input} onChange={onChange} />
+    );
+    console.log(component);
+    expect(component.find('.dropdown-autocomplete-input').length).toEqual(2);
+    expect(component.find('.checkbox-input-option').length).toEqual(6);
+    expect(renderedDropdownValues(component)).toEqual(['option1', 'option3']);
+    expect(renderedCheckboxesText(component)).toEqual([
+      '1',
+      '2',
+      '3',
+      '7',
+      '8',
+      '9'
+    ]);
+  });
+
+  it('updates state when clicking checkboxes', () => {
+    const component = mount(
+      <SingleDropdownMulticheckbox input={input} onChange={onChange} />
+    );
+
+    expect(component.find('.dropdown-autocomplete-input').length).toEqual(2);
+    expect(component.find('.checkbox-input-option').length).toEqual(6);
+    expect(renderedDropdownValues(component)).toEqual(['option1', 'option3']);
+    expect(renderedCheckboxesText(component)).toEqual([
+      '1',
+      '2',
+      '3',
+      '7',
+      '8',
+      '9'
+    ]);
+
+    clickCheckbox(component, 0);
+    expect(onChange).toHaveBeenLastCalledWith('test-input', {
+      'options-a': {
+        option1: ['2', '3'],
+        option2: ['x', 'y', 'z']
+      },
+      'options-b': {
+        option3: ['9', '8', '7'],
+        option4: ['a', 'b', 'c']
+      }
+    });
+  });
+
+  it('resets the input in state when any set of checkboxes is []', () => {
+    const component = mount(
+      <SingleDropdownMulticheckbox input={input} onChange={onChange} />
+    );
+    expect(component.find('.dropdown-autocomplete-input').length).toEqual(2);
+    expect(renderedDropdownValues(component)).toEqual(['option1', 'option3']);
+    clickCheckbox(component, 0);
+    expect(onChange).toHaveBeenCalledWith('test-input', {
+      'options-a': {
+        option1: ['2', '3'],
+        option2: ['x', 'y', 'z']
+      },
+      'options-b': {
+        option3: ['9', '8', '7'],
+        option4: ['a', 'b', 'c']
+      }
+    });
+
+    clickCheckbox(component, 1);
+    expect(onChange).toHaveBeenCalledWith('test-input', {
+      'options-a': {
+        option1: ['3'],
+        option2: ['x', 'y', 'z']
+      },
+      'options-b': {
+        option3: ['9', '8', '7'],
+        option4: ['a', 'b', 'c']
+      }
+    });
+    clickCheckbox(component, 2);
+    expect(onChange).toHaveBeenCalledWith('test-input', null);
+  });
+
+  it('correctly sets the checkbox states when given a default', () => {
+    input.default = {
+      'options-a': {
+        option1: ['1', '2'],
+        option2: ['y']
+      },
+      'options-b': {
+        option3: ['8', '9', '7'],
+        option4: ['c']
+      }
+    };
+    const component = mount(
+      <SingleDropdownMulticheckbox input={input} onChange={onChange} />
+    );
+
+    expect(component.find('.dropdown-autocomplete-input').length).toEqual(2);
+    expect(component.find('.checkbox-input-option').length).toEqual(6);
+    expect(renderedDropdownValues(component)).toEqual(['option1', 'option3']);
+    expect(renderedCheckboxesText(component)).toEqual([
+      '1',
+      '2',
+      '3',
+      '7',
+      '8',
+      '9'
+    ]);
+    expect(checkedCheckboxesText(component)).toEqual(['1', '2', '7', '8', '9']);
+  });
+
+  it('checkboxes switch when dropdown value changes', () => {
+    input.default = {
+      'options-a': {
+        option1: ['1', '2'],
+        option2: ['y']
+      },
+      'options-b': {
+        option3: ['8', '9', '7'],
+        option4: ['c']
+      }
+    };
+    const component = mount(
+      <SingleDropdownMulticheckbox input={input} onChange={onChange} />
+    );
+    expect(component.find('.dropdown-autocomplete-input').length).toEqual(2);
+    expect(component.find('.checkbox-input-option').length).toEqual(6);
+    expect(renderedDropdownValues(component)).toEqual(['option1', 'option3']);
+    expect(renderedCheckboxesText(component)).toEqual([
+      '1',
+      '2',
+      '3',
+      '7',
+      '8',
+      '9'
+    ]);
+    expect(checkedCheckboxesText(component)).toEqual(['1', '2', '7', '8', '9']);
+
+    component
+      .find('.icon-wrapper')
+      .first()
+      .simulate('click')
+      .update()
+      .find('.dropdown-autocomplete-options')
+      .find('li')
+      .last()
+      .simulate('click')
+      .update();
+
+    expect(renderedDropdownValues(component)).toEqual(['option2', 'option3']);
+    expect(renderedCheckboxesText(component)).toEqual([
+      'x',
+      'y',
+      'z',
+      '7',
+      '8',
+      '9'
+    ]);
+    expect(checkedCheckboxesText(component)).toEqual(['y', '7', '8', '9']);
+  });
+});

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
@@ -161,7 +161,19 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
     // Update state whenever a new selection comes in.
     if (!_.isEqual(lastSelected, selected)) {
       setLastSelected(selected);
-      onChange(input.name, selected);
+      if (
+        Object.values(
+          selected
+        ).every((nestedInput: {[key: string]: string[]}) =>
+          Object.values(nestedInput).every(
+            (selection: string[]) => selection.length > 0
+          )
+        )
+      ) {
+        onChange(input.name, selected);
+      } else {
+        onChange(input.name, null);
+      }
     }
   }, [selected]);
 

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
@@ -1,88 +1,158 @@
 // Input component that takes a simple object and
 // shows values based on a selected key
 
-import React, {useState, useEffect, useMemo, useContext, useCallback} from 'react';
-import * as _ from 'lodash';
+import React, {useState, useEffect, useMemo, useCallback} from 'react';
 
 import DropdownAutocomplete from 'etna-js/components/inputs/dropdown_autocomplete';
 import CheckboxesInput from './checkboxes';
-import MultiselectStringInput, {getAllOptions} from './multiselect_string';
-import {InputBackendComponent} from "./input_types";
+import {InputBackendComponent, InputSpecification} from './input_types';
 
-const handleClickOption = useCallback((option: any) => {
-  let copy = [...selectedOptions];
-  if (!selectedOptions.includes(option)) {
-    copy.push(option);
-  } else {
-    copy = selectedOptions.filter((opt) => option !== opt);
-  }
-  setSelectedOptions(copy);
-}, [selectedOptions]);
-
-
-const SingleDropdownMulticheckbox: InputBackendComponent = ({input, onChange}) => {
+const SingleDropdownMulticheckbox: InputBackendComponent = ({
+  input,
+  onChange
+}) => {
+  const [checkboxInputs, setCheckboxInputs] = useState(
+    {} as {[key: string]: InputSpecification | null}
+  );
+  const [selected, setSelected] = useState(
+    {} as {[key: string]: {[key: string]: string[]}}
+  );
+  const [dropdownValues, setDropdownValues] = useState(
+    {} as {[key: string]: string}
+  );
   const {data} = input;
 
-  if (!input || !onChange) return null;
-
-  const allOptions: OptionSet = useMemo(() => {
-    return Object.keys(data || {}).reduce((dataObj, k) => {
-      if (!data) return dataObj;
-      const next = data[k];
-      return {
-          ...dataObj,
-          ...(typeof next === "object" && next != null && !Array.isArray(next) ? next : {})
-      };
-    }, {} as OptionSet);
+  const dropdownOptions: {[key: string]: string[]} = useMemo(() => {
+    return Object.keys(data || {}).reduce(
+      (
+        acc: {[key: string]: string[]},
+        nextCwlInput: string
+      ): {[key: string]: string[]} => {
+        acc[nextCwlInput] = data ? Object.keys(data[nextCwlInput]) : [];
+        return acc;
+      },
+      {}
+    );
   }, [data]);
 
   useEffect(() => {
-    if (input.default) {
-      setPath(getPath(allOptions, input.default));
-    }
-  }, [input, allOptions]);
+    // By default set the first option as selected for each CWL input.
+    setDropdownValues(
+      Object.entries(dropdownOptions).reduce(
+        (
+          acc: {[key: string]: string},
+          [nextCwlInput, options]: [string, string[]]
+        ) => {
+          acc[nextCwlInput] = options[0];
+          return acc;
+        },
+        {}
+      )
+    );
 
-  const handleSelect = useCallback((value: string | null, depth: number) => {
-    // User has not selected something...perhaps
-    //   still typing?
-    if (null == value) return;
+    // by default all boxes are selected
+    setSelected(
+      Object.entries(dropdownOptions).reduce(
+        (
+          acc: {[key: string]: {[key: string]: string[]}},
+          [nextCwlInput, options]: [string, string[]]
+        ): {[key: string]: {[key: string]: string[]}} => {
+          acc[nextCwlInput] = {};
+          options.forEach((option) => {
+            acc[nextCwlInput][option] = data ? data[nextCwlInput][option] : [];
+          });
+          return acc;
+        },
+        {}
+      )
+    );
+  }, []);
 
-    const updatedPath = path.slice(0, depth);
-    updatedPath.push(value);
-    setPath(updatedPath);
+  useEffect(() => {
+    // when options change for the dropdown menu,
+    //   set the checkboxes to the options
+    //   for the selected dropdownOption.
+    setCheckboxInputs(
+      Object.entries(dropdownValues).reduce(
+        (
+          acc: {[key: string]: InputSpecification},
+          [cwlInputName, dropdownValue]: [string, string]
+        ): {[key: string]: InputSpecification} => {
+          acc[cwlInputName] = {
+            ...input,
+            name: `${cwlInputName}-${dropdownValue}`,
+            data: data ? data[cwlInputName][dropdownValue] : [],
+            default: selected[cwlInputName][dropdownValue]
+          };
+          return acc;
+        },
+        {}
+      )
+    );
+  }, [dropdownValues, selected]);
 
-    if (getOptions(updatedPath, allOptions) == null) {
-      // If we are updating a leaf
-      onChange(input.name, value);
-    } else {
-      // Otherwise a leaf has not been selected.
-      onChange(input.name, null);
-    }
-  }, [input, allOptions, path, setPath, onChange]);
+  useEffect(() => {
+    // Update state whenever a new selection comes in.
+    onChange(input.name, selected);
+  }, [selected]);
+
+  const handleSelect = useCallback(
+    (cwlInputName: string, value: string) => {
+      // Set the checkbox input to `null` first, to clear
+      //   out the component.
+      setCheckboxInputs({
+        ...checkboxInputs,
+        [cwlInputName]: null
+      });
+      setDropdownValues({...dropdownValues, [cwlInputName]: value});
+    },
+    [dropdownOptions]
+  );
+
+  const handleClickOption = useCallback(
+    (cwlInputName: string, options: string[]) => {
+      setSelected({
+        ...selected,
+        [cwlInputName]: {
+          ...selected[cwlInputName],
+          [dropdownValues[cwlInputName]]: [...options]
+        }
+      });
+    },
+    [dropdownValues]
+  );
+
+  if (!input || !onChange) return null;
 
   return (
     <div>
-      <div>
-        <MultiselectStringInput
-          onAll={handleAllInputs}
-          onClear={handleClearInputs}
-          onChange={onChange}
-          input={input} />
-      </div>
-      <div className='checkbox-input-wrapper'>
-        {options.map((option, index) => {
-          return (
-            <CheckboxInput
-              option={option}
-              key={index}
-              checked={selectedOptions.includes(option)}
-              onChange={handleClickOption}
-            />
-          );
-        })}
-      </div>
+      {Object.keys(dropdownValues).map((cwlInputName: string) => {
+        let checkboxInput = checkboxInputs[cwlInputName];
+        if (!checkboxInput) return null;
+
+        return (
+          <React.Fragment>
+            <div>
+              <DropdownAutocomplete
+                defaultValue={dropdownValues[cwlInputName]}
+                onSelect={(value: string) => handleSelect(cwlInputName, value)}
+                list={dropdownOptions[cwlInputName]}
+              />
+            </div>
+            <div className='checkbox-input-wrapper'>
+              <CheckboxesInput
+                key={`${cwlInputName}-${dropdownValues[cwlInputName]}`}
+                input={checkboxInput}
+                onChange={(inputName: string, checked: string[]) =>
+                  handleClickOption(cwlInputName, checked)
+                }
+              />
+            </div>
+          </React.Fragment>
+        );
+      })}
     </div>
   );
-}
+};
 
 export default SingleDropdownMulticheckbox;

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
@@ -2,10 +2,50 @@
 // shows values based on a selected key
 
 import React, {useState, useEffect, useMemo, useCallback} from 'react';
+import useDeepCompareEffect from 'react-use/lib/useDeepCompareEffect';
+import * as _ from 'lodash';
 
 import DropdownAutocomplete from 'etna-js/components/inputs/dropdown_autocomplete';
 import CheckboxesInput from './checkboxes';
 import {InputBackendComponent, InputSpecification} from './input_types';
+
+function DropdownCheckboxCombo({
+  dropdownValue,
+  handleSelect,
+  handleClickOption,
+  cwlInputName,
+  dropdownOptions,
+  checkboxInput
+}: {
+  dropdownValue: string;
+  dropdownOptions: string[];
+  cwlInputName: string;
+  handleSelect: (cwlInputName: string, value: string) => void;
+  handleClickOption: (cwlInputName: string, options: string[]) => void;
+  checkboxInput: InputSpecification;
+}) {
+  if (!checkboxInput) return null;
+
+  return (
+    <React.Fragment>
+      <div>
+        <DropdownAutocomplete
+          defaultValue={dropdownValue}
+          onSelect={(value: string) => handleSelect(cwlInputName, value)}
+          list={dropdownOptions}
+        />
+      </div>
+      <div className='checkbox-input-wrapper'>
+        <CheckboxesInput
+          input={checkboxInput}
+          onChange={(inputName: string, checkedOptions: string[]) =>
+            handleClickOption(cwlInputName, checkedOptions)
+          }
+        />
+      </div>
+    </React.Fragment>
+  );
+}
 
 const SingleDropdownMulticheckbox: InputBackendComponent = ({
   input,
@@ -17,30 +57,38 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
   const [selected, setSelected] = useState(
     {} as {[key: string]: {[key: string]: string[]}}
   );
-  const [dropdownValues, setDropdownValues] = useState(
+  const [lastSelected, setLastSelected] = useState(
+    {} as {[key: string]: {[key: string]: string[]}}
+  );
+  const [currentDropdownValues, setCurrentDropdownValues] = useState(
     {} as {[key: string]: string}
   );
   const [initialized, setInitialized] = useState(false);
+  const [dropdownOptions, setDropdownOptions] = useState(
+    {} as {[key: string]: string[]}
+  );
   const {data} = input;
 
-  const dropdownOptions: {[key: string]: string[]} = useMemo(() => {
-    console.log('here', data);
-    return Object.keys(data || {}).reduce(
-      (
-        acc: {[key: string]: string[]},
-        nextCwlInput: string
-      ): {[key: string]: string[]} => {
-        acc[nextCwlInput] = data ? Object.keys(data[nextCwlInput]) : [];
-        return acc;
-      },
-      {}
+  useDeepCompareEffect(() => {
+    if (!data) return;
+
+    setDropdownOptions(
+      Object.keys(data).reduce(
+        (
+          acc: {[key: string]: string[]},
+          nextCwlInput: string
+        ): {[key: string]: string[]} => {
+          acc[nextCwlInput] = Object.keys(data[nextCwlInput]);
+          return acc;
+        },
+        {}
+      )
     );
   }, [data]);
 
-  useEffect(() => {
-    console.log('dropdownOptions', dropdownOptions);
+  useDeepCompareEffect(() => {
     // By default set the first option as selected for each CWL input.
-    setDropdownValues(
+    setCurrentDropdownValues(
       Object.entries(dropdownOptions).reduce(
         (
           acc: {[key: string]: string},
@@ -52,38 +100,43 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
         {}
       )
     );
+  }, [dropdownOptions]);
 
-    if (input.default) {
-      // Set the boxes to any previous selection
-      setSelected(input.default);
-    } else {
-      // by default all boxes are selected
-      setSelected(
-        Object.entries(dropdownOptions).reduce(
-          (
-            acc: {[key: string]: {[key: string]: string[]}},
-            [nextCwlInput, options]: [string, string[]]
-          ): {[key: string]: {[key: string]: string[]}} => {
-            acc[nextCwlInput] = {};
-            options.forEach((option) => {
-              acc[nextCwlInput][option] = data
-                ? data[nextCwlInput][option]
-                : [];
-            });
-            return acc;
-          },
-          {}
-        )
-      );
+  useDeepCompareEffect(() => {
+    if (!initialized && !_.isEqual(dropdownOptions, {})) {
+      setInitialized(true);
+      if (input.default) {
+        // Set the boxes to any previous selection
+        setSelected(input.default);
+      } else {
+        // by default all boxes are selected
+        setSelected(
+          Object.entries(dropdownOptions).reduce(
+            (
+              acc: {[key: string]: {[key: string]: string[]}},
+              [nextCwlInput, options]: [string, string[]]
+            ): {[key: string]: {[key: string]: string[]}} => {
+              acc[nextCwlInput] = {};
+              options.forEach((option) => {
+                acc[nextCwlInput][option] = data
+                  ? data[nextCwlInput][option]
+                  : [];
+              });
+              return acc;
+            },
+            {}
+          )
+        );
+      }
     }
-  }, [data]);
+  }, [input.default, input.data, dropdownOptions]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     // when options change for the dropdown menu,
     //   set the checkboxes to the options
     //   for the selected dropdownOption.
     setCheckboxInputs(
-      Object.entries(dropdownValues).reduce(
+      Object.entries(currentDropdownValues).reduce(
         (
           acc: {[key: string]: InputSpecification},
           [cwlInputName, dropdownValue]: [string, string]
@@ -102,11 +155,14 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
         {}
       )
     );
-  }, [dropdownValues, selected]);
+  }, [currentDropdownValues, selected]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     // Update state whenever a new selection comes in.
-    onChange(input.name, selected);
+    if (!_.isEqual(lastSelected, selected)) {
+      setLastSelected(selected);
+      onChange(input.name, selected);
+    }
   }, [selected]);
 
   const handleSelect = useCallback(
@@ -117,9 +173,12 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
         ...checkboxInputs,
         [cwlInputName]: null
       });
-      setDropdownValues({...dropdownValues, [cwlInputName]: value});
+      setCurrentDropdownValues({
+        ...currentDropdownValues,
+        [cwlInputName]: value
+      });
     },
-    [dropdownOptions]
+    [currentDropdownValues]
   );
 
   const handleClickOption = useCallback(
@@ -128,40 +187,32 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
         ...selected,
         [cwlInputName]: {
           ...selected[cwlInputName],
-          [dropdownValues[cwlInputName]]: [...options]
+          [currentDropdownValues[cwlInputName]]: [...options]
         }
       });
     },
-    [dropdownValues]
+    [currentDropdownValues]
   );
 
   if (!input || !onChange) return null;
-  console.log('dropdownOptions2', dropdownOptions);
+
   return (
     <div>
-      {Object.keys(dropdownValues).map((cwlInputName: string) => {
+      {Object.keys(currentDropdownValues).map((cwlInputName: string) => {
         let checkboxInput = checkboxInputs[cwlInputName];
+
         if (!checkboxInput) return null;
 
         return (
-          <React.Fragment>
-            <div>
-              <DropdownAutocomplete
-                defaultValue={dropdownValues[cwlInputName]}
-                onSelect={(value: string) => handleSelect(cwlInputName, value)}
-                list={dropdownOptions[cwlInputName]}
-              />
-            </div>
-            <div className='checkbox-input-wrapper'>
-              <CheckboxesInput
-                key={`${cwlInputName}-${dropdownValues[cwlInputName]}`}
-                input={checkboxInput}
-                onChange={(inputName: string, checked: string[]) =>
-                  handleClickOption(cwlInputName, checked)
-                }
-              />
-            </div>
-          </React.Fragment>
+          <DropdownCheckboxCombo
+            key={`${cwlInputName}-${checkboxInput.name}`}
+            cwlInputName={cwlInputName}
+            checkboxInput={checkboxInput}
+            handleSelect={handleSelect}
+            handleClickOption={handleClickOption}
+            dropdownValue={currentDropdownValues[cwlInputName]}
+            dropdownOptions={dropdownOptions[cwlInputName]}
+          />
         );
       })}
     </div>

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/single_dropdown_multicheckbox.tsx
@@ -20,9 +20,11 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
   const [dropdownValues, setDropdownValues] = useState(
     {} as {[key: string]: string}
   );
+  const [initialized, setInitialized] = useState(false);
   const {data} = input;
 
   const dropdownOptions: {[key: string]: string[]} = useMemo(() => {
+    console.log('here', data);
     return Object.keys(data || {}).reduce(
       (
         acc: {[key: string]: string[]},
@@ -36,6 +38,7 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
   }, [data]);
 
   useEffect(() => {
+    console.log('dropdownOptions', dropdownOptions);
     // By default set the first option as selected for each CWL input.
     setDropdownValues(
       Object.entries(dropdownOptions).reduce(
@@ -50,23 +53,30 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
       )
     );
 
-    // by default all boxes are selected
-    setSelected(
-      Object.entries(dropdownOptions).reduce(
-        (
-          acc: {[key: string]: {[key: string]: string[]}},
-          [nextCwlInput, options]: [string, string[]]
-        ): {[key: string]: {[key: string]: string[]}} => {
-          acc[nextCwlInput] = {};
-          options.forEach((option) => {
-            acc[nextCwlInput][option] = data ? data[nextCwlInput][option] : [];
-          });
-          return acc;
-        },
-        {}
-      )
-    );
-  }, []);
+    if (input.default) {
+      // Set the boxes to any previous selection
+      setSelected(input.default);
+    } else {
+      // by default all boxes are selected
+      setSelected(
+        Object.entries(dropdownOptions).reduce(
+          (
+            acc: {[key: string]: {[key: string]: string[]}},
+            [nextCwlInput, options]: [string, string[]]
+          ): {[key: string]: {[key: string]: string[]}} => {
+            acc[nextCwlInput] = {};
+            options.forEach((option) => {
+              acc[nextCwlInput][option] = data
+                ? data[nextCwlInput][option]
+                : [];
+            });
+            return acc;
+          },
+          {}
+        )
+      );
+    }
+  }, [data]);
 
   useEffect(() => {
     // when options change for the dropdown menu,
@@ -82,7 +92,10 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
             ...input,
             name: `${cwlInputName}-${dropdownValue}`,
             data: data ? data[cwlInputName][dropdownValue] : [],
-            default: selected[cwlInputName][dropdownValue]
+            default:
+              selected && selected[cwlInputName]
+                ? selected[cwlInputName][dropdownValue]
+                : []
           };
           return acc;
         },
@@ -123,7 +136,7 @@ const SingleDropdownMulticheckbox: InputBackendComponent = ({
   );
 
   if (!input || !onChange) return null;
-
+  console.log('dropdownOptions2', dropdownOptions);
   return (
     <div>
       {Object.keys(dropdownValues).map((cwlInputName: string) => {

--- a/vulcan/package-lock.json
+++ b/vulcan/package-lock.json
@@ -2626,6 +2626,11 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
+      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw=="
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -2738,6 +2743,11 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "a-big-triangle": {
       "version": "1.0.3",
@@ -4497,6 +4507,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
@@ -4683,6 +4701,15 @@
       "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
       "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
     },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -4732,6 +4759,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
       "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
+    },
+    "css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "requires": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "css-what": {
       "version": "4.0.0",
@@ -5607,6 +5650,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -13808,6 +13859,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -15099,6 +15160,11 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -15266,6 +15332,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "inline-style-prefixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz",
+      "integrity": "sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==",
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "0.12.0",
@@ -15703,8 +15777,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -18044,6 +18117,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -18299,6 +18377,28 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "nano-css": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.1.tgz",
+      "integrity": "sha512-ENPIyNzANQRyYVvb62ajDd7PAyIgS2LIUnT9ewih4yrXSZX4hKoUwssy8WjUH++kEOA5wUTMgNnV7ko5n34kUA==",
+      "requires": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        }
+      }
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -19912,6 +20012,32 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
+    },
+    "react-use": {
+      "version": "17.2.4",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.2.4.tgz",
+      "integrity": "sha512-vQGpsAM0F5UIlshw5UI8ULGPS4yn5rm7/qvn3T1Gnkrz7YRMEEMh+ynKcmRloOyiIeLvKWiQjMiwRGtdbgs5qQ==",
+      "requires": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -20303,6 +20429,11 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
       "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -20494,6 +20625,14 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "rtl-css-js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.1.tgz",
+      "integrity": "sha512-G9N1s/6329FpJr8k9e1U/Lg0IDWThv99sb7k0IrXHjSnubxe01h52/ajsPRafJK1/2Vqrhz3VKLe3E1dx6jS9Q==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
@@ -20740,6 +20879,11 @@
         "ajv-keywords": "^3.4.1"
       }
     },
+    "screenfull": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.1.0.tgz",
+      "integrity": "sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA=="
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -20768,6 +20912,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -21113,6 +21262,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "spark-md5": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.1.tgz",
@@ -21185,6 +21339,14 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
@@ -21205,6 +21367,37 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "static-eval": {
@@ -21540,6 +21733,11 @@
         }
       }
     },
+    "stylis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+    },
     "supercluster": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.2.tgz",
@@ -21781,6 +21979,11 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
     },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -21931,6 +22134,11 @@
         "to-array-buffer": "^3.0.0"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
     "topojson-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -21992,6 +22200,16 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
+    },
+    "tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/vulcan/package.json
+++ b/vulcan/package.json
@@ -44,6 +44,7 @@
     "react-redux": "^7.2.0",
     "react-spinners": "^0.9.0",
     "react-table": "^7.6.1",
+    "react-use": "^17.2.4",
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0",


### PR DESCRIPTION
This PR adds the UI widget for a single dropdown + checkboxes, for the differential gene expression workflow.

While this does work, @corps  has indicated that it's not a performant solution and we may want to re-think how the front end handles data loading and syncing in general, to avoid recursion issues (which would clean up a lot of the complex widgets). So leaving this PR WIP for now, until we sort that out.