### PR TITLE
Metis client not retrying

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -208,7 +208,14 @@ class MetisClient < Client
       Errno::ECONNABORTED,
       Errno::EHOSTDOWN,
       Errno::EHOSTUNREACH,
+      Errno::EINVAL,
+      Errno::ETIMEDOUT,
       Net::ReadTimeout,
+      Net::HTTPFatalError,
+      Net::HTTPBadResponse,
+      Net::HTTPHeaderSyntaxError,
+      Net::HTTPServerException,
+      Net::ProtocolError,
       IOError,
       EOFError,
       Timeout::Error,
@@ -329,7 +336,6 @@ class MetisClient < Client
   def get_file(path, &block)
     https.request(get(path)) do |response|
       response.read_body do |chunk|
-        puts chunk
         yield chunk
       end
     end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -216,10 +216,20 @@ class MetisClient < Client
       Net::HTTPHeaderSyntaxError,
       Net::HTTPServerException,
       Net::ProtocolError,
+      Net::HTTPRequestTimeOut,
+      Net::HTTPGatewayTimeOut,
+      Net::HTTPBadRequest,
+      Net::HTTPBadGateway,
+      Net::HTTPError,
+      Net::HTTPInternalServerError,
+      Net::HTTPRetriableError,
+      Net::HTTPServerError,
+      Net::HTTPServiceUnavailable,
+      Net::HTTPUnprocessableEntity,
+      Net::OpenTimeout,
       IOError,
       EOFError,
-      Timeout::Error,
-      Net::OpenTimeout
+      Timeout::Error
     ]
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -217,6 +217,8 @@ class MetisClient < Client
       Net::HTTPServerException,
       Net::ProtocolError,
       Net::HTTPRequestTimeOut,
+      Net::HTTPRequestTimeout,
+      Net::HTTPGatewayTimeout,
       Net::HTTPGatewayTimeOut,
       Net::HTTPBadRequest,
       Net::HTTPBadGateway,
@@ -298,14 +300,18 @@ class MetisClient < Client
       )
     rescue OpenSSL::SSL::SSLError => e
       if e.message =~ /write client hello/
+        puts "SSL error, retrying"
         return retry_blob(upload_path, upload, blob, retries)
       end
       raise e
     rescue *net_exceptions  => e
+      puts "Received #{e.class.name}, retrying"
       return retry_blob(upload_path, upload, blob, retries)
     end
 
-    if response.code == '503' || response.code == '502'
+    retry_codes = ['503', '502', '504', '408']
+    if retry_codes.include?(response.code)
+      puts "Received response with code #{response.code}, retrying"
       retry_blob(upload_path, upload, blob, retries)
       return
     end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -214,7 +214,6 @@ class MetisClient < Client
       Net::HTTPFatalError,
       Net::HTTPBadResponse,
       Net::HTTPHeaderSyntaxError,
-      Net::HTTPServerException,
       Net::ProtocolError,
       Net::HTTPRequestTimeOut,
       Net::HTTPRequestTimeout,
@@ -229,6 +228,7 @@ class MetisClient < Client
       Net::HTTPServiceUnavailable,
       Net::HTTPUnprocessableEntity,
       Net::OpenTimeout,
+      Net::WriteTimeout,
       IOError,
       EOFError,
       Timeout::Error
@@ -890,7 +890,7 @@ EOT
           download_path = file[:download_url].sub(%r!^https://[^/]*?/!, '/')
           completed = 0.0
           size = file[:size]
-            
+
           open(actual_file,"w") do |io|
             start = Time.now
             @shell.client.get_file(download_path) do |chunk|
@@ -918,7 +918,7 @@ EOT
           else
             puts "DownloadError -- max retries reached. Giving up."
             raise ShellError, e.message
-          end  
+          end
         end
       end
     end


### PR DESCRIPTION
This PR adds even more Net::HTTP exceptions to the list, and some debugging print statements.

I can't reproduce the exception behavior on staging, even when I run chef-client or deliberately throw a 502 or 503 from the server. The weird thing is that Arjun's stacktrace and the source code both show that an exception should be thrown on a 503 in `blob_upload` and thus needs to be caught by our rescue + `net_exceptions` list. However, when I test locally and against staging using the same Ruby version (`2.6.6`), I don't get an exception thrown, rather I get a `response` object whose `code` value must be inspected as we see a couple lines down from the rescue block.

I will test a bit more to see if I can reproduce the production issue, but putting this code up here for now.

===================

So I was able to reproduce the exception behavior going from C4 to staging -- using the previous metis_client, I'd get a 503 exception thrown on edge-apache restart, which would kill the entire client process. Using this version, the client survived both an edge-apache stop as well as a chef-client deploy, so I think this will work much better. :crossed_fingers: 