### PR TITLE
Additional notification for production metis deploys

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -8,6 +8,10 @@ function notifySlackOfVersion() {
     if ! [ -e "/var/run/deployment/notified/${APP_NAME}/$(cat /built-from-sha)" ]; then
       touch "/var/run/deployment/notified/${APP_NAME}/$(cat /built-from-sha)"
       post-to-slack "${APP_NAME} in ${ENV}" "bioinformatics-ping" "Deployed https://github.com/mountetna/monoetna/commit/$(cat /built-from-sha)"
+
+      if [[ $APP_NAME == "metis" && $ENV == "production" ]]; then
+        post-to-slack "${APP_NAME} in ${ENV}" "bioinformatics-ping" "<!channel> ${APP_NAME} restarted in ${ENV} -- please check your upload / download jobs!"
+      fi
     fi
   fi
 }

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -8,10 +8,6 @@ function notifySlackOfVersion() {
     if ! [ -e "/var/run/deployment/notified/${APP_NAME}/$(cat /built-from-sha)" ]; then
       touch "/var/run/deployment/notified/${APP_NAME}/$(cat /built-from-sha)"
       post-to-slack "${APP_NAME} in ${ENV}" "bioinformatics-ping" "Deployed https://github.com/mountetna/monoetna/commit/$(cat /built-from-sha)"
-
-      if [[ $APP_NAME == "metis" && $ENV == "production" ]]; then
-        post-to-slack "${APP_NAME} in ${ENV}" "bioinformatics-ping" "<!channel> ${APP_NAME} restarted in ${ENV} -- please check your upload / download jobs!"
-      fi
     fi
   fi
 }

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -266,6 +266,8 @@ class MetisClient < Client
       raise e
     rescue Errno::ECONNREFUSED => e
       return retry_blob(upload_path, upload, blob, retries)
+    rescue Net::OpenTimeout => e
+      return retry_blob(upload_path, upload, blob, retries)
     end
 
     if response.code == '503' || response.code == '502'

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -264,9 +264,7 @@ class MetisClient < Client
         return retry_blob(upload_path, upload, blob, retries)
       end
       raise e
-    rescue Errno::ECONNREFUSED => e
-      return retry_blob(upload_path, upload, blob, retries)
-    rescue Net::OpenTimeout => e
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Net::OpenTimeout  => e
       return retry_blob(upload_path, upload, blob, retries)
     end
 


### PR DESCRIPTION
This should add an `@channel` to the bioinformatics-ping channel when Metis is redeployed in production (@corps how would I test that behavior locally?). Pretty much a bandaid for when the metis_client retry doesn't work. I've also added another exception catch that I saw when testing, to the retry code (not sure if that is what triggers the production issues).

Testing locally this seems to work okay, though I'm not sure I'm reproducing the production issue. Restarting and stopping edge-apache and the front-end container don't seem to affect metis_client at all (even without these changes), so perhaps there is something more complex going on.

Thoughts? Will this be too noisy?