### PR TITLE
More metric improvements

### DIFF
--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -60,12 +60,61 @@ module Etna::Application
     end
   end
 
+  # This will cause metrics to persist to a file.
+  # NOTE -- /tmp/metrics.bin should be a persistent mount when using this.
+  # You will still need to export metrics in the text format for the node_exporter on the host machine to
+  # export them to prometheus.  Ensure that the /tmp/metrics.bin is on a named volume or a bind mount, either is fine.
+  def enable_job_metrics!
+    require 'prometheus'
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new({
+      dir: "/tmp/metrics.bin"
+    })
+  end
+
   def setup_yabeda
+    application = self.id
+    Yabeda.configure do
+      default_tag :application, application
+
+      group :etna do
+        histogram :response_time do
+          comment "Time spent by a controller returning a response"
+          unit :seconds
+          tags [:controller, :action, :user_hash]
+          buckets [0.01, 0.1, 0.3, 0.5, 1, 5]
+        end
+
+        counter :visits do
+          comment "Counts visits to the controller"
+          tags [:controller, :action, :user_hash]
+        end
+
+        counter :rollbar_errors do
+          comment "Counts errors detected by and sent to rollbar"
+        end
+
+        gauge :last_command_completion do
+          comment "Unix time of last time command was completed"
+          tags [:command, :status, :application]
+        end
+
+        histogram :command_runtime do
+          comment "Time spent processing a given command"
+          tags [:command, :status, :application]
+          unit :seconds
+          buckets [0.1, 1, 5, 60, 300, 1500]
+        end
+      end
+    end
+
     Yabeda.configure!
   end
 
+  # Writes all metrics currently gathered to a text format prometheus file.  If /tmp/metrics.prom is bind mounted
+  # to the host directed bound to the node_exporter's file exporter directory, these will be exported to
+  # prometheus.  Combine this enable_job_metrics! for maximum effect.
   def write_job_metrics(name)
-    node_metrics_dir = config(:node_metrics_dir) || "/tmp/metrics.prom"
+    node_metrics_dir = "/tmp/metrics.prom"
     ::FileUtils.mkdir_p(node_metrics_dir)
 
     tmp_file = ::File.join(node_metrics_dir, "#{name}.prom.$$")
@@ -126,17 +175,32 @@ module Etna::Application
   end
 
   def run_command(config, *args, &block)
+    application = self.id
+    status = 'success'
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     cmd, cmd_args, cmd_kwds = find_command(*args)
-    cmd.setup(config)
 
-    if block_given?
-      return unless yield [cmd, cmd_args]
+    begin
+      cmd.setup(config)
+      if block_given?
+        return unless yield [cmd, cmd_args]
+      end
+
+      cmd.execute(*cmd.fill_in_missing_params(cmd_args), **cmd_kwds)
+    rescue => e
+      Rollbar.error(e)
+      status = 'failed'
+      raise
+    ensure
+      if Yabeda.configured?
+        tags = { command: cmd.class.name, status: status, application: application }
+        dur = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+        Yabeda.etna.last_command_completion.set(tags, Time.now.to_i)
+        Yabeda.etna.command_runtime.measure(tags, dur)
+        write_job_metrics("run_command")
+      end
     end
-
-    cmd.execute(*cmd.fill_in_missing_params(cmd_args), **cmd_kwds)
-  rescue => e
-    Rollbar.error(e)
-    raise
   end
 end
 

--- a/etna/lib/etna/logger.rb
+++ b/etna/lib/etna/logger.rb
@@ -40,6 +40,10 @@ module Etna
         error(trace)
       end
 
+      if defined? Yabeda
+        Yabeda.etna.rollbar_errors.increment({}, 1) rescue nil
+      end
+
       Rollbar.error(e)
     end
 

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -1,4 +1,5 @@
 require 'digest'
+require 'date'
 
 module Etna
   class Route
@@ -80,7 +81,7 @@ module Etna
       return "unknown" unless @action
       secret = Etna::Application.instance.config(:user_hash_secret) || 'notsosecret'
       controller, action = @action.split('#')
-      Digest::MD5.hexdigest(email + secret + controller + action)
+      Digest::MD5.hexdigest(email + secret + controller + action + Date.today.to_s)
     end
 
     def try_yabeda(request, &block)

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -77,8 +77,10 @@ module Etna
     end
 
     def hash_user_email(email)
+      return "unknown" unless @action
       secret = Etna::Application.instance.config(:user_hash_secret) || 'notsosecret'
-      Digest::MD5.hexdigest(email + secret)
+      controller, action = @action.split('#')
+      Digest::MD5.hexdigest(email + secret + controller + action)
     end
 
     def try_yabeda(request, &block)

--- a/janus/config.ru
+++ b/janus/config.ru
@@ -13,6 +13,7 @@ require_relative './lib/server/refresh_token'
 Janus.instance.configure(YAML.load(File.read('config.yml')))
 
 use Etna::CrossOrigin
+use Etna::MetricsExporter
 use Etna::ParseBody
 use Etna::SymbolizeParams
 use Rack::Static, urls: ['/css', '/js', '/fonts', '/img'], root: 'lib/client'

--- a/magma/bin/magma
+++ b/magma/bin/magma
@@ -8,4 +8,7 @@ require 'yaml'
 
 config = YAML.load(File.read(File.expand_path("../../config.yml",__FILE__)))
 
+require 'yabeda'
+Magma.instance.enable_job_metrics!
+Magma.instance.setup_yabeda
 Magma.instance.run_command(config, *ARGV)

--- a/magma/config.ru
+++ b/magma/config.ru
@@ -7,6 +7,7 @@ require_relative 'lib/magma'
 
 Magma.instance.configure(YAML.load(File.read('config.yml')))
 use Etna::CrossOrigin
+use Etna::MetricsExporter
 use Etna::ParseBody
 use Etna::SymbolizeParams
 use Etna::Auth

--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -134,6 +134,19 @@ class Magma
     end
   end
 
+  def setup_yabeda
+    Yabeda.configure do
+      group :magma do
+        gauge :data_rows do
+          comment "The number of data rows by project and model for magma."
+          tags [:project_name, :model_name]
+        end
+      end
+    end
+
+    super
+  end
+
   def test?
     ENV["MAGMA_ENV"] == "test"
   end

--- a/magma/lib/magma/commands.rb
+++ b/magma/lib/magma/commands.rb
@@ -239,6 +239,24 @@ EOT
     end
   end
 
+  class MeasureDataRows < Etna::Command
+    def setup(config)
+      super
+      Magma.instance.load_models
+      Magma.instance.setup_db
+    end
+
+    def execute
+      Magma.instance.magma_projects.keys.each do |project_name|
+        project = Magma.instance.get_project(project_name)
+        project.models.each do |model_name, model|
+          tags = {model_name: model_name.to_s, project_name: project_name.to_s}
+          Yabeda.magma.data_rows.set(tags, model.count)
+        end
+      end
+    end
+  end
+
   class CreateDb < Etna::Command
     usage '<project_name> # Attach an existing project to a magma instance, creating database and schema'
 

--- a/metis/config.ru
+++ b/metis/config.ru
@@ -8,6 +8,7 @@ require './lib/server'
 Metis.instance.configure(YAML.load(File.read("config.yml")))
 
 use Etna::CrossOrigin
+use Etna::MetricsExporter
 use Etna::ParseBody
 use Etna::SymbolizeParams
 use Etna::Auth

--- a/polyphemus/bin/polyphemus
+++ b/polyphemus/bin/polyphemus
@@ -9,5 +9,6 @@ require 'yaml'
 config = YAML.load(File.read(File.expand_path("../../config.yml",__FILE__)))
 
 require 'yabeda'
+Polyphemus.instance.enable_job_metrics!
 Polyphemus.instance.setup_yabeda
 Polyphemus.instance.run_command(config, *ARGV)

--- a/polyphemus/lib/polyphemus.rb
+++ b/polyphemus/lib/polyphemus.rb
@@ -17,31 +17,4 @@ class Polyphemus
     @db.extension :pg_json
     @db.pool.connection_validation_timeout = -1
   end
-
-  def setup_yabeda
-    Yabeda.configure do
-      group :polyphemus do
-        gauge :last_command_completion do
-          comment "Unix time of last time command was completed"
-          tags [:command, :status]
-        end
-      end
-    end
-
-    super
-  end
-
-  def run_command(config, *args, &block)
-    cmd, cmd_args, cmd_kwds = find_command(*args)
-
-    begin
-      super
-      Yabeda.polyphemus.last_command_completion.set({ command: cmd.class.name, status: 'success' }, Time.now.to_i)
-    rescue
-      Yabeda.polyphemus.last_command_completion.set({ command: cmd.class.name, status: 'failed' }, Time.now.to_i)
-      raise
-    ensure
-      write_job_metrics("#{cmd.class.name}.last_run")
-    end
-  end
 end

--- a/timur/config.ru
+++ b/timur/config.ru
@@ -9,6 +9,7 @@ require_relative 'lib/server'
 
 Timur.instance.configure(YAML.load(File.read('config.yml')))
 
+use Etna::MetricsExporter
 use Etna::ParseBody
 use Etna::SymbolizeParams
 use Etna::Auth


### PR DESCRIPTION
1.  Measure all etna routes -- capture response times, controllers, and unique users.  Unique users are tracked as tags, hashing their email against a production secret to ensure anonymity.
2.  Measure rollbar error rates
3. Measure command runtimes and status.
4. -- WIP measure the number of rows for each project + model pairing with a polyphemus job.  To be complete, still working on this.