### PR TITLE
fix value combine error

### DIFF
--- a/polyphemus/lib/etls/redcap/lib/value.rb
+++ b/polyphemus/lib/etls/redcap/lib/value.rb
@@ -27,7 +27,7 @@ module Redcap
       when "select_choice"
         return @template.select_choice(field_name, field_value(redcap_record))
       when "combine"
-        return field_value_array(redcap_record).join(@config[:combine] || ' ')
+        return field_value_array(redcap_record)&.join(@config[:combine] || ' ')
       else
         raise "Invalid value specified in value config: #{@config}"
       end

--- a/polyphemus/spec/etls/redcap/loader_spec.rb
+++ b/polyphemus/spec/etls/redcap/loader_spec.rb
@@ -124,7 +124,6 @@ describe Polyphemus::RedcapEtlScriptRunner do
 
       expect(records.keys).to match_array([:feature, :year])
       expect(records[:feature].values).to match_array([
-        {:name=>"Radio", :value=>"1969", :year=>"Jatsun Thunderer 2"},
         {:name=>"Door", :value=>"1979", :year=>"ToyoT CorolloroC 1"},
         {:name=>"Engine", :value=>"1979", :year=>"ToyoT CorolloroC 1"},
         {:name=>"Wheels", :value=>"1980", :year=>"ToyoT CorolloroC 2"}
@@ -149,7 +148,6 @@ describe Polyphemus::RedcapEtlScriptRunner do
                 calendar_year: "year",
                 feature_list: {
                   "redcap_field": "feature",
-                  "exists": true,
                   "value": "combine",
                   "combine": ", "
                 }
@@ -162,7 +160,8 @@ describe Polyphemus::RedcapEtlScriptRunner do
       expect(records.keys).to match_array([:year])
       expect(records[:year].values).to match_array(
         [
-          {:calendar_year=>"1969", :feature_list=>"Radio"},
+          {:calendar_year=>"1968"},
+          {:calendar_year=>"1969"},
           {:calendar_year=>"1979", :feature_list=>"Door, Engine"},
           {:calendar_year=>"1980", :feature_list=>"Wheels"}
         ]

--- a/polyphemus/spec/fixtures/redcap_test2_data_all.json
+++ b/polyphemus/spec/fixtures/redcap_test2_data_all.json
@@ -71,15 +71,6 @@
     "value": "1980"
   },
   {
-    "record": "Jatsun",
-    "record_id": "Jatsun",
-    "redcap_event_name": "Thunderer",
-    "redcap_repeat_instrument": "model_versions",
-    "redcap_repeat_instance": 2,
-    "field_name": "feature",
-    "value": "Radio"
-  },
-  {
     "record": "ToyoT",
     "record_id": "ToyoT",
     "redcap_event_name": "CorolloroC",


### PR DESCRIPTION
This is an error resulting from, possibly, an empty checkbox value being passed to the "combine" value type which I recently added to the redcap loader.