### PR TITLE
Fix page bounds with any

### DIFF
--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -69,8 +69,6 @@ class Magma
     end
 
     def answer
-      require 'pry'
-      binding.pry
       table = to_table(query)
 
       @start_predicate.extract(table, identity)
@@ -208,11 +206,11 @@ class Magma
       bounds_select_parts << Sequel.function(:row_number)
                              .over(order: order_by_aliases)
                              .as(:row)
-      require 'pry'
-      binding.pry
 
-      # @start_predicate.alias_for_attribute(@model.identity)
-      count_query.from_self.select(
+      # Get bounds based off of distinct counts,
+      #   otherwise count does not reflect unique records
+      #   and pagination results don't make sense.
+      count_query.distinct.from_self.select(
           *bounds_select_parts
       ).from_self(alias: :main_query).select(
           # only the first row from each page
@@ -305,8 +303,6 @@ class Magma
     end
 
     def paged_query(query)
-      require 'pry'
-      binding.pry
       raise QuestionError, 'Page must start at 1' unless @options[:page] > 0
       bounds = to_table(page_bounds_query).map do |row|
         order_by_aliases.map { |c| row[c] }

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -69,6 +69,8 @@ class Magma
     end
 
     def answer
+      require 'pry'
+      binding.pry
       table = to_table(query)
 
       @start_predicate.extract(table, identity)
@@ -206,7 +208,10 @@ class Magma
       bounds_select_parts << Sequel.function(:row_number)
                              .over(order: order_by_aliases)
                              .as(:row)
+      require 'pry'
+      binding.pry
 
+      # @start_predicate.alias_for_attribute(@model.identity)
       count_query.from_self.select(
           *bounds_select_parts
       ).from_self(alias: :main_query).select(
@@ -300,6 +305,8 @@ class Magma
     end
 
     def paged_query(query)
+      require 'pry'
+      binding.pry
       raise QuestionError, 'Page must start at 1' unless @options[:page] > 0
       bounds = to_table(page_bounds_query).map do |row|
         order_by_aliases.map { |c| row[c] }

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -194,7 +194,7 @@ class Magma
         query = constraint.apply(query)
       end
 
-      query.select(
+      query.distinct.select(
           *order_by_column_names.zip(order_by_aliases).map { |c, a| c.as(a) }
       )
     end
@@ -207,10 +207,7 @@ class Magma
                              .over(order: order_by_aliases)
                              .as(:row)
 
-      # Get bounds based off of distinct counts,
-      #   otherwise count does not reflect unique records
-      #   and pagination results don't make sense.
-      count_query.distinct.from_self.select(
+      count_query.from_self.select(
           *bounds_select_parts
       ).from_self(alias: :main_query).select(
           # only the first row from each page

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -1230,7 +1230,7 @@ describe QueryController do
       expect(json_body[:errors]).to eq(["Page 3 not found"])
     end
 
-    it 'can paginate with ::any filter' do 
+    it 'can paginate with one-to-many relationships' do 
       lion = create(:labor, project: @project, name: 'Nemean Lion')
       hydra = create(:labor, project: @project, name: 'Lernean Hydra')
       stables = create(:labor, project: @project, name: 'Augean Stables')
@@ -1247,6 +1247,39 @@ describe QueryController do
       
       expect(json_body[:answer].map { |a| a.last }).to eq(
         ['Augean Stables', 'Lernean Hydra'])
+    end
+
+    it 'can paginate and order with one-to-many relationships' do 
+      now = DateTime.now
+      
+      Timecop.freeze(now - 1000)
+
+      lion = create(:labor, project: @project, name: 'Nemean Lion')
+      
+      Timecop.freeze(now - 500)
+      
+      hydra = create(:labor, project: @project, name: 'Lernean Hydra')
+      
+      Timecop.freeze(now - 250)
+      
+      stables = create(:labor, project: @project, name: 'Augean Stables')
+
+      Timecop.return
+
+      poison = create(:prize, labor: hydra, name: 'poison', worth: 0)
+      poop = create(:prize, labor: stables, name: 'poop', worth: 4)
+      iou = create(:prize, labor: stables, name: 'iou', worth: 3)
+      skin = create(:prize, labor: lion, name: 'skin', worth: 5)
+
+      query_opts(
+        ['labor', ['prize', [ '::has', 'worth' ], '::any'], '::all', 'name' ],
+        page: 1,
+        page_size: 2,
+        order: 'updated_at'
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq(
+        ['Nemean Lion', 'Lernean Hydra'])
     end
   end
 

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -1229,6 +1229,25 @@ describe QueryController do
       expect(last_response.status).to eq(422)
       expect(json_body[:errors]).to eq(["Page 3 not found"])
     end
+
+    it 'can paginate with ::any filter' do 
+      lion = create(:labor, project: @project, name: 'Nemean Lion')
+      hydra = create(:labor, project: @project, name: 'Lernean Hydra')
+      stables = create(:labor, project: @project, name: 'Augean Stables')
+      poison = create(:prize, labor: hydra, name: 'poison', worth: 0)
+      poop = create(:prize, labor: stables, name: 'poop', worth: 4)
+      iou = create(:prize, labor: stables, name: 'iou', worth: 3)
+      skin = create(:prize, labor: lion, name: 'skin', worth: 5)
+
+      query_opts(
+        ['labor', ['prize', [ '::has', 'worth' ], '::any'], '::all', 'name' ],
+        page: 1,
+        page_size: 2
+      )
+      
+      expect(json_body[:answer].map { |a| a.last }).to eq(
+        ['Augean Stables', 'Lernean Hydra'])
+    end
   end
 
   context 'restriction' do


### PR DESCRIPTION
Kind of getting stuck on this larger query refactor with subqueries, so extracting out this small bug fix to the page bounds when using `::any`. Basically this PR fixes an issue when using `::any` with page limits might result in incomplete data being returned in the query results, because of duplicate entries from the `count` query (that calculates the page bounds internally).