### PR TITLE
Magma query subqueries up tree

### DIFF
--- a/magma/lib/magma/query/predicate/subquery_operator.rb
+++ b/magma/lib/magma/query/predicate/subquery_operator.rb
@@ -13,7 +13,7 @@ class Magma
         main_table_alias: predicate.alias_name,
         main_table_join_column_name: parent_column_name(predicate.model),
         internal_table_alias: internal_table_alias,
-        subquery_fk_column_name: parent_column_name(predicate.model),
+        subquery_pivot_column_name: parent_column_name(predicate.model),
         filters: subquery_filters(subquery_args, internal_table_alias, predicate.model),
         condition: condition,
       )

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -115,6 +115,7 @@ class Magma
     private
 
     def to_table(query)
+      binding.pry
       Magma::QueryExecutor.new(query, @options[:timeout], Magma.instance.db).execute
     end
 

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -115,7 +115,6 @@ class Magma
     private
 
     def to_table(query)
-      binding.pry
       Magma::QueryExecutor.new(query, @options[:timeout], Magma.instance.db).execute
     end
 

--- a/magma/lib/magma/query/subquery_base.rb
+++ b/magma/lib/magma/query/subquery_base.rb
@@ -1,15 +1,15 @@
 class Magma
   class SubqueryBase
-    attr_reader :subquery_model, :derived_table_alias, :main_table_alias, :main_table_join_column_name, :internal_table_alias, :subquery_fk_column_name, :include_constraint
+    attr_reader :subquery_model, :derived_table_alias, :main_table_alias, :main_table_join_column_name, :internal_table_alias, :subquery_pivot_column_name, :include_constraint
 
-    def initialize(subquery_model:, derived_table_alias:, main_table_alias:, main_table_join_column_name:, internal_table_alias:, subquery_fk_column_name:, filters:, condition:, include_constraint: true)
+    def initialize(subquery_model:, derived_table_alias:, main_table_alias:, main_table_join_column_name:, internal_table_alias:, subquery_pivot_column_name:, filters:, condition:, include_constraint: true)
       @subquery_model = subquery_model
 
       @derived_table_alias = derived_table_alias.to_sym
       @main_table_alias = main_table_alias.to_sym
       @internal_table_alias = internal_table_alias.to_sym
       @main_table_join_column_name = main_table_join_column_name.to_sym
-      @subquery_fk_column_name = subquery_fk_column_name.to_sym
+      @subquery_pivot_column_name = subquery_pivot_column_name.to_sym
 
       @filters = filters
       @include_constraint = include_constraint
@@ -17,7 +17,7 @@ class Magma
       @constraints = @filters.map do |filter|
         Magma::SubqueryConstraint.new(
           filter,
-          @subquery_fk_column_name,
+          @subquery_pivot_column_name,
           condition
         )
       end
@@ -48,7 +48,7 @@ class Magma
     end
 
     def subquery_table_column
-      Sequel.qualify(derived_table_alias, subquery_fk_column_name)
+      Sequel.qualify(derived_table_alias, subquery_pivot_column_name)
     end
 
     def constraint

--- a/magma/lib/magma/query/subquery_constraint.rb
+++ b/magma/lib/magma/query/subquery_constraint.rb
@@ -1,18 +1,18 @@
 class Magma
   class SubqueryConstraint
-    attr_reader :filter, :subquery_fk_column_name, :condition
+    attr_reader :filter, :subquery_pivot_column_name, :condition
 
-    def initialize(filter, subquery_fk_column_name, condition)
+    def initialize(filter, subquery_pivot_column_name, condition)
       @filter = filter
-      @subquery_fk_column_name = subquery_fk_column_name
+      @subquery_pivot_column_name = subquery_pivot_column_name
       @condition = condition
     end
 
     def apply(query)
       query = query.select(
-        subquery_fk_column_name
+        subquery_pivot_column_name
       ).group_by(
-        subquery_fk_column_name
+        subquery_pivot_column_name
       )
 
       constraints.each do |constraint|

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -238,6 +238,11 @@ describe QueryController do
 
         expect(json_body[:answer].map(&:last)).to eq([ "Lernean Hydra", "Nemean Lion" ])
         expect(json_body[:format]).to eq([ "labors::labor#name", "labors::labor#name" ])
+
+        query(['prize', ['labor', ['::has', 'name'], '::every'], '::all', '::identifier'])
+
+        expect(json_body[:answer].map(&:last)).to eq([ "Augean Stables", "Lernean Hydra", "Nemean Lion" ])
+        expect(json_body[:format]).to eq([ "labors::labor#name", "labors::labor#name" ])
       end
 
       it 'supports ::every with attribute value as filter' do


### PR DESCRIPTION
This PR fixes an issue with Magma query with subqueries, to correctly work when going up the model tree, and adds specs for that scenario. I think this fixes a lot of the issues seen early in the week with 0 results returned (i.e. finding `sc_rna_seq` records where patient was treated with dexamethasone). The counts returned and UI table also seem to behave correctly with this fix...