### PR TITLE
Fixing some noisy errors from rollbar

### DIFF
--- a/magma/lib/magma/server/controller.rb
+++ b/magma/lib/magma/server/controller.rb
@@ -4,5 +4,16 @@ class Magma
       super
       @project_name = @params[:project_name]
     end
+
+    def handle_error(e)
+      case e
+      when NameError
+        if e.message.match(/Could not find Magma::Model/)
+          return failure(404, error: 'That project or model does not exist.')
+        end
+      end
+
+      super
+    end
   end
 end

--- a/magma/lib/magma/validation_object.rb
+++ b/magma/lib/magma/validation_object.rb
@@ -79,7 +79,7 @@ class Magma
 
   class RegexpValidationObject < ValidationObject
     def validate(value)
-      @object.match?(value)
+      value.is_a?(String) && @object.match?(value)
     end
 
     def error_message(name, value, hint)

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -27,6 +27,18 @@ describe RetrieveController do
     expect(last_response.status).to eq(403)
   end
 
+  it 'fails for non-existent models' do
+    retrieve(
+      {
+        model_name: 'laborvvvv',
+        record_names: [],
+        attribute_names: [],
+        project_name: 'labors'
+      },
+    )
+    expect(last_response.status).to eq(404)
+  end
+
   it 'calls the retrieve endpoint and returns a template.' do
     retrieve(
       model_name: 'aspect',

--- a/magma/spec/validation_spec.rb
+++ b/magma/spec/validation_spec.rb
@@ -41,6 +41,9 @@ describe Magma::Validation do
       # passes
       errors = validate(Labors::Monster, 'Nemean Lion', name: 'Nemean Lion', species: 'lion')
       expect(errors).to be_empty
+
+      errors = validate(Labors::Monster, 'Nemean Lion', name: 'Nemean Lion', species: [])
+      expect(errors).to eq(["On species, '[]' is improperly formatted."])
     end
 
     it 'validates a regexp proc' do

--- a/metis/lib/server/controllers/upload_controller.rb
+++ b/metis/lib/server/controllers/upload_controller.rb
@@ -183,6 +183,12 @@ class UploadController < Metis::Controller
   private
 
   def metis_uid
-    @request.cookies[Metis.instance.config(:metis_uid_name)] || @params[:metis_uid]
+    id = @request.cookies[Metis.instance.config(:metis_uid_name)] || @params[:metis_uid]
+
+    if id.nil?
+      raise Etna::BadRequest("metis_uid not set, did you forget to configure metis_uid to #{Metis.instance.config(:metis_uid_name)}?")
+    end
+
+    id
   end
 end

--- a/metis/lib/server/controllers/upload_controller.rb
+++ b/metis/lib/server/controllers/upload_controller.rb
@@ -186,7 +186,7 @@ class UploadController < Metis::Controller
     id = @request.cookies[Metis.instance.config(:metis_uid_name)] || @params[:metis_uid]
 
     if id.nil?
-      raise Etna::BadRequest("metis_uid not set, did you forget to configure metis_uid to #{Metis.instance.config(:metis_uid_name)}?")
+      raise Etna::BadRequest.new("metis_uid not set, did you forget to configure metis_uid to #{Metis.instance.config(:metis_uid_name)}?")
     end
 
     id


### PR DESCRIPTION
I upgraded the rollbar account so that we see items flow through that system again.
I took a jab at a couple of common errors our users are using that could have improved responses.

We could probably take a look at rollbar from time to time to see common errors users are hitting and see if we can improve the error messaging around them.