### PR TITLE
Addressing test, fixing issue with polling

### DIFF
--- a/etna/packages/etna-js/spec/helpers.js
+++ b/etna/packages/etna-js/spec/helpers.js
@@ -5,6 +5,12 @@ import {appSubscription} from "../utils/subscription";
 
 export const mockStore = (state, middleware = []) => configureMockStore([thunk, ...middleware])(state);
 
+function nockDebug(...args) {
+  if (process.env['NOCK_DEBUG'] === '1') {
+    console.log(...args);
+  }
+}
+
 export const stubUrl = ({
   verb = 'get',
   path,
@@ -29,21 +35,21 @@ export const stubUrl = ({
     }
   }
 
-  console.log('Stubbing for', {request, path, verb, response, host}, '\nactive')
+  nockDebug('Stubbing for', {request, path, verb, response, host}, '\nactive')
 
   return new Promise((resolve, reject) => {
     const base = nock(host)[verb](path, request);
     nocked = response instanceof Function
       ? base.reply(function (uri, body, cb) {
         response(uri, body, function () {
-          console.log('responding to', { uri, body }, '\nusing custom response cb')
+          nockDebug('responding to', { uri, body }, '\nusing custom response cb')
           nock.removeInterceptor(base);
           resolve();
           return cb.apply(this, arguments);
         })
       })
       : base.reply(function () {
-        console.log('responding to', { path, request }, '\nreplying with', { status, response })
+        nockDebug('responding to', { path, request }, '\nreplying with', { status, response })
         nock.removeInterceptor(base);
         resolve();
         return [status, response, {

--- a/vulcan/lib/client/jsx/contexts/__tests__/session_sync.spec.tsx
+++ b/vulcan/lib/client/jsx/contexts/__tests__/session_sync.spec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {integrateElement} from "../../test_utils/integration";
 import {asyncFn, AsyncMock, createFakeStorage} from "../../test_utils/mocks";
 import {setStatus, setWorkflow, setWorkflows} from "../../actions/vulcan";
-import {SessionStatusResponse, Workflow} from "../../api_types";
+import {defaultSessionStatusResponse, SessionStatusResponse, StatusString, StepStatus, Workflow} from "../../api_types";
 import {
   createStatusFixture,
   createStepFixture, createStepStatusFixture,
@@ -17,6 +17,15 @@ describe('useSessionSync', () => {
     let workflow: Workflow;
     let postInputsMock: AsyncMock<SessionStatusResponse>;
     let pollStatusMock: AsyncMock<SessionStatusResponse>;
+
+    async function setupStablePollingState(status: StatusString) {
+      const {dispatch, contextData} = setup;
+      await act(async () => {
+        await dispatch(setStatus(createStatusFixture(workflow, createStepStatusFixture({name: "testStep", status}))));
+        const [[resolve]] = await pollStatusMock.awaitCall(false);
+        resolve({ ...defaultSessionStatusResponse, status: contextData.stateRef.current.status, session: contextData.stateRef.current.session });
+      });
+    }
 
     beforeEach(async () => {
       postInputsMock = asyncFn<SessionStatusResponse>()
@@ -33,60 +42,58 @@ describe('useSessionSync', () => {
         providerOverrides: {
           storage,
           getWorkflows: defaultContext.getWorkflows,
-          pollStatus: pollStatusMock[0],
-          postInputs: postInputsMock[0],
+          pollStatus: pollStatusMock.jestMock,
+          postInputs: postInputsMock.jestMock,
         }
       });
 
       const {dispatch} = setup;
       await act(async () => {
         await dispatch(setWorkflow(workflow, 'test'));
-        await dispatch(setStatus(createStatusFixture(workflow, createStepStatusFixture({name: "testStep", status: "running"}))));
-      })
-
+        await setupStablePollingState("running");
+      });
     })
 
     it('polls for a status update', async () => {
       const {contextData} = setup;
-      pollStatusMock[0].mockClear();
+      const call = pollStatusMock.awaitCall(true);
 
       await act(async () => {
         contextData.requestPoll();
       });
 
-      expect(pollStatusMock[0]).toHaveBeenCalledWith(contextData.stateRef.current.session)
+      const [_, args] = await call;
+      expect(args[0]).toBe(contextData.stateRef.current.session)
     })
 
     describe('when there is no running step status', () => {
       beforeEach(async () => {
-        await act(async () => {
-          const {dispatch} = setup;
-          await dispatch(setStatus(createStatusFixture(workflow, createStepStatusFixture({name: "a", status: "complete"}))));
-        })
+        await setupStablePollingState("complete");
       })
 
       it('does not continue to poll', async () => {
         const {contextData} = setup;
-        pollStatusMock[0].mockClear();
+        const call = pollStatusMock.awaitCall(true);
 
         await act(async () => {
           contextData.requestPoll();
         });
 
-        expect(pollStatusMock[0]).not.toHaveBeenCalled();
-      })
+        expect(pollStatusMock.hasPendingRequest()).toBeFalsy();
+        expect(postInputsMock.hasPendingRequest()).toBeFalsy();
+      });
 
       describe('but the request is a post', () => {
         it('does post', async () => {
           const {contextData} = setup;
-          pollStatusMock[0].mockClear();
+          const call = pollStatusMock.awaitCall(true);
 
           await act(async () => {
             contextData.requestPoll(true);
           });
 
-          expect(pollStatusMock[0]).not.toHaveBeenCalled();
-          expect(postInputsMock[0]).toHaveBeenCalled();
+          expect(pollStatusMock.hasPendingRequest()).toBeFalsy();
+          expect(postInputsMock.hasPendingRequest()).toBeTruthy();
         })
       })
     })

--- a/vulcan/lib/client/jsx/contexts/session_sync.tsx
+++ b/vulcan/lib/client/jsx/contexts/session_sync.tsx
@@ -49,7 +49,7 @@ export function useSessionSync(
 
   const statusIsFresh = lastCompletedPollingRequest === state.current.session.inputs;
   const requestPoll = useCallback((post = false) => {
-    if (!post && (hasNoRunningSteps(state.current.status) || statusIsFresh)) {
+    if (!post && hasNoRunningSteps(state.current.status) && statusIsFresh) {
       return;
     }
 

--- a/vulcan/lib/client/jsx/contexts/vulcan_context.tsx
+++ b/vulcan/lib/client/jsx/contexts/vulcan_context.tsx
@@ -11,20 +11,16 @@ import {useActionInvoker} from "etna-js/hooks/useActionInvoker";
 
 export const defaultContext = {
   state: defaultVulcanState as VulcanState,
-  stateRef: {current: defaultVulcanState},
-  // This would be set with a context dispatch when the provide is actually installed.
+  stateRef: {current: defaultVulcanState}, // This would be set with a context dispatch when the provide is actually
+                                           // installed.
   dispatch: (a: VulcanAction) => console.warn('action dispatched but not handled', a),
-  useActionInvoker: (() => () => null) as typeof useActionInvoker,
-  ...defaultSessionStorageHelpers,
-  ...defaultApiHelpers,
-  ...defaultSessionSyncHelpers,
-  ...defaultDataBufferingHelpers,
+  useActionInvoker: (() => () => null) as typeof useActionInvoker, ...defaultSessionStorageHelpers, ...defaultApiHelpers, ...defaultSessionSyncHelpers, ...defaultDataBufferingHelpers,
 }
 
 export type VulcanContextData = typeof defaultContext;
 export const VulcanContext = createContext(defaultContext);
 export type VulcanContext = typeof VulcanContext;
-export type ProviderProps = { params?: {}, storage?: typeof localStorage, children: any };
+export type ProviderProps = { params?: {}, storage?: typeof localStorage, wrapper?: [Function, Function], children: any };
 
 // Existing mostly to down type the return result into A from potentially inferring A & B
 function withOverrides<A, B extends Partial<A>, K extends keyof A>(base: A, overrides: B): A {
@@ -32,33 +28,35 @@ function withOverrides<A, B extends Partial<A>, K extends keyof A>(base: A, over
 }
 
 export const VulcanProvider = (props: ProviderProps & Partial<VulcanContextData>) => {
-  const actionInvokerHelpers = withOverrides({useActionInvoker}, props);
-  const stateRef = useRef(props.state || defaultContext.state);
-  const [state, dispatch] = useReducer(function (state: VulcanState, action: VulcanAction) {
-    const result = VulcanReducer(state, action);
-    stateRef.current = result;
-    return result;
-  }, stateRef.current);
-  const localSessionHelpers = withOverrides(useLocalSessionStorage(state, props), props);
-  const apiHelpers = withOverrides(useApi(actionInvokerHelpers.useActionInvoker()), props);
-  const {scheduleWork, getData, getWorkflows, pollStatus, postInputs} = apiHelpers;
-  const sessionSyncHelpers = withOverrides(useSessionSync(stateRef, scheduleWork, pollStatus, postInputs, dispatch), props);
-  const dataBufferingHelpers = useDataBuffering(state, dispatch, scheduleWork, getData);
-  useWorkflowsLoading(JSON.stringify(props.params), dispatch, getWorkflows, scheduleWork);
-  useInputStateManagement(state, dispatch, sessionSyncHelpers.statusIsFresh);
+  const [start, end] = props.wrapper || [() => null, () => null];
+  start();
 
-  return (
-      <VulcanContext.Provider value={{
-        state,
-        stateRef,
-        dispatch,
-        ...actionInvokerHelpers,
-        ...localSessionHelpers,
-        ...apiHelpers,
-        ...sessionSyncHelpers,
-        ...dataBufferingHelpers,
-      }}>
-        {props.children}
-      </VulcanContext.Provider>
-  );
+  try {
+    const actionInvokerHelpers = withOverrides({useActionInvoker}, props);
+    const stateRef = useRef(props.state || defaultContext.state);
+    const [state, dispatch] = useReducer(function (state: VulcanState, action: VulcanAction) {
+      const result = VulcanReducer(state, action);
+      stateRef.current = result;
+      return result;
+    }, stateRef.current);
+    const localSessionHelpers = withOverrides(useLocalSessionStorage(state, props), props);
+    const apiHelpers = withOverrides(useApi(actionInvokerHelpers.useActionInvoker()), props);
+    const {scheduleWork, getData, getWorkflows, pollStatus, postInputs} = apiHelpers;
+    const sessionSyncHelpers = withOverrides(useSessionSync(stateRef, scheduleWork, pollStatus, postInputs, dispatch),
+      props
+    );
+    const dataBufferingHelpers = useDataBuffering(state, dispatch, scheduleWork, getData);
+    useWorkflowsLoading(JSON.stringify(props.params), dispatch, getWorkflows, scheduleWork);
+    useInputStateManagement(state, dispatch, sessionSyncHelpers.statusIsFresh);
+
+    return (<VulcanContext.Provider value={{
+      state,
+      stateRef,
+      dispatch, ...actionInvokerHelpers, ...localSessionHelpers, ...apiHelpers, ...sessionSyncHelpers, ...dataBufferingHelpers,
+    }}>
+      {props.children}
+    </VulcanContext.Provider>);
+  } finally {
+    end();
+  }
 };

--- a/vulcan/lib/client/jsx/test_utils/mocks.ts
+++ b/vulcan/lib/client/jsx/test_utils/mocks.ts
@@ -25,7 +25,34 @@ export function createFakeStorage(): Storage {
 }
 
 export type PromiseArgs<R> = [(r: R) => void, (e: any) => void];
-export type AsyncMock<R> = [jest.Mock, PromiseArgs<R>[]];
+export class AsyncMock<R> {
+  constructor(public jestMock: jest.Mock, private promiseArgs: PromiseArgs<R>[]) {
+  }
+
+  hasPendingRequest() {
+    return this.promiseArgs.length > 0;
+  }
+
+  async awaitCall(reset: boolean): Promise<[PromiseArgs<R>, any[]]> {
+    if (reset) {
+      this.promiseArgs.length = 0;
+      this.jestMock.mockClear();
+    }
+
+    while (!this.hasPendingRequest()) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    const next = this.promiseArgs.shift();
+    const call = this.jestMock.mock.calls.shift();
+    if (next && call) {
+      return [next, call];
+    }
+
+    throw new Error('Should never have been reached');
+  }
+}
+
 export function asyncFn<R>(): AsyncMock<R> {
   const mock = jest.fn();
   const promiseArgs: PromiseArgs<R>[] = [];
@@ -36,5 +63,5 @@ export function asyncFn<R>(): AsyncMock<R> {
     })
   });
 
-  return [mock, promiseArgs];
+  return new AsyncMock<R>(mock, promiseArgs);
 }


### PR DESCRIPTION
Ok, I spent most of the day trying to get deeper testing of this, but I'm realizing there's still a few issues with the way our testing in react + promises works that is frustrating.

Mostly, react testing requires us to wrap a lot of promise calls in `act` calls, which... gets tricky.  We can't just use a hook in the global Promise constructor because frustratingly `jest` itself needs the normal Promise constructor behavior for other purposes, too.  

What we need is a more disciplined dependency injection like approach that would allow us to inject asynchronous wrappers into the contexts so that all our fetches and promises and jazz would magically get the `act` wrapper, but not the code unrelated to our code.

I could also do with reducing the amount of debug output in tests right now, so working on that bit by bit.

For now, this atleast fixes the polling behavior you saw.