### PR TITLE
fix slicing for tables

### DIFF
--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -167,8 +167,14 @@ const QueryFilterControl = ({
   const noOperandOperators: string[] = ['::has', '::lacks'];
 
   const magmifyOperator = useCallback(
-    (operator: string) => operatorOptions[operator],
-    [operatorOptions]
+    (operator: string) => {
+      if (attributeType === 'number' && operator === 'Equals') {
+        return '::=';
+      }
+
+      return operatorOptions[operator];
+    },
+    [operatorOptions, attributeType]
   );
 
   const prettifyOperator = useCallback(

--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -116,6 +116,7 @@ const QueryFilterControl = ({
           return 'date';
         case 'integer':
         case 'float':
+        case 'number':
           return 'number';
         default:
           return 'text';

--- a/timur/lib/client/jsx/components/query/query_model_attributes_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attributes_selector.tsx
@@ -147,7 +147,7 @@ const QueryModelAttributeSelector = ({
 
   const hasMatrixSlices = matrixModelNames.includes(modelValue);
   const hasCollectionSlices = collectionModelNames.includes(modelValue);
-
+  console.log('sliceable things', matrixModelNames, collectionModelNames);
   const hasSlices = hasMatrixSlices || hasCollectionSlices;
 
   const id = `${label}-${Math.random()}`;

--- a/timur/lib/client/jsx/components/query/query_model_attributes_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attributes_selector.tsx
@@ -147,7 +147,7 @@ const QueryModelAttributeSelector = ({
 
   const hasMatrixSlices = matrixModelNames.includes(modelValue);
   const hasCollectionSlices = collectionModelNames.includes(modelValue);
-  console.log('sliceable things', matrixModelNames, collectionModelNames);
+
   const hasSlices = hasMatrixSlices || hasCollectionSlices;
 
   const id = `${label}-${Math.random()}`;

--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -95,7 +95,7 @@ export const selectCollectionModelNames = (
     for (let i = 0; i < path.length - 1; i++) {
       let current = path[i];
       let next = path[i + 1];
-      if (current === rootModelName || next === rootModelName) {
+      if ((current === rootModelName && !next) || next === rootModelName) {
         continue;
       } else if (
         i === 0 &&

--- a/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
+++ b/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
@@ -49,6 +49,12 @@ const models = {
     revisions: {},
     views: {},
     template: require('../../fixtures/template_wound.json')
+  },
+  aspect: {
+    documents: {},
+    revisions: {},
+    views: {},
+    template: require('../../fixtures/template_aspect.json')
   }
 };
 
@@ -120,6 +126,13 @@ describe('useSliceMethods', () => {
             attribute_name: 'name',
             display_label: 'prize.name'
           }
+        ],
+        aspect: [
+          {
+            model_name: 'aspect',
+            attribute_name: 'name',
+            display_label: 'aspect.name'
+          }
         ]
       }
     };
@@ -130,7 +143,7 @@ describe('useSliceMethods', () => {
       wrapper: querySpecWrapper(mockState, store)
     });
 
-    expect(result.current.collectionModelNames).toEqual(['prize']);
+    expect(result.current.collectionModelNames).toEqual(['aspect', 'prize']);
   });
 
   it('does not include collections if in the full parentage of root', async () => {

--- a/timur/test/javascript/fixtures/template_aspect.json
+++ b/timur/test/javascript/fixtures/template_aspect.json
@@ -1,0 +1,45 @@
+{
+  "name": "aspect",
+  "attributes": {
+    "created_at": {
+      "name": "created_at",
+      "attribute_name": "created_at",
+      "display_name": "Created At",
+      "hidden": true,
+      "validation": null,
+      "attribute_type": "date_time"
+    },
+    "updated_at": {
+      "name": "updated_at",
+      "attribute_name": "updated_at",
+      "display_name": "Updated At",
+      "hidden": true,
+      "validation": null,
+      "attribute_type": "date_time"
+    },
+    "monster": {
+      "name": "monster",
+      "attribute_name": "monster",
+      "model_name": "monster",
+      "link_model_name": "monster",
+      "display_name": "Monster",
+      "restricted": false,
+      "read_only": false,
+      "hidden": false,
+      "validation": null,
+      "attribute_type": "parent"
+    },
+    "name": {
+      "name": "name",
+      "attribute_name": "name",
+      "display_name": "Name",
+      "restricted": false,
+      "read_only": false,
+      "hidden": false,
+      "validation": null,
+      "attribute_type": "identifier"
+    }
+  },
+  "identifier": "name",
+  "parent": "monster"
+}


### PR DESCRIPTION
Noticed this bug when trying to compose some test queries, this PR re-enables slicing for tables when you go "down" the tree.

Also fixes the equals operator for numbers and casts operand as numeric.