### PR TITLE
Add the ability to follow defaultValue on debounced inputs

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.39'
+  spec.version           = '0.1.40'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -192,7 +192,7 @@ module Etna::Application
       status = 'failed'
       raise
     ensure
-      if Yabeda.configured?
+      if defined?(Yabeda) && Yabeda.configured?
         tags = { command: cmd.class.name, status: status, application: application }
         dur = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 

--- a/etna/packages/etna-js/components/inputs/slow_text_input.jsx
+++ b/etna/packages/etna-js/components/inputs/slow_text_input.jsx
@@ -5,7 +5,7 @@ import {Debouncer} from "../../utils/debouncer";
 export default function SlowTextInput(props) {
   const {onChange, waitTime, eager, defaultValue, followDefault, ...inputProps} = props;
   const inputRef = useRef();
-  const [value, setValue] = useState(defaultValue || '');
+  const [value, setValue] = useState(defaultValue == null ? '' : defaultValue);
   const [prevDefault, setPrevDefault] = useState(() => defaultValue);
   const [debouncer, setDebouncer] = useState(() => new Debouncer({windowMs: waitTime, eager}));
   // Clear the existing debouncer and accept any new changes to the settings

--- a/etna/packages/etna-js/components/inputs/slow_text_input.jsx
+++ b/etna/packages/etna-js/components/inputs/slow_text_input.jsx
@@ -1,46 +1,41 @@
-import React, {Component} from 'react';
+import React, {Component, useCallback, useEffect, useRef, useState} from 'react';
 import debounce from '../../utils/debounce';
+import {Debouncer} from "../../utils/debouncer";
 
-// this is an input that debounces text input of some sort
-export default class SlowTextInput extends Component {
-  constructor() {
-    super();
-    this.state = {};
-  }
+export default function SlowTextInput(props) {
+  const {onChange, waitTime, eager, defaultValue, followDefault, ...inputProps} = props;
+  const inputRef = useRef();
+  const [value, setValue] = useState(defaultValue || '');
+  const [prevDefault, setPrevDefault] = useState(() => defaultValue);
+  const [debouncer, setDebouncer] = useState(() => new Debouncer({windowMs: waitTime, eager}));
+  // Clear the existing debouncer and accept any new changes to the settings
+  useEffect(() => {
+    const debouncer = new Debouncer({windowMs: waitTime, eager})
+    setDebouncer(debouncer);
+    return () => debouncer.reset();
+  }, [waitTime, eager]);
 
-  onChange(value) {
-    this.props.onChange(value);
-  }
+  const onChangeWithDebounce = useCallback(() => {
+    const v = inputRef.current.value;
+    debouncer.ready(() => onChange(v));
+    setValue(v);
+  }, [onChange, debouncer]);
 
-  handleChange() {
-    let input_value = this.text_input.value;
-    this.setState({input_value});
-    this.onChange(input_value);
-  }
+  // When the default value changes, follow it
+  useEffect(() => {
+    if (followDefault && defaultValue !== prevDefault) {
+      debouncer.reset();
+      setValue(defaultValue);
+      setPrevDefault(defaultValue);
+    }
+  }, [defaultValue, followDefault, debouncer, setPrevDefault, prevDefault]);
 
-  componentWillMount() {
-    this.onChange = debounce(this.onChange, this.props.waitTime || 500);
-  }
 
-  render() {
-    let {
-      onChange,
-      waitTime,
-      defaultValue,
-      ...inputProps
-    } = this.props;
-    let {input_value} = this.state;
-
-    if (defaultValue == null || defaultValue == undefined) defaultValue = '';
-
-    return (
-      <input
-        type='text'
-        ref={(input) => (this.text_input = input)}
-        onChange={this.handleChange.bind(this)}
-        value={input_value == undefined ? defaultValue : input_value}
-        {...inputProps}
-      />
-    );
-  }
+  return <input
+    type='text'
+    ref={inputRef}
+    onChange={onChangeWithDebounce}
+    value={value}
+    {...inputProps}
+    />;
 }

--- a/etna/packages/etna-js/utils/debouncer.jsx
+++ b/etna/packages/etna-js/utils/debouncer.jsx
@@ -11,6 +11,7 @@ export class Debouncer {
     this.promise = new Promise((resolve) => {
       this.resolve = resolve;
     });
+    if (this.lastTimeout) clearTimeout(this.lastTimeout);
     this.lastTimeout = null;
     this.lastFire = Date.now();
     this.f = null;

--- a/janus/Gemfile.lock
+++ b/janus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/magma/Gemfile.lock
+++ b/magma/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/timur/Gemfile.lock
+++ b/timur/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/vulcan/Gemfile.lock
+++ b/vulcan/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.39)
+    etna (0.1.40)
       concurrent-ruby
       jwt
       multipart-post

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/float.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/float.tsx
@@ -11,7 +11,7 @@ export function FloatInput({onChange, data, ...props}: WithInputParams<{}, numbe
 
   return (
     <EtnaFloatInput
-      key={value}
+      followDefault
       defaultValue={value}
       onChange={onNewFloat}
     />

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/input_types.ts
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/input_types.ts
@@ -81,7 +81,9 @@ export type WorkflowStepGroup = { label: string, steps: WorkflowStep[] }
 
 export type InputBackendComponent<Params extends {} = {}, Value = unknown, DataElement = unknown> = (p: WithInputParams<Params, Value, DataElement>) => React.ReactElement | null;
 export type WithInputParams<Params extends {}, Value, DataElement = unknown> = Params & {
-  onChange: (v: Maybe<Value>) => void; value: Maybe<Value>; data: DataEnvelope<DataElement> | undefined | null;
+  onChange: (v: Maybe<Value>) => void;
+  value: Maybe<Value>;
+  data: DataEnvelope<DataElement> | undefined | null;
 }
 
 export interface ValidationInputSpecification<Value = unknown, DataElement = unknown> {

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/integer.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/integer.tsx
@@ -11,7 +11,7 @@ export default function IntegerInput({onChange, data, ...props}: WithInputParams
 
   return (
     <EtnaIntegerInput
-      key={value}
+      followDefault
       defaultValue={value}
       onChange={onNewInt}
     />

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/string.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/string.tsx
@@ -10,7 +10,7 @@ export default function StringInput({onChange, data, ...props}: WithInputParams<
 
   return (
     <SlowTextInput
-      key={value}
+      followDefault
       defaultValue={value}
       onChange={(e: string) => {
         onChange(some(e));


### PR DESCRIPTION
Test this by running `make -C vulcan start-storybook`, navigating to http://localhost:9700 after webpack build is done, and checking the workflow manager component.

1.  Reset and loading from file still works
2. Focus isn't randomly lost.

I was using the `key` prop to force remounts and reconsuming of the value, but this causes the browser to sometimes "lose" focus due to the way the dom works.  This alternative is more complex and requires explicit "following" of defaultValue, but it works.

The idea is that the inputs still debounce, but they optionally also track changes to defaultValue (resulting from forced setting of the value).  This change also uses the explicit debouncer constructor which also includes `reset()`, meaning that we can prevent accidental debounces from setting state after a component is dismounted, or settings changes.