### PR TITLE
fix cursor logging

### DIFF
--- a/polyphemus/lib/etl.rb
+++ b/polyphemus/lib/etl.rb
@@ -104,7 +104,7 @@ class Polyphemus
     def run_once
       logger.info("Starting loop")
       @cursor_group.with_next do |cursor|
-        logger.info("Selecting cursor for #{cursor}")
+        logger.info("Selecting cursor for #{cursor.name}")
         cursor.load_from_db
         logger.info("Finding batch...")
         batch = @scanner.find_batch(cursor)


### PR DESCRIPTION
This fixes an issue where polyphemus is spamming logs because it is printing out the entire cursor for each ETL whenever they run.