### PR TITLE
allow supereditors to add projects

### DIFF
--- a/janus/lib/client/jsx/janus-admin.jsx
+++ b/janus/lib/client/jsx/janus-admin.jsx
@@ -3,7 +3,7 @@ import Icon from 'etna-js/components/icon';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 import {selectUser} from 'etna-js/selectors/user-selector';
 import { json_post, json_get } from 'etna-js/utils/fetch';
-import {isSuperuser} from 'etna-js/utils/janus';
+import {isSuperEditor} from 'etna-js/utils/janus';
 
 import TextField from '@material-ui/core/TextField';
 import Table from '@material-ui/core/Table';
@@ -95,7 +95,7 @@ const JanusAdmin = () => {
   useEffect(retrieveAllProjects, []);
   return <div id='janus-admin'>
     <Projects user={user} projects={projects}/>
-    { isSuperuser(user) && <NewProject retrieveAllProjects={retrieveAllProjects}/> }
+    { isSuperEditor(user) && <NewProject retrieveAllProjects={retrieveAllProjects}/> }
   </div>;
 }
 

--- a/janus/lib/client/jsx/janus-nav.jsx
+++ b/janus/lib/client/jsx/janus-nav.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Nav from 'etna-js/components/Nav';
 import {selectUser} from 'etna-js/selectors/user-selector';
-import {isSuperViewer} from 'etna-js/utils/janus';
+import {isSuperViewer, isSuperEditor} from 'etna-js/utils/janus';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 
 const Logo = () => <div id='logo'/>;
@@ -9,7 +9,7 @@ const Logo = () => <div id='logo'/>;
 const NavBar = ({user}) => <div id='nav'>
   <div className='nav_item'><a href='/settings'>Settings</a></div>
   { isSuperViewer(user) && <div className='nav_item'><a href='/admin'>Admin</a></div> }
-  { isSuperViewer(user) && <div className='nav_item'><a href='/flags'>Flags</a></div> }
+  { isSuperEditor(user) && <div className='nav_item'><a href='/flags'>Flags</a></div> }
 </div>
 
 const JanusNav = () => {

--- a/janus/lib/server.rb
+++ b/janus/lib/server.rb
@@ -31,7 +31,7 @@ class Janus
 
     post '/add_user/:project_name', action: 'admin#add_user', auth: { user: { is_admin?: :project_name } }
 
-    post '/add_project', action: 'admin#add_project', auth: { user: { is_superuser?: true } }
+    post '/add_project', action: 'admin#add_project', auth: { user: { is_supereditor?: true } }
 
     post '/flag_user', action: 'admin#flag_user', auth: { user: { is_superuser?: true } }
 


### PR DESCRIPTION
A wee change allowing people with supereditor permissions to add new projects, which should allow us to enable DSCO people to create their own projects.