### PR TITLE
count bucket files in sql instead of ruby

### DIFF
--- a/metis/lib/models/bucket.rb
+++ b/metis/lib/models/bucket.rb
@@ -70,7 +70,7 @@ class Metis
         project_name: project_name,
         access: access,
         description: description,
-        count: files.count
+        count: Metis::File.where(bucket: self).count
       }
     end
   end


### PR DESCRIPTION
After deploying the earlier foreign key fix I noted that things were still bad - looking at the ipi project page on Metis for example showed nothing for a full 28s while a request to `bucket#list` completed. Egad! I had no idea things were so bad. The most mystifying part is that no one has quite complained about this before, nearly to the extent that they ought to, what gives?

In any case, after some futzing around in the console the answer is obvious: don't inflate tens of thousands of Metis::File instances merely to count them and you won't have 28s response times. Equivalent SQL runs in `ms` :)