### PR TITLE
Polyphemus hotfix2 cascade mvir1

### DIFF
--- a/etna/lib/etna/clients/metis/client.rb
+++ b/etna/lib/etna/clients/metis/client.rb
@@ -210,6 +210,52 @@ module Etna
         }
       end
 
+      def resolve_conflicts_and_verify_rename(project_name:, source_bucket:, dest_bucket:, folder:, file:)
+        parent_folder = ::File.dirname(file.file_path)
+
+        should_rename_original = true
+
+        # If the destination folder already exists, check to see if
+        #   the file also exists, otherwise we risk a
+        #   rename conflict.
+        create_folder_request = CreateFolderRequest.new(
+          project_name: project_name,
+          bucket_name: dest_bucket,
+          folder_path: parent_folder
+        )
+
+        if folder_exists?(create_folder_request)
+          # If file exists in destination, delete the older file.
+          list_dest_folder_request = Etna::Clients::Metis::ListFolderRequest.new(
+            bucket_name: dest_bucket,
+            project_name: project_name,
+            folder_path: parent_folder
+          )
+
+          dest_file = list_folder(list_dest_folder_request).files.all.find { |f| f.file_name == file.file_name }
+
+          if (dest_file && file.updated_at <= dest_file.updated_at)
+            # Delete source file if it's out of date
+            delete_file(Etna::Clients::Metis::DeleteFileRequest.new(
+              bucket_name: source_bucket,
+              project_name: project_name,
+              file_path: file.file_path,
+            ))
+
+            should_rename_original = false
+          elsif (dest_file && file.updated_at > dest_file.updated_at)
+            # Delete dest file if it's out of date
+            delete_file(Etna::Clients::Metis::DeleteFileRequest.new(
+              bucket_name: dest_bucket,
+              project_name: project_name,
+              file_path: dest_file.file_path,
+            ))
+          end
+        end
+
+        should_rename_original
+      end
+
       def recursively_rename_folder(project_name:, source_bucket:, dest_bucket:, folder:)
         folder_contents = list_folder(
           Etna::Clients::Metis::ListFolderRequest.new(
@@ -228,44 +274,21 @@ module Etna
         end
 
         folder_contents.files.all.each do |file|
-          # If file exists in destination, delete the older file.
-          list_dest_folder_request = Etna::Clients::Metis::ListFolderRequest.new(
-            bucket_name: dest_bucket,
+          should_rename = resolve_conflicts_and_verify_rename(
             project_name: project_name,
-            folder_path: ::File.dirname(file.file_path)
-          )
+            source_bucket: source_bucket,
+            dest_bucket: dest_bucket,
+            folder: folder,
+            file: file)
 
-          dest_file = list_folder(list_dest_folder_request).files.all.find { |f| f.file_name == file.file_name }
-
-          should_rename = true
-          if (dest_file && file.updated_at <= dest_file.updated_at)
-            # Delete source file if it's out of date
-            delete_file(Etna::Clients::Metis::DeleteFileRequest.new(
-              bucket_name: source_bucket,
-              project_name: project_name,
-              file_path: file.file_path,
-            ))
-
-            should_rename = false
-          elsif (dest_file && file.updated_at > dest_file.updated_at)
-            # Delete dest file if it's out of date
-            delete_file(Etna::Clients::Metis::DeleteFileRequest.new(
-              bucket_name: dest_bucket,
-              project_name: project_name,
-              file_path: dest_file.file_path,
-            ))
-          end
-
-          if should_rename
-            rename_file(Etna::Clients::Metis::RenameFileRequest.new(
-              bucket_name: source_bucket,
-              project_name: project_name,
-              file_path: file.file_path,
-              new_bucket_name: dest_bucket,
-              new_file_path: file.file_path,
-              create_parent: true)
-            )
-          end
+          rename_file(Etna::Clients::Metis::RenameFileRequest.new(
+            bucket_name: source_bucket,
+            project_name: project_name,
+            file_path: file.file_path,
+            new_bucket_name: dest_bucket,
+            new_file_path: file.file_path,
+            create_parent: true)
+          ) if should_rename
         end
 
         # Now delete the source folder

--- a/etna/spec/metis_client_spec.rb
+++ b/etna/spec/metis_client_spec.rb
@@ -433,7 +433,7 @@ describe 'Metis Client class' do
             folders: [],
             files: []
           }.to_json
-        }).times(3).then
+        }).times(4).then
         .to_return({
           status: 200, # List an existing file
           headers: {
@@ -449,7 +449,7 @@ describe 'Metis Client class' do
               "updated_at": "2000-02-01 00:00:00"
             }]
           }.to_json
-        }).then
+        }).times(2).then
         .to_return({
           status: 422
         })


### PR DESCRIPTION
This PR fixes an edge case I missed in my earlier PR, where the parent folder in the destination bucket may not exist for a given file, throwing an exception when you check for a duplicate copy. So this checks for a parent folder before attempting to list it...

