### PR TITLE
Bug Fix: color_by error for 'Tube' and all magma-queried data

### DIFF
--- a/vulcan/lib/server/workflows/scripts/plot_umap.py
+++ b/vulcan/lib/server/workflows/scripts/plot_umap.py
@@ -48,11 +48,11 @@ elif color_by == 'Manual Annotations':
     annots = input_json('annots.json')
     color = [annots[x] for x in leiden]
 elif color_by == 'Tube':
-    color = scdata.obs[ 'Record_ID' ]
+    color = scdata.obs[ 'Record_ID' ].values
 elif color_by in scdata.raw.var_names:
     color = flatten(scdata.raw.X[ : , scdata.raw.var_names == color_by ].toarray())
 elif color_by in color_options.keys():
-    color = get(scdata.obs[ 'Record_ID' ], buildTargetPath(color_options[color_by], pdat))
+    color = get(scdata.obs[ 'Record_ID' ].values, buildTargetPath(color_options[color_by], pdat))
 else:
     color = None
 


### PR DESCRIPTION
Contrary to my previous assumption, record_ids get added into the `scdata` anndata object just fine in the earlier stages of the workflow. Instead, the error came from a mismatch between indexes/keys/rownames of the `scdata.obsm` (contains UMAP) and `scdata.obs` (contains Record_IDs) when the plotting dataframe is built.  `.obsm` has `1...numCells`, but `.obs` has the cell barcodes.  Not sure why the scanpy authors chose this.  All color options requiring a magma query get mapped to cells through these Record_IDs, so those took on the mismatched indexes in this step too.

Fix: Now the script uses `.values` when it grabs the record_ids to focus on the values and ignore the `.obs` indexes completely.