### PR TITLE
tweak limit on sftp ingest to smaller batches

### DIFF
--- a/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
@@ -6,7 +6,7 @@ class Polyphemus::SftpIngestMetisTriageFilesEtl < Polyphemus::DbTriageFileEtl
     @bucket_name = "waiting_room"
     super(
       project_bucket_pairs: [[@project_name, @bucket_name]],
-      limit: 20,
+      limit: 5,
     )
   end
 

--- a/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
@@ -6,7 +6,7 @@ class Polyphemus::SftpIngestMetisTriageFilesEtl < Polyphemus::DbTriageFileEtl
     @bucket_name = "waiting_room"
     super(
       project_bucket_pairs: [[@project_name, @bucket_name]],
-      limit: 5,
+      limit: 1,
     )
   end
 


### PR DESCRIPTION
This PR lowers the batch size of the ingest ETL from 20 to 1. The files are so large and take so long to get into Metis (the SFTP interface seems slow?), that I think it's worth chunking them into smaller batches so the ETL can update its state more frequently. Right now a restart to the ETL during an active run (i.e. caused by a deployment) causes the ETL state to be lost and start over again. So I'd like to save progress on every file, basically.