### PR TITLE
Relax the temporary id regex for censor

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.36'
+  spec.version           = '0.1.37'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -8,7 +8,6 @@ require_relative './command'
 require_relative './generate_autocompletion_script'
 require 'singleton'
 require 'rollbar'
-require 'yabeda'
 require 'fileutils'
 
 module Etna::Application

--- a/etna/lib/etna/server.rb
+++ b/etna/lib/etna/server.rb
@@ -74,6 +74,10 @@ module Etna
     def initialize
       # Setup logging.
       application.setup_logger
+
+      # This needs to be required before yabeda invocation, but cannot belong at the top of any module since clients
+      # do not install yabeda.
+      require 'yabeda'
       application.setup_yabeda
     end
 

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'securerandom'
 require 'timecop'
 require 'webmock/rspec'
 require 'base64'
+require 'yabeda'
 
 Bundler.setup(:default, :test)
 

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post
@@ -37,13 +37,9 @@ GEM
     json (2.5.1)
     jwt (2.2.2)
     method_source (1.0.0)
-    mini_portile2 (2.5.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     pg (1.2.3)

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/lib/magma/censor.rb
+++ b/magma/lib/magma/censor.rb
@@ -10,7 +10,7 @@ class Magma
       reasons = []
       return reasons unless restrict?
 
-      record_names = record_set.values.map(&:record_name).reject {|name| name =~ Magma::Loader::TEMP_ID_MATCH }
+      record_names = record_set.values.map(&:record_name).reject { |name| name =~ Magma::Loader::TEMP_ID_MATCH }
 
       unrestricted_identifiers = Magma::Question.new(
         @project_name,

--- a/magma/lib/magma/loader.rb
+++ b/magma/lib/magma/loader.rb
@@ -279,7 +279,7 @@ class Magma
       temp_ids[obj] ||= TempId.new(new_temp_id, obj)
     end
 
-    TEMP_ID_MATCH=/^::temp/
+    TEMP_ID_MATCH=/^::/
 
     def identifier_id(model, identifier)
       return nil unless identifier

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/bin/polyphemus
+++ b/polyphemus/bin/polyphemus
@@ -8,5 +8,6 @@ require 'yaml'
 
 config = YAML.load(File.read(File.expand_path("../../config.yml",__FILE__)))
 
+require 'yabeda'
 Polyphemus.instance.setup_yabeda
 Polyphemus.instance.run_command(config, *ARGV)

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post
@@ -42,10 +42,10 @@ GEM
     minitest (5.14.2)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.3)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-linux)
+    nokogiri (1.11.6-x86_64-linux)
       racc (~> 1.4)
     pg (0.21.0)
     prometheus-client (2.1.0)

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.36)
+    etna (0.1.37)
       concurrent-ruby
       jwt
       multipart-post
@@ -39,13 +39,9 @@ GEM
     json (2.5.1)
     jwt (2.2.3)
     method_source (1.0.0)
-    mini_portile2 (2.5.1)
     minitest (5.14.1)
     multipart-post (2.1.1)
     nio4r (2.5.4)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     pg (0.21.0)


### PR DESCRIPTION
I _think_ this could be improved, but it got me thinking --

the censor hook is actually called _before_ upsert.  If it was called _after_ upsert, we could actually still just do a check (either exchange the temp ids out with real ones, or even just a ::first check for tables), but right now it happens in this order which means new records aren't yet visible.

Which makes me think -- does this prevent creating new records to a child relationship of a restricted model right now?  My experiments showed no, we don't.  

I think the long term fix is that we hold an open transaction, do the upsert, _then_ run the censor query within that transaction, validate, and then commit.  But that is a big refactor.  We should add this to part of our data ingestion work.