### PR TITLE
Adjustments to job metrics handling, fix for bundler issue, and metis…

### DIFF
--- a/docker/etna-base-dev/Dockerfile
+++ b/docker/etna-base-dev/Dockerfile
@@ -3,7 +3,9 @@ WORKDIR /app
 
 ENV DOCKER_VERSION 19.03.12
 ENV RUBY_VERSION 2.5.7
-ENV BUNDLER_VERSION 2.2.0
+# This is so dumb -- but if BUNDLER_VERSION is set as an environment variable,
+# it causes issues with bundler... bleck.  So, so add an underscore at the end.
+ENV BUNDLER_VERSION_ 2.2.5
 ENV DOCKERIZE_VERSION 0.5.0
 ENV NODE_VERSION 12.18.1
 ENV DOCKERIZE_URL https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
@@ -47,7 +49,7 @@ ENV BUNDLE_BIN="$BUNDLE_PATH/bin"
 ENV BUNDLE_SILENCE_ROOT_WARNING=0
 ENV BUNDLE_APP_CONFIG="/app/.bundle"
 
-RUN gem install bundler --default -v "=$BUNDLER_VERSION"
+RUN gem install bundler --default -v "=$BUNDLER_VERSION_"
 RUN gem update --system
 
 # We also the GEM_PATH to be this BUNDLE_PATH so that ides (Rubymine) will find gems easier.

--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -60,17 +60,6 @@ module Etna::Application
     end
   end
 
-  # This will cause metrics to persist to a file.
-  # NOTE -- /tmp/metrics.bin should be a persistent mount when using this.
-  # You will still need to export metrics in the text format for the node_exporter on the host machine to
-  # export them to prometheus.  Ensure that the /tmp/metrics.bin is on a named volume or a bind mount, either is fine.
-  def enable_job_metrics!
-    require 'prometheus'
-    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new({
-      dir: "/tmp/metrics.bin"
-    })
-  end
-
   def setup_yabeda
     application = self.id
     Yabeda.configure do
@@ -198,7 +187,8 @@ module Etna::Application
 
         Yabeda.etna.last_command_completion.set(tags, Time.now.to_i)
         Yabeda.etna.command_runtime.measure(tags, dur)
-        write_job_metrics("run_command")
+
+        write_job_metrics("run_command.#{cmd.class.name}")
       end
     end
   end

--- a/janus/janus.completion
+++ b/janus/janus.completion
@@ -430,16 +430,7 @@ COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
 return
 fi
 shift
-if [[ "$#" == "1" ]];  then
-all_completion_names="__privileged__"
-if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
-return
-fi
-COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
-return
-fi
-shift
-all_flag_completion_names="$all_flag_completion_names  "
+all_flag_completion_names="$all_flag_completion_names --privileged "
 arg_flag_completion_names="$arg_flag_completion_names  "
 multi_flags="$multi_flags  "
 while [[ "$#" != "0" ]]; do

--- a/magma/bin/magma
+++ b/magma/bin/magma
@@ -9,6 +9,5 @@ require 'yaml'
 config = YAML.load(File.read(File.expand_path("../../config.yml",__FILE__)))
 
 require 'yabeda'
-Magma.instance.enable_job_metrics!
 Magma.instance.setup_yabeda
 Magma.instance.run_command(config, *ARGV)

--- a/magma/magma.completion
+++ b/magma/magma.completion
@@ -17,7 +17,7 @@ arg_flag_completion_names="$arg_flag_completion_names  "
 multi_flags="$multi_flags  "
 while [[ "$#" != "0" ]]; do
 if [[ "$#" == "1" ]];  then
-all_completion_names="console create_db generate_completion_script global_migrate help load load_project migrate plan unload"
+all_completion_names="console create_db generate_completion_script global_migrate help load load_project measure_data_rows migrate plan unload"
 all_completion_names="$all_completion_names $all_flag_completion_names"
 if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
 return
@@ -281,6 +281,44 @@ fi
 COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
 return
 fi
+shift
+all_flag_completion_names="$all_flag_completion_names  "
+arg_flag_completion_names="$arg_flag_completion_names  "
+multi_flags="$multi_flags  "
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+if ! [[ "$multi_flags" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+fi
+a=$1
+shift
+if [[ "$arg_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
+return
+elif [[ "$1" == "measure_data_rows" ]]; then
 shift
 all_flag_completion_names="$all_flag_completion_names  "
 arg_flag_completion_names="$arg_flag_completion_names  "

--- a/metis/lib/metis.rb
+++ b/metis/lib/metis.rb
@@ -39,6 +39,19 @@ class Metis
     ::File.join(config(:data_path), project)
   end
 
+  def setup_yabeda
+    Yabeda.configure do
+      group :metis do
+        gauge :file_count do
+          comment "The number of files by project and bucket_name"
+          tags [:project_name, :bucket_name]
+        end
+      end
+    end
+
+    super
+  end
+
   def archiver
     @archiver ||= Metis::Archiver.new(config(:backup))
   end

--- a/metis/metis.completion
+++ b/metis/metis.completion
@@ -17,7 +17,7 @@ arg_flag_completion_names="$arg_flag_completion_names  "
 multi_flags="$multi_flags  "
 while [[ "$#" != "0" ]]; do
 if [[ "$#" == "1" ]];  then
-all_completion_names="archive assimilate console create_db generate_completion_script help migrate remove_orphan_data_blocks schema"
+all_completion_names="archive assimilate checksum_files console create_db generate_completion_script help measure_file_counts migrate remove_orphan_data_blocks schema"
 all_completion_names="$all_completion_names $all_flag_completion_names"
 if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
 return
@@ -90,6 +90,44 @@ fi
 COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
 return
 fi
+shift
+all_flag_completion_names="$all_flag_completion_names  "
+arg_flag_completion_names="$arg_flag_completion_names  "
+multi_flags="$multi_flags  "
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+if ! [[ "$multi_flags" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+fi
+a=$1
+shift
+if [[ "$arg_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
+return
+elif [[ "$1" == "checksum_files" ]]; then
 shift
 all_flag_completion_names="$all_flag_completion_names  "
 arg_flag_completion_names="$arg_flag_completion_names  "
@@ -242,6 +280,44 @@ fi
 done
 return
 elif [[ "$1" == "help" ]]; then
+shift
+all_flag_completion_names="$all_flag_completion_names  "
+arg_flag_completion_names="$arg_flag_completion_names  "
+multi_flags="$multi_flags  "
+while [[ "$#" != "0" ]]; do
+if [[ "$#" == "1" ]];  then
+all_completion_names=""
+all_completion_names="$all_completion_names $all_flag_completion_names"
+if [[ -z "$(echo $all_completion_names | xargs)" ]]; then
+return
+fi
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+elif [[ -z "$(echo $all_flag_completion_names | xargs)" ]]; then
+return
+elif [[ "$all_flag_completion_names" =~ $1\  ]]; then
+if ! [[ "$multi_flags" =~ $1\  ]]; then
+all_flag_completion_names="${all_flag_completion_names//$1\ /}"
+fi
+a=$1
+shift
+if [[ "$arg_flag_completion_names" =~ $a\  ]]; then
+if [[ "$#" == "1" ]];  then
+a="${a//--/}"
+a="${a//-/_}"
+i="_completions_for_$a"
+all_completion_names="${!i}"
+COMPREPLY=($(compgen -W "$all_completion_names" -- "$1"))
+return
+fi
+shift
+fi
+else
+return
+fi
+done
+return
+elif [[ "$1" == "measure_file_counts" ]]; then
 shift
 all_flag_completion_names="$all_flag_completion_names  "
 arg_flag_completion_names="$arg_flag_completion_names  "

--- a/polyphemus/bin/polyphemus
+++ b/polyphemus/bin/polyphemus
@@ -9,6 +9,5 @@ require 'yaml'
 config = YAML.load(File.read(File.expand_path("../../config.yml",__FILE__)))
 
 require 'yabeda'
-Polyphemus.instance.enable_job_metrics!
 Polyphemus.instance.setup_yabeda
 Polyphemus.instance.run_command(config, *ARGV)

--- a/polyphemus/lib/etl.rb
+++ b/polyphemus/lib/etl.rb
@@ -14,7 +14,7 @@ class Polyphemus
     def self.inherited(subclass)
       subclass.include(Etna::CommandExecutor)
 
-      self.const_set(:Run, Class.new(Etna::Command) do
+      subclass.const_set(:Run, Class.new(Etna::Command) do
         usage 'runs the etl process until no more active processing is currently available.'
         include WithLogger
 
@@ -39,7 +39,7 @@ class Polyphemus
         end
       end) unless self.const_defined?(:Run)
 
-      self.const_set(:Reset, Class.new(Etna::Command) do
+      subclass.const_set(:Reset, Class.new(Etna::Command) do
         usage 'resets the cursor for this etl, so that next processing starts from the beginning of time.'
         include WithLogger
 


### PR DESCRIPTION
… file counter.

Metrics no longer persist in aggregate files -- instead, we produce a file for each unique command class name, which contains the last collected metrics.  this approach prevents the application servers from buffering data indefinitely.  It is still scraped via the node_exporter.

Adds a new command that will be run on a systemd timer and collect file totals by bucket and project name.