### PR TITLE
Order color mappings of the UMAP workflow + other tweaks

### DIFF
--- a/archimedes/archimedes/functions/list/__init__.py
+++ b/archimedes/archimedes/functions/list/__init__.py
@@ -1,1 +1,1 @@
-from .manipulations import unique, flatten
+from .manipulations import unique, flatten, order

--- a/archimedes/archimedes/functions/list/manipulations.py
+++ b/archimedes/archimedes/functions/list/manipulations.py
@@ -1,10 +1,11 @@
 from collections.abc import Iterable
+from typing import List, Union
 import re 
 
-def unique(ls):
+def unique(ls: list):
     return list(dict.fromkeys(ls))
 
-def flatten(ls):
+def flatten(ls: list):
     def _flatten(l):
         for el in l:
             if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
@@ -13,14 +14,14 @@ def flatten(ls):
                 yield el
     return list(_flatten(ls))
 
-def order_num(ls: list, return_indexes: bool = False):
+def order_num(ls: List[Union[int, float]], return_indexes: bool = False):
     if return_indexes:
         ret = 0
     else:
         ret = 1
     return list(i[ret] for i in sorted(enumerate(ls), key = lambda x:x[1]))
 
-def order_str(ls: list, return_indexes: bool = False): 
+def order_str(ls: List[str], return_indexes: bool = False): 
     """ Sort a string iterable in the way that humans expect.""" 
     convert = lambda text: int(text) if text.isdigit() else text 
     alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key[1].lower()) ]

--- a/archimedes/archimedes/functions/list/manipulations.py
+++ b/archimedes/archimedes/functions/list/manipulations.py
@@ -13,8 +13,34 @@ def flatten(ls):
                 yield el
     return list(_flatten(ls))
 
-def order(ls): 
-    """ Sort the given iterable in the way that humans expect.""" 
+def order_num(ls: list, return_indexes: bool = False):
+    if return_indexes:
+        ret = 0
+    else:
+        ret = 1
+    return list(i[ret] for i in sorted(enumerate(ls), key = lambda x:x[1]))
+
+def order_str(ls: list, return_indexes: bool = False): 
+    """ Sort a string iterable in the way that humans expect.""" 
     convert = lambda text: int(text) if text.isdigit() else text 
-    alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key.lower()) ] 
-    return sorted(ls, key = alphanum_key)
+    alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key[1].lower()) ]
+    if return_indexes:
+        ret = 0
+    else:
+        ret = 1
+    return list(i[ret] for i in sorted(enumerate(ls), key = alphanum_key))
+
+def order(ls: list, return_indexes: bool = False):
+    """
+    Output: ls reordered in "increasing" order
+    types: str, bool, 'number' (else case):
+    """
+    if all(map(lambda x: isinstance(x, str), ls)):
+        return order_str(ls, return_indexes)
+    elif all(map(lambda x: isinstance(x, bool), ls)):
+        num_ls = list({True: 0, False: 1}[x] for x in ls)
+        order_inds = order_num(num_ls, True)
+        if return_indexes: return order_inds
+        else: return ls[order_inds]
+    else:
+        return order_num(ls, return_indexes)

--- a/archimedes/archimedes/functions/list/manipulations.py
+++ b/archimedes/archimedes/functions/list/manipulations.py
@@ -1,10 +1,8 @@
 from collections.abc import Iterable
+import re 
 
 def unique(ls):
     return list(dict.fromkeys(ls))
-
-# def flatten(ls):
-#     return list(itertools.chain.from_iterable(ls))
 
 def flatten(ls):
     def _flatten(l):
@@ -14,3 +12,9 @@ def flatten(ls):
             else:
                 yield el
     return list(_flatten(ls))
+
+def order(ls): 
+    """ Sort the given iterable in the way that humans expect.""" 
+    convert = lambda text: int(text) if text.isdigit() else text 
+    alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key.lower()) ] 
+    return sorted(ls, key = alphanum_key)

--- a/archimedes/archimedes/functions/plotting/__init__.py
+++ b/archimedes/archimedes/functions/plotting/__init__.py
@@ -2,3 +2,4 @@ import plotly.express as px
 import plotly.io as pio
 
 from .colors import colors
+from .scatter_plot import scatter_plotly

--- a/archimedes/archimedes/functions/plotting/scatter_plot.py
+++ b/archimedes/archimedes/functions/plotting/scatter_plot.py
@@ -1,5 +1,6 @@
 import plotly.express as px
 
+from .utils import *
 from .colors import colors
 from ..utils import do_call
 from ..list import unique, order
@@ -23,14 +24,10 @@ def scatter_plotly(
     """
 
     # Parse dependent defaults (given 'None' b/c python)
-    def fill_by_if_None_and_logic(this, fill, logic = True):
-        if (this == None and logic):
-            return fill
-        return this
-    xlab = fill_by_if_None_and_logic(xlab, x_by)
-    ylab = fill_by_if_None_and_logic(ylab, y_by)
-    plot_title = fill_by_if_None_and_logic(plot_title, color_by)
-    legend_title = fill_by_if_None_and_logic(legend_title, color_by)
+    xlab = _default_to_if_None_and_logic(xlab, x_by)
+    ylab = _default_to_if_None_and_logic(ylab, y_by)
+    plot_title = _default_to_if_None_and_logic(plot_title, color_by)
+    legend_title = _default_to_if_None_and_logic(legend_title, color_by)
 
     # Add to px_args (Can probably remove this section once I learn python syntax better!)
     px_args['data_frame'] = data_frame

--- a/archimedes/archimedes/functions/plotting/scatter_plot.py
+++ b/archimedes/archimedes/functions/plotting/scatter_plot.py
@@ -2,7 +2,6 @@ import plotly.express as px
 
 from .utils import _default_to_if_None_and_logic
 from .colors import colors
-from ..utils import do_call
 from ..list import unique, order
 
 def scatter_plotly(
@@ -52,7 +51,7 @@ def scatter_plotly(
                 px_args['data_frame'] = data_frame.iloc[ list(reversed( order(data_frame[color_by], return_indexes=True) )) ]
     
     # Make plot
-    fig = do_call(px.scatter, px_args)
+    fig = px.scatter(**px_args)
 
     fig.update_layout(
         title_text=plot_title,

--- a/archimedes/archimedes/functions/plotting/scatter_plot.py
+++ b/archimedes/archimedes/functions/plotting/scatter_plot.py
@@ -1,0 +1,66 @@
+import plotly.express as px
+
+from .colors import colors
+from ..utils import do_call
+from ..list import unique, order
+
+def scatter_plotly(
+    data_frame, x_by: str, y_by: str, color_by: str,
+    px_args: dict = {},
+    size = 5, color_panel: list = colors,
+    color_order_legend: str = 'increasing',
+    plot_title: str = None, legend_title: str = None,
+    xlab: str = None, ylab: str = None
+    ):
+    """
+    Produces a scatter plot using plotly.express.scatter based on the pandas 'data_frame' given.
+    'x_by', 'y_by', and 'color_by' should indicate columns of 'data_frame' to use for x/y/color.
+    'px_args' should be a dictionary of additional bits to send in the 'plotly.express.scatter' call.
+    'size' sets the size of points.  Can be either a number directly or the name of a column of 'data_frame'.
+    'color_panel' (string list) sets the colors when 'color_by' references discrete data
+    'color_order_legend' ('increasing', 'decreasing', or 'unordered') sets the ordering of keys in the legend, when 'color_by' references discrete data
+    'plot_title', 'legend_title', 'xlab', and 'ylab' set titles.
+    """
+
+    # Parse dependent defaults (given 'None' b/c python)
+    def fill_by_if_None_and_logic(this, fill, logic = True):
+        if (this == None and logic):
+            return fill
+        return this
+    xlab = fill_by_if_None_and_logic(xlab, x_by)
+    ylab = fill_by_if_None_and_logic(ylab, y_by)
+    plot_title = fill_by_if_None_and_logic(plot_title, color_by)
+    legend_title = fill_by_if_None_and_logic(legend_title, color_by)
+
+    # Add to px_args (Can probably remove this section once I learn python syntax better!)
+    px_args['data_frame'] = data_frame
+    px_args['x'] = x_by
+    px_args['y'] = y_by
+    px_args['color'] = color_by
+    px_args['color_discrete_sequence'] = color_panel
+
+    # FUTURE! Make this work for bool too.  And maybe other types
+    if not all(map(lambda x: isinstance(x, str), data_frame[color_by])):
+        color_order_legend = 'unordered'
+    if (color_order_legend == 'increasing'):
+        px_args['category_orders'] = {color_by: order(unique(data_frame[color_by])) }
+    elif (color_order_legend == 'decreasing'):
+        px_args['category_orders'] = {color_by: order(unique(data_frame[color_by]).reverse()) }
+    
+    # Make plot
+    fig = do_call(px.scatter, px_args)
+
+    fig.update_layout(
+        title_text=plot_title,
+        xaxis_title=xlab,
+        yaxis_title=ylab,
+        legend_title=legend_title,
+        legend= {'itemsizing': 'constant'}
+    )
+
+    # Tweaks
+    # fig.update_coloraxes(colorbar_title_text=color_by)
+    fig.update_traces(marker={'size': size})
+
+    return fig
+

--- a/archimedes/archimedes/functions/plotting/scatter_plot.py
+++ b/archimedes/archimedes/functions/plotting/scatter_plot.py
@@ -39,13 +39,15 @@ def scatter_plotly(
     px_args['color'] = color_by
     px_args['color_discrete_sequence'] = color_panel
 
+    # Set legend key order.
     # FUTURE! Make this work for bool too.  And maybe other types
     if not all(map(lambda x: isinstance(x, str), data_frame[color_by])):
         color_order_legend = 'unordered'
-    if (color_order_legend == 'increasing'):
-        px_args['category_orders'] = {color_by: order(unique(data_frame[color_by])) }
-    elif (color_order_legend == 'decreasing'):
-        px_args['category_orders'] = {color_by: order(unique(data_frame[color_by]).reverse()) }
+    if (color_order_legend == 'increasing' or 'decreasing'):
+        categories = order(unique(data_frame[color_by]))
+        px_args['category_orders'] = { color_by: categories }
+    if (color_order_legend == 'decreasing'):
+        px_args['category_orders'] = { color_by: list(reversed(categories)) }
     
     # Make plot
     fig = do_call(px.scatter, px_args)

--- a/archimedes/archimedes/functions/plotting/scatter_plot.py
+++ b/archimedes/archimedes/functions/plotting/scatter_plot.py
@@ -1,6 +1,6 @@
 import plotly.express as px
 
-from .utils import *
+from .utils import _default_to_if_None_and_logic
 from .colors import colors
 from ..utils import do_call
 from ..list import unique, order

--- a/archimedes/archimedes/functions/plotting/utils.py
+++ b/archimedes/archimedes/functions/plotting/utils.py
@@ -1,4 +1,4 @@
-def default_to_if_None_and_logic(this, fill, logic = True):
+def _default_to_if_None_and_logic(this, fill, logic = True):
     if (this == None and logic):
         return fill
     return this

--- a/archimedes/archimedes/functions/plotting/utils.py
+++ b/archimedes/archimedes/functions/plotting/utils.py
@@ -1,0 +1,4 @@
+def default_to_if_None_and_logic(this, fill, logic = True):
+    if (this == None and logic):
+        return fill
+    return this

--- a/archimedes/archimedes/functions/utils/__init__.py
+++ b/archimedes/archimedes/functions/utils/__init__.py
@@ -1,6 +1,3 @@
 from numpy import random
 import re
 import pandas
-
-def do_call(what, kwargs = {}):
-    return what(**kwargs)

--- a/archimedes/archimedes/functions/utils/__init__.py
+++ b/archimedes/archimedes/functions/utils/__init__.py
@@ -1,3 +1,6 @@
 from numpy import random
 import re
 import pandas
+
+def do_call(what, kwargs = {}):
+    return what(**kwargs)

--- a/vulcan/lib/server/workflows/scripts/plot_umap.py
+++ b/vulcan/lib/server/workflows/scripts/plot_umap.py
@@ -1,21 +1,22 @@
 from archimedes.functions.dataflow import output_path, input_path, input_var, json, input_json, buildTargetPath
-from archimedes.functions.utils import do_call
 from archimedes.functions.scanpy import scanpy as sc
-from archimedes.functions.plotting import px, pio, colors
+from archimedes.functions.plotting import pio, scatter_plotly
 from archimedes.functions.magma import connect, question
-from archimedes.functions.list import flatten, unique, order
+from archimedes.functions.list import flatten
 from archimedes.functions.environment import project_name
 from archimedes.functions.utils import pandas as pd
 
-
+# Read inputs
 scdata = sc.read(input_path('umap_anndata.h5ad'))
 
 leiden = list(map(str, input_json('leiden.json')))
 
 color_by = input_var('color_by')
 
-magma = connect()
+px_args = {}
 
+# Prep magma querying
+magma = connect()
 def get(ids, value):
     ids = ids if type(ids) == list else ids.tolist()
     values = dict(question(magma, [
@@ -30,6 +31,7 @@ def get(ids, value):
 pdat = input_json("project_data")[project_name]
 color_options = pdat['color_options']
 
+# Obtain color data
 custom_tooltip = False
 if color_by == 'Cluster':
     color = leiden
@@ -54,33 +56,21 @@ elif color_by in color_options.keys():
 else:
     color = None
 
-##### OUTPUT
-plot_args = {
-    'data_frame': scdata.obsm['X_umap'],
-    'x':0, 'y':1,
-    'color_discrete_sequence': colors,
-    'color': color
-    }
-
-# if 'color is dicrete'
-plot_args['category_orders'] = {'color': order(unique(color)) }
+# Make data.frame and set extra plot settings
+dat = pd.DataFrame(scdata.obsm['X_umap'])
+dat[color_by] = color
 
 if custom_tooltip:
-    dat = pd.DataFrame(scdata.obsm['X_umap'])
     dat[hover_name] = hover_text
-    plot_args['data_frame'] = dat
-    plot_args['hover_data'] = [hover_name]
+    px_args['hover_data'] = [hover_name]
 
-fig = do_call(px.scatter, plot_args)
-
-fig.update_layout(
-    xaxis_title='UMAP1',
-    yaxis_title='UMAP2',
-    legend_title=color_by
-)
-fig.update_coloraxes(colorbar_title_text=color_by)
-
-fig.update_traces(marker={'size': 5})
+# Make & output plot
+fig = scatter_plotly(
+    dat, 0, 1, color_by,
+    px_args = px_args,
+    xlab = 'UMAP1',
+    ylab = 'UMAP2',
+    size = 5)
 
 with open(output_path('umap.plotly.json'), 'w') as output_file:
     json.dump(json.loads(pio.to_json(fig)), output_file)

--- a/vulcan/lib/server/workflows/scripts/plot_umap.py
+++ b/vulcan/lib/server/workflows/scripts/plot_umap.py
@@ -1,9 +1,9 @@
 from archimedes.functions.dataflow import output_path, input_path, input_var, json, input_json, buildTargetPath
-from archimedes.functions.utils import re
+from archimedes.functions.utils import do_call
 from archimedes.functions.scanpy import scanpy as sc
 from archimedes.functions.plotting import px, pio, colors
 from archimedes.functions.magma import connect, question
-from archimedes.functions.list import flatten
+from archimedes.functions.list import flatten, unique, order
 from archimedes.functions.environment import project_name
 from archimedes.functions.utils import pandas as pd
 
@@ -55,29 +55,32 @@ else:
     color = None
 
 ##### OUTPUT
+plot_args = {
+    'data_frame': scdata.obsm['X_umap'],
+    'x':0, 'y':1,
+    'color_discrete_sequence': colors,
+    'color': color
+    }
+
+# if 'color is dicrete'
+plot_args['category_orders'] = {'color': order(unique(color)) }
+
 if custom_tooltip:
     dat = pd.DataFrame(scdata.obsm['X_umap'])
     dat[hover_name] = hover_text
-    fig = px.scatter(
-        dat, x=0, y=1,
-        color_discrete_sequence=colors,
-        color=color,
-        hover_data=[hover_name]
-        )
-else:
-    fig = px.scatter(
-        scdata.obsm['X_umap'], x=0, y=1,
-        color_discrete_sequence=colors,
-        color=color)
+    plot_args['data_frame'] = dat
+    plot_args['hover_data'] = [hover_name]
+
+fig = do_call(px.scatter, plot_args)
 
 fig.update_layout(
-    xaxis_title='UMAP0',
-    yaxis_title='UMAP1',
+    xaxis_title='UMAP1',
+    yaxis_title='UMAP2',
     legend_title=color_by
 )
 fig.update_coloraxes(colorbar_title_text=color_by)
 
-fig.update_traces(marker={'size': 5, 'opacity': 0.5})
+fig.update_traces(marker={'size': 5})
 
 with open(output_path('umap.plotly.json'), 'w') as output_file:
     json.dump(json.loads(pio.to_json(fig)), output_file)

--- a/vulcan/lib/server/workflows/scripts/plot_umap.py
+++ b/vulcan/lib/server/workflows/scripts/plot_umap.py
@@ -70,6 +70,8 @@ fig = scatter_plotly(
     px_args = px_args,
     xlab = 'UMAP1',
     ylab = 'UMAP2',
+    color_order = 'increasing',
+    order_when_continuous_color = True,
     size = 5)
 
 with open(output_path('umap.plotly.json'), 'w') as output_file:

--- a/vulcan/lib/server/workflows/scripts/umap-projects.py
+++ b/vulcan/lib/server/workflows/scripts/umap-projects.py
@@ -24,6 +24,7 @@ project_data = {
 			#   Cluster, Tube, and Gene are standard options that do not need to be added here!
 			'Experiment': 'experiment#alias',
 			'Tissue': 'biospecimen_group#biospecimen_type',
+			'Fraction': 'sc_seq#cell_fraction',
 			'Pool': 'sc_seq_pool#::identifier',
 			'Biospecimen Group': 'biospecimen_group#::identifier',
 		},


### PR DESCRIPTION
Adds an `order()` function to `archimedes/functions/list` for this purpose.

Also:
- **pretty impactful for the fututre!** Separates data grab and plot-tweak planning code from direct scatter plot generation code, && turns the latter into its own separate function in archimedes! (`scatter_plotly` of `archimedes.functions.plotting`)
- adds a `do_call()` function to `archimedes/functions/utils` to simplify conditional coding by allowing common inputs to be set in a dict, conditional inputs to be added, then the function called on those inputs later.
- Sets point opacity to full & make legend keys larger.
- adds 'Fraction' as a color-by option for HuMu.

How do we feel about this ordering?
![ordering](https://user-images.githubusercontent.com/38870347/121757234-bfd03100-cad1-11eb-891d-36339f2305ee.png)