### PR TITLE
fix issue with page bounds on subqueries

### DIFF
--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -190,6 +190,7 @@ class Magma
 
       joins = @start_predicate.join.uniq
       constraints = @start_predicate.constraint.uniq
+      subqueries = @start_predicate.subquery.uniq
 
       joins.each do |join|
         query = join.apply(query)
@@ -197,6 +198,10 @@ class Magma
 
       constraints.each do |constraint|
         query = constraint.apply(query)
+      end
+
+      subqueries.each do |subquery|
+        query = subquery.apply(query)
       end
 
       query.distinct.select(

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -1629,7 +1629,7 @@ describe QueryController do
       expect(json_body[:errors]).to eq(["Page 3 not found"])
     end
 
-    it 'can paginate with one-to-many relationships' do 
+    it 'can paginate with ::any filter' do 
       lion = create(:labor, project: @project, name: 'Nemean Lion')
       hydra = create(:labor, project: @project, name: 'Lernean Hydra')
       stables = create(:labor, project: @project, name: 'Augean Stables')
@@ -1648,7 +1648,31 @@ describe QueryController do
         ['Augean Stables', 'Lernean Hydra'])
     end
 
-    it 'can paginate and order with one-to-many relationships' do 
+    it 'can paginate with ::any filter when some records do not have filter results' do 
+      lion = create(:labor, project: @project, name: 'Nemean Lion')
+      hydra = create(:labor, project: @project, name: 'Lernean Hydra')
+      stables = create(:labor, project: @project, name: 'Augean Stables')
+      hind = create(:labor, project: @project, name: 'Ceryneian Hind')
+      boar = create(:labor, project: @project, name: 'Erymanthian Boar')
+      birds = create(:labor, project: @project, name: 'Stymphalian Birds')
+      
+      [lion, hydra, stables, hind, boar, birds].each do |labor|
+        (0..10).each do |prize_number|
+          create(:prize, name: "#{labor.name} prize #{prize_number}", labor: labor)
+        end
+      end
+
+      query_opts(
+        ['labor', ['prize', [ 'name', '::matches', 'ian' ], '::any'], '::all', 'name' ],
+        page: 2,
+        page_size: 2
+      )
+
+      expect(json_body[:answer].map { |a| a.last }).to eq(
+        ['Stymphalian Birds'])
+    end
+
+    it 'can paginate and order with ::any filter' do 
       now = DateTime.now
       
       Timecop.freeze(now - 1000)


### PR DESCRIPTION
This PR fixes the issue with page bounds and subqueries, where bounds were not correctly calculated on subqueries. This is because the `count_query` is distinct from the `base_query`, and so we need to include the subquery logic there as well (in `Magma::Question`). The user would see counts returned on the Query page, but the table pagination + rows rendered would not behave correctly ... i.e. searching patients with a specific demographic would result in varying number of rows rendered on the page because not every patient might have that demographic field (page 1 might have 0 rows, page 2 have 1 row, page 3 have 6 rows, etc.). This is because the bounds would be calculated on non-subquery results (i.e. bounds are `patient_1` to `patient_10`), but the actual, subquery results would be `[patient_2, patient_11, patient_23, etc.]`, leading to a mismatch in the UI.