### PR TITLE
Timur query refactor

### DIFF
--- a/magma/lib/magma/query/predicate/subquery_base.rb
+++ b/magma/lib/magma/query/predicate/subquery_base.rb
@@ -26,7 +26,7 @@ class Magma
 
     def subquery_filters(subquery_args, internal_table_alias, subquery_model)
       subquery_filters = []
-      while subquery_args.first.is_a?(Array)
+      while subquery_args.first.is_a?(Array) && !Magma::SubqueryUtils.is_subquery?(predicate, subquery_args.first)
         filter_args = subquery_args.shift
         subquery_filter = FilterPredicate.new(
           question: @question,

--- a/magma/lib/magma/query/predicate/subquery_filter.rb
+++ b/magma/lib/magma/query/predicate/subquery_filter.rb
@@ -33,7 +33,9 @@ class Magma
         nested_subqueries << create_nested_subquery(nested_args, subquery_model, internal_table_alias)
       end if has_nested_subquery
 
-      subquery_class.new(
+      # subquery_class is always SubqueryInner if it is a nested subquery...
+      clazz = is_nested_subquery?(main_model) ? subquery_class : Magma::SubqueryInner
+      clazz.new(
         subquery_model: subquery_model,
         derived_table_alias: derived_table_alias,
         main_table_alias: join_table_alias,
@@ -43,8 +45,12 @@ class Magma
         filters: subquery_filters(subquery_args, internal_table_alias, subquery_model),
         subqueries: nested_subqueries,
         condition: verb_applies ? verb.do(:subquery_config).condition : nil,
-        include_constraint: !has_nested_subquery,
+        include_constraint: true,
       )
+    end
+
+    def is_nested_subquery?(model)
+      model.model_name == predicate.model.model_name
     end
 
     def going_down_graph?(start_model, end_model)

--- a/magma/lib/magma/query/predicate/subquery_filter.rb
+++ b/magma/lib/magma/query/predicate/subquery_filter.rb
@@ -33,7 +33,7 @@ class Magma
         nested_subqueries << create_nested_subquery(nested_args, subquery_model, internal_table_alias)
       end if has_nested_subquery
 
-      # subquery_class is always SubqueryInner if it is a nested subquery...
+      # Always use SubqueryInner if it is a nested subquery...
       clazz = is_nested_subquery?(main_model) ? subquery_class : Magma::SubqueryInner
       clazz.new(
         subquery_model: subquery_model,
@@ -45,7 +45,6 @@ class Magma
         filters: subquery_filters(subquery_args, internal_table_alias, subquery_model),
         subqueries: nested_subqueries,
         condition: verb_applies ? verb.do(:subquery_config).condition : nil,
-        include_constraint: true,
       )
     end
 

--- a/magma/lib/magma/query/predicate/subquery_filter.rb
+++ b/magma/lib/magma/query/predicate/subquery_filter.rb
@@ -3,55 +3,69 @@ require_relative "subquery_base"
 class Magma
   class SubqueryFilter < Magma::SubqueryPredicateBase
     def create_subqueries(query_args)
-      main_model = predicate.model
-      join_table_alias = predicate.alias_name
-      args = query_args
-
-      loop do
-        verb, subquery_model_name_args, subquery_args = predicate.class.match_verbs(args, predicate, true)
-
-        raise Magma::QuestionError, "This does not appear to be a valid subquery filter, #{args}." if subquery_model_name_args.first.is_a?(Array)
-
-        subquery_model_name = subquery_model_name_args.first
-        validate_attribute(main_model, subquery_model_name)
-
-        subquery_model = model(subquery_model_name)
-
-        is_down_graph = going_down_graph?(main_model, subquery_model)
-
-        original_subquery_args = subquery_args.dup
-
-        internal_table_alias = random_alias_name
-        derived_table_alias = random_alias_name
-
-        has_nested_subquery = has_nested_subquery?(original_subquery_args, subquery_model_name)
-
-        @subqueries << subquery_class.new(
-          subquery_model: subquery_model,
-          derived_table_alias: derived_table_alias,
-          main_table_alias: join_table_alias,
-          main_table_join_column_name: is_down_graph ? "id" : parent_column_name(main_model),
-          internal_table_alias: internal_table_alias,
-          subquery_pivot_column_name: is_down_graph ? parent_column_name(subquery_model) : "id",
-          filters: subquery_filters(subquery_args, internal_table_alias, subquery_model),
-          condition: verb.do(:subquery_config).condition,
-          include_constraint: !has_nested_subquery,
-        )
-
-        break unless has_nested_subquery
-
-        main_model = subquery_model
-        join_table_alias = derived_table_alias.dup
-        args = original_subquery_args
-      end
+      @subqueries << create_nested_subquery(query_args, predicate.model, predicate.alias_name)
     end
 
     private
+
+    def create_nested_subquery(args, main_model, join_table_alias)
+      verb, subquery_model_name_args, subquery_args = predicate.class.match_verbs(args, predicate, true)
+
+      raise Magma::QuestionError, "This does not appear to be a valid subquery filter, #{args}." if subquery_model_name_args.first.is_a?(Array)
+
+      subquery_model_name = subquery_model_name_args.first
+      validate_attribute(main_model, subquery_model_name)
+
+      subquery_model = model(subquery_model_name)
+
+      is_down_graph = going_down_graph?(main_model, subquery_model)
+      verb_applies = verb_applies_to_model?(subquery_args)
+
+      original_subquery_args = subquery_args.dup
+
+      internal_table_alias = random_alias_name
+      derived_table_alias = random_alias_name
+
+      nested_subqueries = []
+      has_nested_subquery = has_nested_subquery?(original_subquery_args, subquery_model_name)
+      begin
+        nested_args = original_subquery_args.first.is_a?(Array) ? original_subquery_args.first : original_subquery_args
+        nested_subqueries << create_nested_subquery(nested_args, subquery_model, internal_table_alias)
+      end if has_nested_subquery
+
+      subquery_class.new(
+        subquery_model: subquery_model,
+        derived_table_alias: derived_table_alias,
+        main_table_alias: join_table_alias,
+        main_table_join_column_name: is_down_graph ? "id" : parent_column_name(main_model),
+        internal_table_alias: internal_table_alias,
+        subquery_pivot_column_name: is_down_graph ? parent_column_name(subquery_model) : "id",
+        filters: subquery_filters(subquery_args, internal_table_alias, subquery_model),
+        subqueries: nested_subqueries,
+        condition: verb_applies ? verb.do(:subquery_config).condition : nil,
+        include_constraint: !has_nested_subquery,
+      )
+    end
 
     def going_down_graph?(start_model, end_model)
       # Returns boolean if start_model is parent of end_model, so
       #   the relationship is one-to-many.
       end_model.parent_model_name == start_model.model_name
+    end
+
+    def verb_applies_to_model?(subquery_args)
+      # If subquery_args.first is not an array, and it
+      #   is an actual model name, then the verb
+      #   actually does not apply to the current subquery_model_name.
+      # It most likely applies further down the model predicate chain.
+      return true if subquery_args.first.is_a?(Array)
+
+      begin
+        next_model = model(subquery_args.first)
+        return false
+      rescue NameError
+        return true # Not a real model, probably another predicate
+      end
     end
 
     def validate_attribute(model, attribute_name)
@@ -68,8 +82,9 @@ class Magma
       #
       # as elements get shifted from the Array.
       Magma::SubqueryUtils.is_subquery?(predicate, args) &&
-        !args.first.is_a?(Array) &&
-        args.first != model_name
+        (!args.first.is_a?(Array) ?
+          args.first != model_name :
+          Magma::SubqueryUtils.is_subquery?(predicate, args.first))
     end
 
     def model(name)

--- a/magma/lib/magma/query/predicate/subquery_operator.rb
+++ b/magma/lib/magma/query/predicate/subquery_operator.rb
@@ -15,6 +15,7 @@ class Magma
         internal_table_alias: internal_table_alias,
         subquery_pivot_column_name: parent_column_name(predicate.model),
         filters: subquery_filters(subquery_args, internal_table_alias, predicate.model),
+        subqueries: [],
         condition: condition,
       )
     end

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -116,7 +116,6 @@ class Magma
     private
 
     def to_table(query)
-      binding.pry
       Magma::QueryExecutor.new(query, @options[:timeout], Magma.instance.db).execute
     end
 

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -1,7 +1,7 @@
-require_relative "predicate"
-require_relative "join"
-require_relative "constraint"
-require_relative "query_executor"
+require_relative 'predicate'
+require_relative 'join'
+require_relative 'constraint'
+require_relative 'query_executor'
 
 # A query for a piece of data. Each question is a path through the data
 # hierarchy/schema/graph or whatever you want to call it. The basic idea is
@@ -48,7 +48,6 @@ class Magma
 
   class Question
     attr_reader :user
-
     def initialize(project_name, query_args, options = {})
       @model = Magma.instance.get_model(project_name, query_args.shift)
       @options = options
@@ -57,7 +56,7 @@ class Magma
     end
 
     # allow us to re-use the same question for a different page
-    def set_page(page)
+    def set_page page
       @options[:page] = page
     end
 
@@ -78,7 +77,7 @@ class Magma
     def each_page_answer
       all_bounds.each do |bound|
         query = base_query.select(
-          *(predicate_collect(:select)).uniq
+            *(predicate_collect(:select)).uniq
         )
         query = apply_bounds(query, bound[:lower], bound[:upper])
         table = to_table(query)
@@ -128,7 +127,7 @@ class Magma
       end
 
       query = query.select(
-        *(predicate_collect(:select)).uniq
+          *(predicate_collect(:select)).uniq
       )
 
       query
@@ -136,12 +135,12 @@ class Magma
 
     def order_by_attributes
       @order_by_attributes ||= begin
-          order_columns = []
-          if @options[:order]
-            order_columns << @options[:order]
-          end
-          order_columns << @start_predicate.identity
+        order_columns = []
+        if @options[:order]
+          order_columns << @options[:order]
         end
+        order_columns << @start_predicate.identity
+      end
     end
 
     def order_by_aliases
@@ -156,7 +155,7 @@ class Magma
     # question, but does not select any columns
     def base_query
       query = @model.from(
-        Sequel.as(@model.table_name, @start_predicate.alias_name)
+          Sequel.as(@model.table_name, @start_predicate.alias_name)
       )
 
       query = query.order(*order_by_column_names)
@@ -186,7 +185,7 @@ class Magma
       # values, only for filters on the start_predicate.
 
       query = @model.from(
-        Sequel.as(@model.table_name, @start_predicate.alias_name)
+          Sequel.as(@model.table_name, @start_predicate.alias_name)
       ).order(@start_predicate.identity)
 
       joins = @start_predicate.join.uniq
@@ -206,29 +205,28 @@ class Magma
       end
 
       query.distinct.select(
-        *order_by_column_names.zip(order_by_aliases).map { |c, a| c.as(a) }
+          *order_by_column_names.zip(order_by_aliases).map { |c, a| c.as(a) }
       )
     end
 
     # get page bounds for this question using @options[:page] and @options[:page_size]
     def bounds_query
-      raise QuestionError, "Page size must be greater than 1" unless @options[:page_size] > 1
+      raise QuestionError, 'Page size must be greater than 1' unless @options[:page_size] > 1
       bounds_select_parts = order_by_aliases.dup
       bounds_select_parts << Sequel.function(:row_number)
-        .over(order: order_by_aliases)
-        .as(:row)
+                             .over(order: order_by_aliases)
+                             .as(:row)
 
       count_query.from_self.select(
-        *bounds_select_parts
+          *bounds_select_parts
       ).from_self(alias: :main_query).select(
-      # only the first row from each page
-        *order_by_aliases
-      ).where(
-        Sequel.lit(
-          "? % ? = 1",
-          Sequel[:main_query][:row],
-          @options[:page_size]
-        )
+          # only the first row from each page
+          *order_by_aliases).where(
+          Sequel.lit(
+              '? % ? = 1',
+              Sequel[:main_query][:row],
+              @options[:page_size]
+          )
       )
     end
 
@@ -240,10 +238,11 @@ class Magma
     def all_bounds
       bounds = to_table(bounds_query)
       bounds.map.with_index do |row, index|
-        bound = { :lower => order_by_aliases.map { |c| row[c] }, :upper => nil }
+        bound = {:lower => order_by_aliases.map { |c| row[c] }, :upper => nil}
+
 
         if bounds[index + 1]
-          bound[:upper] = order_by_aliases.map { |c| bounds[index + 1][c] }
+          bound[:upper] = order_by_aliases.map{ |c| bounds[index + 1][c] }
         end
 
         bound
@@ -252,9 +251,9 @@ class Magma
 
     def apply_multi_stage_ordering_bounds(query, upper: nil, lower: nil)
       bounds = upper || lower
-      prev = upper ? Sequel.lit("TRUE") : Sequel.lit("FALSE")
-      start = lower ? Sequel.lit("TRUE") : Sequel.lit("FALSE")
-      operator = upper ? "<" : ">="
+      prev = upper ? Sequel.lit('TRUE') : Sequel.lit('FALSE')
+      start = lower ? Sequel.lit('TRUE') : Sequel.lit('FALSE')
+      operator = upper ? '<' : '>='
 
       # upper (a < 1 & true) | (b < 2 & (a == 1 & true))
       # lower (a >= 1 | false) & (b >= 2 | (a != 1 | false)) & (c >= 5 | (b != 2 | (a != 1 | false)))
@@ -262,22 +261,22 @@ class Magma
         column, value = n
 
         if value.nil? && upper
-          step = Sequel.lit("FALSE")
+          step = Sequel.lit('FALSE')
         elsif value.nil? && lower
-          step = Sequel.lit("TRUE")
+          step = Sequel.lit('TRUE')
         else
           step = Sequel.lit(
-            "? #{operator} ?",
-            column,
-            value
+              "? #{operator} ?",
+              column,
+              value
           )
         end
 
         next_cond = nil
         if upper
-          next_cond = Sequel.lit("(? AND ?)", step, prev)
+          next_cond = Sequel.lit('(? AND ?)', step, prev)
         elsif lower
-          next_cond = Sequel.lit("(? OR ?)", step, prev)
+          next_cond = Sequel.lit('(? OR ?)', step, prev)
         end
 
         if upper
@@ -287,7 +286,7 @@ class Magma
             prev = Sequel.lit("(? = ? AND ?)", column, value, prev)
           end
 
-          Sequel.lit("(? OR ?)", cond, next_cond)
+          Sequel.lit('(? OR ?)', cond, next_cond)
         elsif lower
           if value.nil?
             prev = Sequel.lit("(? IS NOT NULL OR ?)", column, prev)
@@ -295,7 +294,7 @@ class Magma
             prev = Sequel.lit("(? != ? OR ?)", column, value, prev)
           end
 
-          Sequel.lit("(? AND ?)", cond, next_cond)
+          Sequel.lit('(? AND ?)', cond, next_cond)
         end
       end)
     end
@@ -311,7 +310,7 @@ class Magma
     end
 
     def paged_query(query)
-      raise QuestionError, "Page must start at 1" unless @options[:page] > 0
+      raise QuestionError, 'Page must start at 1' unless @options[:page] > 0
       bounds = to_table(page_bounds_query).map do |row|
         order_by_aliases.map { |c| row[c] }
       end
@@ -320,7 +319,7 @@ class Magma
       apply_bounds(query, bounds[0], bounds[1])
     end
 
-    def predicate_collect(type)
+    def predicate_collect type
       predicates.map(&type).inject(&:+) || []
     end
   end

--- a/magma/lib/magma/query/subquery_base.rb
+++ b/magma/lib/magma/query/subquery_base.rb
@@ -23,7 +23,7 @@ class Magma
         Magma::SubqueryConstraint.new(
           filter.flatten.map(&:constraint).inject(&:+),
           subquery_pivot_column_name,
-          derived_table_alias,
+          subquery_column_alias,
           condition
         )
       end

--- a/magma/lib/magma/query/subquery_base.rb
+++ b/magma/lib/magma/query/subquery_base.rb
@@ -1,8 +1,8 @@
 class Magma
   class SubqueryBase
-    attr_reader :subquery_model, :derived_table_alias, :main_table_alias, :main_table_join_column_name, :internal_table_alias, :subquery_pivot_column_name, :condition, :include_constraint, :subqueries
+    attr_reader :subquery_model, :derived_table_alias, :main_table_alias, :main_table_join_column_name, :internal_table_alias, :subquery_pivot_column_name, :condition, :subqueries
 
-    def initialize(subquery_model:, derived_table_alias:, main_table_alias:, main_table_join_column_name:, internal_table_alias:, subquery_pivot_column_name:, filters:, condition:, subqueries:, include_constraint: true)
+    def initialize(subquery_model:, derived_table_alias:, main_table_alias:, main_table_join_column_name:, internal_table_alias:, subquery_pivot_column_name:, filters:, condition:, subqueries:)
       @subquery_model = subquery_model
 
       @derived_table_alias = derived_table_alias.to_sym
@@ -13,7 +13,6 @@ class Magma
 
       @filters = filters
       @subqueries = subqueries
-      @include_constraint = include_constraint
       @condition = condition
 
       @constraints = filter_constraints

--- a/magma/lib/magma/query/subquery_constraint.rb
+++ b/magma/lib/magma/query/subquery_constraint.rb
@@ -1,23 +1,19 @@
 class Magma
   class SubqueryConstraint
-    attr_reader :constraints, :subquery_pivot_column_name, :derived_table_alias, :condition
+    attr_reader :constraints, :subquery_pivot_column_name, :pivot_column_alias, :condition
 
-    def initialize(constraints, subquery_pivot_column_name, derived_table_alias, condition)
+    def initialize(constraints, subquery_pivot_column_name, pivot_column_alias, condition)
       @constraints = constraints
       @subquery_pivot_column_name = subquery_pivot_column_name
-      @derived_table_alias = derived_table_alias
+      @pivot_column_alias = pivot_column_alias
       @condition = condition
-    end
-
-    def constraint_column_alias
-      "#{derived_table_alias}_#{subquery_pivot_column_name}"
     end
 
     def apply(query)
       query = query.select(
         Sequel.as(
           subquery_pivot_column_name,
-          constraint_column_alias
+          pivot_column_alias
         )
       ).group_by(
         subquery_pivot_column_name

--- a/magma/lib/magma/query/subquery_inner.rb
+++ b/magma/lib/magma/query/subquery_inner.rb
@@ -2,16 +2,36 @@ require_relative "subquery_base"
 
 class Magma
   class SubqueryInner < Magma::SubqueryBase
-    def apply(query)
-      # Create a derived table
-      #   as the right-table
-      #   filtered with GROUP BY and HAVING,
-      #   COUNT(*) and SUM(), to ensure that
-      #   the conditions are met.
-      query.inner_join(
-        subquery.as(derived_table_alias),
-        Sequel.&(id_mapping)
-      )
+    def apply(query, parent_query = nil)
+      if parent_query
+        binding.pry
+        # There is a subquery that we have a constraint on,
+        #   so we'll do a full_outer_join and then
+        #   group by / sum to enforce the constraint.
+        query.full_outer_join(
+          subquery.as(derived_table_alias),
+          Sequel.&(id_mapping)
+        ).group_by(
+          parent_query.subquery_column_alias.to_sym
+        ).having(
+          Sequel.lit(
+            "SUM(CASE WHEN #{subquery_column_alias} IS NOT NULL THEN 1 ELSE 0 END) #{parent_query.condition}"
+          )
+        )
+      else
+        # Subquery with no ::every or ::any constraint,
+        #   so we just implement the filter constraint
+        #   and enforce it via an inner_join.
+        # Create a derived table
+        #   as the right-table
+        #   filtered with GROUP BY and HAVING,
+        #   COUNT(*) and SUM(), to ensure that
+        #   the conditions are met.
+        query.inner_join(
+          subquery.as(derived_table_alias),
+          Sequel.&(id_mapping)
+        )
+      end
     end
 
     def constraint

--- a/magma/lib/magma/query/subquery_inner.rb
+++ b/magma/lib/magma/query/subquery_inner.rb
@@ -4,7 +4,6 @@ class Magma
   class SubqueryInner < Magma::SubqueryBase
     def apply(query, parent_query = nil)
       if parent_query
-        binding.pry
         # There is a subquery that we have a constraint on,
         #   so we'll do a full_outer_join and then
         #   group by / sum to enforce the constraint.

--- a/magma/lib/magma/query/subquery_outer.rb
+++ b/magma/lib/magma/query/subquery_outer.rb
@@ -21,7 +21,7 @@ class Magma
       Magma::Constraint.new(derived_table_alias,
                             {
         subquery_table_column => subquery_table_column,
-      }) if include_constraint
+      })
     end
   end
 end

--- a/magma/lib/magma/query/subquery_outer.rb
+++ b/magma/lib/magma/query/subquery_outer.rb
@@ -2,7 +2,7 @@ require_relative "subquery_base"
 
 class Magma
   class SubqueryOuter < Magma::SubqueryBase
-    def apply(query)
+    def apply(query, parent_query = nil)
       # Create a derived table
       #   as the right-table
       #   filtered with GROUP BY and HAVING,

--- a/magma/spec/fixtures/labors_model_attributes.yml
+++ b/magma/spec/fixtures/labors_model_attributes.yml
@@ -121,3 +121,13 @@ victim:
     restricted: true
   restricted:
     type: boolean
+  wound:
+    type: table
+wound:
+  victim:
+    type: parent
+    column_name: victim_id
+  location:
+    type: string
+  severity:
+    type: integer

--- a/magma/spec/fixtures/labors_model_attributes.yml
+++ b/magma/spec/fixtures/labors_model_attributes.yml
@@ -123,6 +123,8 @@ victim:
     type: boolean
   wound:
     type: table
+  weapon:
+    type: string
 wound:
   victim:
     type: parent

--- a/magma/spec/labors/migrations/22_add_wounds.rb
+++ b/magma/spec/labors/migrations/22_add_wounds.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table(Sequel[:labors][:wounds]) do
+      primary_key :id
+      DateTime :created_at
+      DateTime :updated_at
+      foreign_key :victim_id, Sequel[:labors][:victims]
+      index :victim_id
+      String :location
+      Integer :severity
+    end
+  end
+end

--- a/magma/spec/labors/migrations/23_add_victim_weapon.rb
+++ b/magma/spec/labors/migrations/23_add_victim_weapon.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(Sequel[:labors][:victims]) do
+      add_column :weapon, String
+    end
+  end
+end

--- a/magma/spec/magma_project_spec.rb
+++ b/magma/spec/magma_project_spec.rb
@@ -138,7 +138,7 @@ describe Magma::Project do
     let(:model) { project.models[:monster] }
 
     it 'returns ordered models for labors project' do
-      expect(project.ordered_models(model)).to match_array([Labors::Victim, Labors::Aspect])
+      expect(project.ordered_models(model)).to match_array([Labors::Victim, Labors::Aspect, Labors::Wound])
     end
   end
 end

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -285,6 +285,10 @@ FactoryBot.define do
     to_create(&:save)
     sequence(:name) { |n| "characteristic#{n}" }
   end
+
+  factory :wound, class: Labors::Wound do
+    to_create(&:save)
+  end
 end
 
 def fixture(name)

--- a/timur/lib/client/jsx/components/query/query_any_every_selector_list.tsx
+++ b/timur/lib/client/jsx/components/query/query_any_every_selector_list.tsx
@@ -1,0 +1,56 @@
+import React, {useContext, useState, useCallback} from 'react';
+
+import AntSwitch from './ant_switch';
+import {QueryContext} from '../../contexts/query/query_context';
+import {QueryFilter} from '../../contexts/query/query_types';
+import {useEffect} from 'react';
+
+const QueryAnyEverySelectorList = ({
+  filter,
+  index
+}: {
+  filter: QueryFilter;
+  index: number;
+}) => {
+  const [anyMap, setAnyMap] = useState({} as {[key: string]: boolean});
+  const {state, patchRecordFilter} = useContext(QueryContext);
+
+  const handlePatchFilter = useCallback(
+    (modelName: string) => {
+      let copy = {
+        ...filter,
+        anyMap: {
+          ...filter.anyMap,
+          [modelName]: !filter.anyMap[modelName]
+        }
+      };
+      patchRecordFilter(index, copy);
+    },
+    [patchRecordFilter, index, filter]
+  );
+
+  useEffect(() => {
+    setAnyMap(filter.anyMap);
+  }, [filter.anyMap]);
+
+  if (!state.rootModel) return null;
+
+  return (
+    <React.Fragment>
+      {Object.entries(anyMap || {}).map(([modelName, value], index: number) => {
+        return (
+          <AntSwitch
+            key={index}
+            checked={value}
+            onChange={() => handlePatchFilter(modelName)}
+            name={`any-every-filter-toggle-${index}`}
+            leftOption={`Every ${modelName}`}
+            rightOption={`Any ${modelName}`}
+          />
+        );
+      })}
+    </React.Fragment>
+  );
+};
+
+export default QueryAnyEverySelectorList;

--- a/timur/lib/client/jsx/components/query/query_any_every_selector_list.tsx
+++ b/timur/lib/client/jsx/components/query/query_any_every_selector_list.tsx
@@ -1,6 +1,8 @@
 import React, {useContext, useState, useCallback} from 'react';
 
-import AntSwitch from './ant_switch';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+
 import {QueryContext} from '../../contexts/query/query_context';
 import {QueryFilter} from '../../contexts/query/query_types';
 import {useEffect} from 'react';
@@ -39,14 +41,16 @@ const QueryAnyEverySelectorList = ({
     <React.Fragment>
       {Object.entries(anyMap || {}).map(([modelName, value], index: number) => {
         return (
-          <AntSwitch
+          <Select
             key={index}
-            checked={value}
+            fullWidth={true}
+            value={value.toString()}
             onChange={() => handlePatchFilter(modelName)}
             name={`any-every-filter-toggle-${index}`}
-            leftOption={`Every ${modelName}`}
-            rightOption={`Any ${modelName}`}
-          />
+          >
+            <MenuItem value={'true'}>Any {modelName}</MenuItem>
+            <MenuItem value={'false'}>Every {modelName}</MenuItem>
+          </Select>
         );
       })}
     </React.Fragment>

--- a/timur/lib/client/jsx/components/query/query_clause.tsx
+++ b/timur/lib/client/jsx/components/query/query_clause.tsx
@@ -1,12 +1,6 @@
-import React, { PropsWithChildren, useCallback, useContext} from 'react';
+import React, { PropsWithChildren } from 'react';
 import Grid from '@material-ui/core/Grid';
 import {makeStyles} from '@material-ui/core/styles';
-
-import {useReduxState} from 'etna-js/hooks/useReduxState';
-import {selectTemplate} from 'etna-js/selectors/magma';
-
-import {QueryContext} from '../../contexts/query/query_context';
-import QueryModelSelector from './query_model_selector';
 
 const useStyles = makeStyles((theme) => ({
   clauseTitle: {

--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -24,7 +24,7 @@ import {useReduxState} from 'etna-js/hooks/useReduxState';
 import {selectTemplate} from 'etna-js/selectors/magma';
 
 import {QueryContext} from '../../contexts/query/query_context';
-import {QueryFilter} from '../../contexts/query/query_types';
+import {QueryFilter, QuerySlice} from '../../contexts/query/query_types';
 import {
   selectAllowedModelAttributes,
   selectMatrixAttributes
@@ -74,11 +74,11 @@ const QueryFilterControl = ({
   patchFilter,
   removeFilter
 }: {
-  filter: QueryFilter;
+  filter: QueryFilter | QuerySlice;
   modelNames: string[];
   matrixAttributesOnly?: boolean;
   hideModel?: boolean;
-  patchFilter: (filter: QueryFilter) => void;
+  patchFilter: (filter: QueryFilter | QuerySlice) => void;
   removeFilter: () => void;
 }) => {
   const classes = useStyles();

--- a/timur/lib/client/jsx/components/query/query_filter_operator.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_operator.tsx
@@ -1,0 +1,81 @@
+import * as _ from 'lodash';
+
+export default class FilterOperator {
+  attributeType: string;
+  operator: string;
+
+  static allOptions: {[key: string]: string} = {
+    Slice: '::slice',
+    Equals: '::equals',
+    Contains: '::matches',
+    In: '::in',
+    'Less than': '::<',
+    'Greater than': '::>',
+    'Is present': '::has',
+    'Is missing': '::lacks',
+    'Is true': '::true',
+    'Is false': '::false',
+    'Is untrue': '::untrue'
+  };
+
+  constructor(attributeType: string, operator: string) {
+    this.attributeType = attributeType;
+    this.operator = operator;
+  }
+
+  hasOperand(): boolean {
+    const noOperandOperators = [
+      '::has',
+      '::lacks',
+      '::true',
+      '::false',
+      '::untrue'
+    ];
+
+    return !noOperandOperators.includes(this.operator);
+  }
+
+  prettify(): string {
+    if (this.attributeType === 'number' && this.operator === '::=') {
+      return 'Equals';
+    }
+    return _.invert(FilterOperator.allOptions)[this.operator];
+  }
+
+  magmify(newOperator: string): string {
+    if (this.attributeType === 'number' && newOperator === 'Equals') {
+      return '::=';
+    }
+
+    return FilterOperator.allOptions[newOperator];
+  }
+
+  options(): {[key: string]: string} {
+    if ('matrix' === this.attributeType) {
+      return Object.keys(FilterOperator.allOptions).reduce(
+        (acc: {[key: string]: string}, key: string) => {
+          if ('Slice' === key) {
+            acc[key] = FilterOperator.allOptions[key];
+          }
+          return acc;
+        },
+        {}
+      );
+    } else {
+      return Object.keys(FilterOperator.allOptions).reduce(
+        (acc: {[key: string]: string}, key: string) => {
+          if ('Slice' !== key) {
+            acc[key] = FilterOperator.allOptions[key];
+          }
+          return acc;
+        },
+        {}
+      );
+    }
+  }
+
+  formatOperand(operand: string): number | string {
+    if (this.attributeType === 'number') return parseFloat(operand);
+    else return operand;
+  }
+}

--- a/timur/lib/client/jsx/components/query/query_filter_operator.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_operator.tsx
@@ -18,21 +18,22 @@ export default class FilterOperator {
     'Is untrue': '::untrue'
   };
 
+  static terminalOperators: string[] = ['::true', '::false', '::untrue'];
+
+  static terminalInvertOperators: string[] = ['::has', '::lacks'];
+
+  static commaSeparatedOperators: string[] = ['::in', '::slice'];
+
   constructor(attributeType: string, operator: string) {
     this.attributeType = attributeType;
     this.operator = operator;
   }
 
   hasOperand(): boolean {
-    const noOperandOperators = [
-      '::has',
-      '::lacks',
-      '::true',
-      '::false',
-      '::untrue'
-    ];
-
-    return !noOperandOperators.includes(this.operator);
+    return !(
+      FilterOperator.terminalOperators.includes(this.operator) ||
+      FilterOperator.terminalInvertOperators.includes(this.operator)
+    );
   }
 
   prettify(): string {

--- a/timur/lib/client/jsx/components/query/query_from_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_from_pane.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useContext} from 'react';
-import Grid from '@material-ui/core/Grid';
 import {makeStyles} from '@material-ui/core/styles';
 
 import {useReduxState} from 'etna-js/hooks/useReduxState';
@@ -11,11 +10,11 @@ import QueryClause from './query_clause';
 
 const useStyles = makeStyles((theme) => ({
   clauseTitle: {
-    fontSize: "1.2rem",
-    minWidth: "120px"
+    fontSize: '1.2rem',
+    minWidth: '120px'
   },
   queryClause: {
-    padding: "5px"
+    padding: '5px'
   }
 }));
 

--- a/timur/lib/client/jsx/components/query/query_slice_model_attribute_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_model_attribute_pane.tsx
@@ -7,7 +7,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 import {QueryContext} from '../../contexts/query/query_context';
 import QueryFilterControl from './query_filter_control';
-import {QueryFilter} from '../../contexts/query/query_types';
+import {QuerySlice} from '../../contexts/query/query_types';
 import useSliceMethods from './query_use_slice_methods';
 
 const QuerySliceModelAttributePane = ({
@@ -17,7 +17,7 @@ const QuerySliceModelAttributePane = ({
   removeSlice
 }: {
   modelName: string;
-  slices: QueryFilter[];
+  slices: QuerySlice[];
   isMatrix: boolean;
   removeSlice: (modelName: string, index: number) => void;
 }) => {
@@ -56,14 +56,14 @@ const QuerySliceModelAttributePane = ({
       </Grid>
       <Grid item xs={10}>
         {slices
-          ? slices.map((filter: QueryFilter, index: number) => (
+          ? slices.map((filter: QuerySlice, index: number) => (
               <QueryFilterControl
                 key={`model-${modelName}-${index}-${updateCounter}`}
                 filter={filter}
                 modelNames={[modelName]}
                 hideModel={true}
                 matrixAttributesOnly={isMatrix}
-                patchFilter={(updatedFilter: QueryFilter) =>
+                patchFilter={(updatedFilter: QuerySlice) =>
                   handlePatchSlice(index, updatedFilter)
                 }
                 removeFilter={() => handleRemoveSlice(index)}

--- a/timur/lib/client/jsx/components/query/query_slice_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_pane.tsx
@@ -2,7 +2,7 @@ import React, {useContext} from 'react';
 
 import {QueryContext} from '../../contexts/query/query_context';
 import QuerySliceModelAttributePane from './query_slice_model_attribute_pane';
-import {QueryFilter} from '../../contexts/query/query_types';
+import {QuerySlice} from '../../contexts/query/query_types';
 
 const QuerySlicePane = ({
   modelName,
@@ -11,7 +11,7 @@ const QuerySlicePane = ({
   handleRemoveSlice
 }: {
   modelName: string;
-  slices: QueryFilter[];
+  slices: QuerySlice[];
   isMatrix: boolean;
   handleRemoveSlice: (modelName: string, index: number) => void;
 }) => {

--- a/timur/lib/client/jsx/components/query/query_use_slice_methods.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_slice_methods.tsx
@@ -3,7 +3,7 @@ import React, {useMemo, useCallback, useContext} from 'react';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 import {selectModels} from 'etna-js/selectors/magma';
 import {QueryContext} from '../../contexts/query/query_context';
-import {QueryFilter} from '../../contexts/query/query_types';
+import {QuerySlice} from '../../contexts/query/query_types';
 import {
   selectMatrixModelNames,
   selectCollectionModelNames,
@@ -32,7 +32,7 @@ const useSliceMethods = (
   );
 
   const handlePatchSlice = useCallback(
-    (index: number, filter: QueryFilter) => {
+    (index: number, filter: QuerySlice) => {
       patchSlice(index, filter);
     },
     [patchSlice]

--- a/timur/lib/client/jsx/components/query/query_where_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_where_pane.tsx
@@ -110,10 +110,10 @@ const QueryWherePane = () => {
               inputProps={{'aria-label': 'secondary checkbox'}}
             />
           </Grid>
-          <Grid item xs={3}>
+          <Grid item xs={2}>
             <QueryAnyEverySelectorList filter={filter} index={index} />
           </Grid>
-          <Grid item container xs={8}>
+          <Grid item container xs={9}>
             <QueryFilterControl
               key={`${index}-${updateCounter}`}
               filter={filter}

--- a/timur/lib/client/jsx/contexts/query/query_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_context.tsx
@@ -1,6 +1,6 @@
 import React, {useState, createContext, useCallback} from 'react';
 
-import {QueryFilter, QueryColumn} from './query_types';
+import {QueryFilter, QueryColumn, QuerySlice} from './query_types';
 
 import {QueryGraph} from '../../utils/query_graph';
 
@@ -12,7 +12,7 @@ const defaultState = {
   rootIdentifier: {} as QueryColumn | null,
   recordFilters: [] as QueryFilter[],
   orRecordFilterIndices: [] as number[],
-  slices: {} as {[key: string]: QueryFilter[]},
+  slices: {} as {[key: string]: QuerySlice[]},
   graph: {} as QueryGraph
 };
 
@@ -23,9 +23,9 @@ export const defaultContext = {
   removeRecordFilter: (index: number) => {},
   patchRecordFilter: (index: number, recordFilter: QueryFilter) => {},
   setOrRecordFilterIndices: (indices: number[]) => {},
-  addSlice: (slice: QueryFilter) => {},
+  addSlice: (slice: QuerySlice) => {},
   removeSlice: (modelName: string, index: number) => {},
-  patchSlice: (index: number, slice: QueryFilter) => {},
+  patchSlice: (index: number, slice: QuerySlice) => {},
   setRootModel: (
     model_name: string | null,
     model_identifier: QueryColumn | null
@@ -108,7 +108,7 @@ export const QueryProvider = (
   );
 
   const addSlice = useCallback(
-    (slice: QueryFilter) => {
+    (slice: QuerySlice) => {
       setState({
         ...state,
         slices: {
@@ -138,7 +138,7 @@ export const QueryProvider = (
   );
 
   const patchSlice = useCallback(
-    (index: number, slice: QueryFilter) => {
+    (index: number, slice: QuerySlice) => {
       let updatedSlices = [...state.slices[slice.modelName]];
       updatedSlices[index] = slice;
       setState({

--- a/timur/lib/client/jsx/contexts/query/query_types.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_types.tsx
@@ -7,8 +7,12 @@ export interface QueryBase {
 
 export interface QuerySlice extends QueryBase {}
 
+export interface QueryFilterAnyMap {
+  [modelName: string]: boolean;
+}
+
 export interface QueryFilter extends QueryBase {
-  anyMap: {[key: string]: boolean};
+  anyMap: QueryFilterAnyMap;
 }
 
 export interface QueryColumn {

--- a/timur/lib/client/jsx/contexts/query/query_types.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_types.tsx
@@ -1,8 +1,14 @@
-export interface QueryFilter {
+export interface QueryBase {
   modelName: string;
   attributeName: string;
   operator: string;
   operand: string | number;
+}
+
+export interface QuerySlice extends QueryBase {}
+
+export interface QueryFilter extends QueryBase {
+  anyMap: {[key: string]: boolean};
 }
 
 export interface QueryColumn {

--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -1,7 +1,11 @@
 import * as _ from 'lodash';
 
 import {Attribute, Model} from '../models/model_types';
-import {QueryColumn, QueryFilter} from '../contexts/query/query_types';
+import {
+  QueryColumn,
+  QueryFilter,
+  QuerySlice
+} from '../contexts/query/query_types';
 import {QueryGraph} from '../utils/query_graph';
 
 export const modelHasAttribute = (
@@ -196,11 +200,11 @@ export const attributeIsFile = (
   ]);
 };
 
-export const isMatrixSlice = (slice: QueryFilter) =>
+export const isMatrixSlice = (slice: QuerySlice) =>
   '::slice' === slice.operator;
 
 export const isMatchingMatrixSlice = (
-  slice: QueryFilter,
+  slice: QuerySlice,
   attribute: QueryColumn
 ) => {
   return (
@@ -211,7 +215,7 @@ export const isMatchingMatrixSlice = (
 };
 
 export const hasMatrixSlice = (
-  slices: QueryFilter[],
+  slices: QuerySlice[],
   attribute: QueryColumn
 ) => {
   return slices.some((slice) => isMatchingMatrixSlice(slice, attribute));

--- a/timur/lib/client/jsx/utils/query_any_every_helpers.ts
+++ b/timur/lib/client/jsx/utils/query_any_every_helpers.ts
@@ -1,7 +1,6 @@
 import * as _ from 'lodash';
 
-import {QueryBase} from '../contexts/query/query_types';
-import {getPath} from '../selectors/query_selector';
+const anyOrEvery = ['::any', '::every'];
 
 export const nextInjectionPathItem = (injectionPath: number[]) => {
   let nextItemPath = [...injectionPath];
@@ -17,14 +16,14 @@ export const injectValueAtPath = (
   value: any
 ) => {
   let currentValue = _.get(array, valueInjectionPath);
-  if ('::any' === currentValue) {
+  if (anyOrEvery.includes(currentValue)) {
     _.set(array, valueInjectionPath, value);
 
-    // We create a new injection path to inject a final "::any"
+    // We create a new injection path to inject a final "::any" or "::every"
     //   after the value.
     let anyInjectionPath = nextInjectionPathItem(valueInjectionPath);
 
-    _.set(array, anyInjectionPath, '::any');
+    _.set(array, anyInjectionPath, currentValue);
 
     return true;
   } else {
@@ -41,27 +40,4 @@ export const injectValueAtPath = (
 
     return false;
   }
-};
-
-const isModelWithAny = (
-  path: any[],
-  injectionPath: number[],
-  filter: QueryBase
-) => {
-  let nextItemPath = nextInjectionPathItem(injectionPath);
-
-  return (
-    _.get(path, injectionPath.join('.')) === filter.modelName &&
-    _.get(path, nextItemPath.join('.')) === '::any'
-  );
-};
-
-export const shouldInjectFilter = (filter: QueryBase, path: any[]) => {
-  // Should only inject data if the final array
-  //   for the filter.modelName is an array with [modelName, '::any']
-  // Otherwise no injection.
-  let injectionPath = getPath(path, filter.modelName, []);
-  if (isModelWithAny(path, injectionPath, filter)) return true;
-
-  return false;
 };

--- a/timur/lib/client/jsx/utils/query_any_every_helpers.ts
+++ b/timur/lib/client/jsx/utils/query_any_every_helpers.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import {QueryFilter} from '../contexts/query/query_types';
+import {QueryBase} from '../contexts/query/query_types';
 import {getPath} from '../selectors/query_selector';
 
 export const nextInjectionPathItem = (injectionPath: number[]) => {
@@ -46,7 +46,7 @@ export const injectValueAtPath = (
 const isModelWithAny = (
   path: any[],
   injectionPath: number[],
-  filter: QueryFilter
+  filter: QueryBase
 ) => {
   let nextItemPath = nextInjectionPathItem(injectionPath);
 
@@ -56,7 +56,7 @@ const isModelWithAny = (
   );
 };
 
-export const shouldInjectFilter = (filter: QueryFilter, path: any[]) => {
+export const shouldInjectFilter = (filter: QueryBase, path: any[]) => {
   // Should only inject data if the final array
   //   for the filter.modelName is an array with [modelName, '::any']
   // Otherwise no injection.

--- a/timur/lib/client/jsx/utils/query_builder.ts
+++ b/timur/lib/client/jsx/utils/query_builder.ts
@@ -19,6 +19,7 @@ import {
   injectValueAtPath,
   nextInjectionPathItem
 } from './query_any_every_helpers';
+import FilterOperator from '../components/query/query_filter_operator';
 
 export class QueryBuilder {
   graph: QueryGraph;
@@ -50,8 +51,9 @@ export class QueryBuilder {
         if (!this.attributes.hasOwnProperty(modelName))
           this.attributes[modelName] = [];
 
-        this.attributes[modelName] =
-          this.attributes[modelName].concat(selectedAttributes);
+        this.attributes[modelName] = this.attributes[modelName].concat(
+          selectedAttributes
+        );
       }
     );
   }
@@ -91,15 +93,17 @@ export class QueryBuilder {
     result.push(queryBase.attributeName);
     result.push(queryBase.operator);
 
-    if (['::in', '::slice'].includes(queryBase.operator)) {
+    if (FilterOperator.commaSeparatedOperators.includes(queryBase.operator)) {
       result.push((queryBase.operand as string).split(','));
-    } else if (['::has', '::lacks'].includes(queryBase.operator)) {
+    } else if (
+      FilterOperator.terminalInvertOperators.includes(queryBase.operator)
+    ) {
       // invert the model and attribute names, ignore operand
       let length = result.length;
       let tmpOperator = result[length - 1];
       result[length - 1] = result[length - 2];
       result[length - 2] = tmpOperator;
-    } else if (['::true', '::false', '::untrue'].includes(queryBase.operator)) {
+    } else if (FilterOperator.terminalOperators.includes(queryBase.operator)) {
       // ignore operand
     } else {
       result.push(queryBase.operand);

--- a/timur/lib/client/jsx/utils/query_filter_path_builder.ts
+++ b/timur/lib/client/jsx/utils/query_filter_path_builder.ts
@@ -2,20 +2,24 @@ import * as _ from 'lodash';
 import {Model} from '../models/model_types';
 import {stepIsOneToMany} from '../selectors/query_selector';
 import {injectValueAtPath} from './query_any_every_helpers';
+import {QueryFilterAnyMap} from '../contexts/query/query_types';
 
 export default class QueryFilterPathBuilder {
   path: string[];
   models: {[key: string]: Model};
   rootModelName: string;
+  anyMap: QueryFilterAnyMap;
 
   constructor(
     path: string[],
     rootModelName: string,
-    models: {[key: string]: Model}
+    models: {[key: string]: Model},
+    anyMap: QueryFilterAnyMap
   ) {
     this.path = path;
     this.models = models;
     this.rootModelName = rootModelName;
+    this.anyMap = anyMap;
   }
 
   build(): any[] {
@@ -26,7 +30,10 @@ export default class QueryFilterPathBuilder {
 
     this.path.forEach((modelName: string) => {
       if (stepIsOneToMany(this.models, previousModelName, modelName)) {
-        let newValue = [modelName, '::any'];
+        let newValue = [
+          modelName,
+          this.anyMap[modelName] ? '::any' : '::every'
+        ];
         if (updatedPath.length === 0) {
           updatedPath.push(...newValue);
         } else {

--- a/timur/lib/client/jsx/utils/query_graph.ts
+++ b/timur/lib/client/jsx/utils/query_graph.ts
@@ -119,4 +119,21 @@ export class QueryGraph {
       this.models[modelName].template.attributes[attributeName].attribute_type
     );
   }
+
+  shortestPath(rootModel: string, targetModel: string): string[] | undefined {
+    let path = this.allPaths(rootModel).find((potentialPath: string[]) =>
+      potentialPath.includes(targetModel)
+    );
+
+    if (!path) return;
+
+    // Direct children paths include the root, and
+    //   we'll filter it out so all paths do not
+    //   include the root model (eliminate redundancy).
+    const pathWithoutRoot = path
+      ?.slice(0, path.indexOf(targetModel) + 1)
+      .filter((m) => m !== rootModel);
+
+    return pathWithoutRoot;
+  }
 }

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -120,7 +120,10 @@ exports[`QueryBuilder renders 1`] = `
               </span>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-11"
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-3"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8"
             >
               <div
                 class="MuiGrid-root MuiGrid-container"

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -120,10 +120,10 @@ exports[`QueryBuilder renders 1`] = `
               </span>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-3"
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2"
             />
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-9"
             >
               <div
                 class="MuiGrid-root MuiGrid-container"

--- a/timur/test/javascript/utils/query_any_every_helpers.spec.ts
+++ b/timur/test/javascript/utils/query_any_every_helpers.spec.ts
@@ -1,7 +1,4 @@
-import {
-  injectValueAtPath,
-  shouldInjectFilter
-} from '../../../lib/client/jsx/utils/query_any_every_helpers';
+import {injectValueAtPath} from '../../../lib/client/jsx/utils/query_any_every_helpers';
 
 describe('injectValueAtPath', () => {
   it('correctly injects and appends ::any', () => {
@@ -17,6 +14,24 @@ describe('injectValueAtPath', () => {
     expect(injected).toEqual(true);
   });
 
+  it('correctly injects and appends ::every', () => {
+    let array = [
+      'modelName',
+      'secondModel',
+      ['thirdModel', '::every'],
+      '::every'
+    ];
+    let injected = injectValueAtPath(array, [2, 1], ['new', 'tuple']);
+
+    expect(array).toEqual([
+      'modelName',
+      'secondModel',
+      ['thirdModel', ['new', 'tuple'], '::every'],
+      '::every'
+    ]);
+    expect(injected).toEqual(true);
+  });
+
   it('unpacks the new value (instead of injecting) if no ::any being replaced', () => {
     let array = ['modelName', ['something', ['nested']]];
     let injected = injectValueAtPath(array, [1, 1, 1], ['new', 'tuple']);
@@ -26,77 +41,5 @@ describe('injectValueAtPath', () => {
       ['something', ['nested', 'new', 'tuple']]
     ]);
     expect(injected).toEqual(false);
-  });
-});
-
-describe('shouldInjectFilter', () => {
-  it('returns true for tuples at the root level', () => {
-    expect(
-      shouldInjectFilter(
-        {
-          modelName: 'test',
-          attributeName: 'foo',
-          operator: '::equals',
-          operand: 'bar'
-        },
-        ['test', '::any']
-      )
-    ).toEqual(true);
-  });
-
-  it('returns true for flat ::anys at root level', () => {
-    expect(
-      shouldInjectFilter(
-        {
-          modelName: 'singleton',
-          attributeName: 'foo',
-          operator: '::equals',
-          operand: 'bar'
-        },
-        ['test', 'singleton', '::any']
-      )
-    ).toEqual(true);
-  });
-
-  it('returns true for nested paths', () => {
-    expect(
-      shouldInjectFilter(
-        {
-          modelName: 'test',
-          attributeName: 'foo',
-          operator: '::equals',
-          operand: 'bar'
-        },
-        ['something', ['where', ['I', ['test', '::any']]]]
-      )
-    ).toEqual(true);
-  });
-
-  it('returns false for paths without ::any', () => {
-    expect(
-      shouldInjectFilter(
-        {
-          modelName: 'test',
-          attributeName: 'foo',
-          operator: '::equals',
-          operand: 'bar'
-        },
-        ['something']
-      )
-    ).toEqual(false);
-  });
-
-  it('returns false for filters without matching models', () => {
-    expect(
-      shouldInjectFilter(
-        {
-          modelName: 'test',
-          attributeName: 'foo',
-          operator: '::equals',
-          operand: 'bar'
-        },
-        ['anotherModel', '::any']
-      )
-    ).toEqual(false);
   });
 });

--- a/timur/test/javascript/utils/query_builder.spec.ts
+++ b/timur/test/javascript/utils/query_builder.spec.ts
@@ -74,25 +74,31 @@ describe('QueryBuilder', () => {
         modelName: 'labor',
         attributeName: 'name',
         operator: '::in',
-        operand: 'lion,hydra,apples'
+        operand: 'lion,hydra,apples',
+        anyMap: {}
       },
       {
         modelName: 'monster',
         attributeName: 'name',
         operator: '::equals',
-        operand: 'Nemean Lion'
+        operand: 'Nemean Lion',
+        anyMap: {}
       },
       {
         modelName: 'labor',
         attributeName: 'number',
         operator: '::equals',
-        operand: 2
+        operand: 2,
+        anyMap: {}
       },
       {
         modelName: 'prize',
         attributeName: 'name',
         operator: '::equals',
-        operand: 'Apples'
+        operand: 'Apples',
+        anyMap: {
+          prize: true
+        }
       }
     ]);
     builder.addSlices({
@@ -145,7 +151,7 @@ describe('QueryBuilder', () => {
         ['labor', 'name', '::in', ['lion', 'hydra', 'apples']],
         ['name', '::equals', 'Nemean Lion'],
         ['labor', 'number', '::equals', 2],
-        ['labor', 'prize', '::all', 'name', '::equals', 'Apples']
+        ['labor', 'prize', ['name', '::equals', 'Apples'], '::any']
       ],
       '::all',
       [
@@ -167,7 +173,7 @@ describe('QueryBuilder', () => {
       [
         '::and',
         ['name', '::equals', 'Nemean Lion'],
-        ['labor', 'prize', '::all', 'name', '::equals', 'Apples'],
+        ['labor', 'prize', ['name', '::equals', 'Apples'], '::any'],
         [
           '::or',
           ['labor', 'name', '::in', ['lion', 'hydra', 'apples']],
@@ -223,13 +229,15 @@ describe('QueryBuilder', () => {
         modelName: 'labor',
         attributeName: 'name',
         operator: '::in',
-        operand: 'lion,hydra,apples'
+        operand: 'lion,hydra,apples',
+        any: true
       },
       {
         modelName: 'monster',
         attributeName: 'name',
         operator: '::equals',
-        operand: 'Nemean Lion'
+        operand: 'Nemean Lion',
+        any: true
       }
     ]);
     builder.addSlices({
@@ -254,7 +262,7 @@ describe('QueryBuilder', () => {
     ]);
   });
 
-  describe('handles any / all for', () => {
+  describe('handles any for', () => {
     it('deep paths in filters with some non-branching models', () => {
       builder.addRootIdentifier(stamp('labor', 'name'));
       builder.addRecordFilters([
@@ -262,7 +270,11 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           attributeName: 'location',
           operator: '::equals',
-          operand: 'arm'
+          operand: 'arm',
+          anyMap: {
+            victim: true,
+            wound: true
+          }
         }
       ]);
 
@@ -273,24 +285,6 @@ describe('QueryBuilder', () => {
           'victim',
           ['wound', ['location', '::equals', 'arm'], '::any'],
           '::any'
-        ],
-        '::all',
-        [['name']]
-      ]);
-
-      builder.setFlatten(false);
-
-      expect(builder.query()).toEqual([
-        'labor',
-        [
-          'monster',
-          'victim',
-          '::all',
-          'wound',
-          '::all',
-          'location',
-          '::equals',
-          'arm'
         ],
         '::all',
         [['name']]
@@ -304,7 +298,11 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           attributeName: 'location',
           operator: '::equals',
-          operand: 'arm'
+          operand: 'arm',
+          anyMap: {
+            victim: true,
+            wound: true
+          }
         }
       ]);
 
@@ -315,15 +313,6 @@ describe('QueryBuilder', () => {
           ['wound', ['location', '::equals', 'arm'], '::any'],
           '::any'
         ],
-        '::all',
-        [['name']]
-      ]);
-
-      builder.setFlatten(false);
-
-      expect(builder.query()).toEqual([
-        'monster',
-        ['victim', '::all', 'wound', '::all', 'location', '::equals', 'arm'],
         '::all',
         [['name']]
       ]);
@@ -336,22 +325,16 @@ describe('QueryBuilder', () => {
           modelName: 'victim',
           attributeName: 'name',
           operator: '::equals',
-          operand: 'Hercules'
+          operand: 'Hercules',
+          anyMap: {
+            victim: true
+          }
         }
       ]);
 
       expect(builder.query()).toEqual([
         'monster',
         ['victim', ['name', '::equals', 'Hercules'], '::any'],
-        '::all',
-        [['name']]
-      ]);
-
-      builder.setFlatten(false);
-
-      expect(builder.query()).toEqual([
-        'monster',
-        ['victim', '::all', 'name', '::equals', 'Hercules'],
         '::all',
         [['name']]
       ]);
@@ -364,7 +347,11 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           attributeName: 'location',
           operator: '::equals',
-          operand: 'arm'
+          operand: 'arm',
+          anyMap: {
+            victim: true,
+            wound: true
+          }
         }
       ]);
 
@@ -376,25 +363,6 @@ describe('QueryBuilder', () => {
           'victim',
           ['wound', ['location', '::equals', 'arm'], '::any'],
           '::any'
-        ],
-        '::all',
-        [['name']]
-      ]);
-
-      builder.setFlatten(false);
-
-      expect(builder.query()).toEqual([
-        'prize',
-        [
-          'labor',
-          'monster',
-          'victim',
-          '::all',
-          'wound',
-          '::all',
-          'location',
-          '::equals',
-          'arm'
         ],
         '::all',
         [['name']]
@@ -408,22 +376,16 @@ describe('QueryBuilder', () => {
           modelName: 'prize',
           attributeName: 'name',
           operator: '::equals',
-          operand: 'Apples'
+          operand: 'Apples',
+          anyMap: {
+            prize: true
+          }
         }
       ]);
 
       expect(builder.query()).toEqual([
         'monster',
         ['labor', 'prize', ['name', '::equals', 'Apples'], '::any'],
-        '::all',
-        [['name']]
-      ]);
-
-      builder.setFlatten(false);
-
-      expect(builder.query()).toEqual([
-        'monster',
-        ['labor', 'prize', '::all', 'name', '::equals', 'Apples'],
         '::all',
         [['name']]
       ]);
@@ -436,7 +398,8 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           attributeName: 'name',
           operator: '::in',
-          operand: 'Lion,Hydra'
+          operand: 'Lion,Hydra',
+          anyMap: {}
         }
       ]);
 
@@ -446,8 +409,149 @@ describe('QueryBuilder', () => {
         '::all',
         [['name']]
       ]);
+    });
+  });
 
-      builder.setFlatten(false);
+  describe('handles every for', () => {
+    it('deep paths in filters with some non-branching models', () => {
+      builder.addRootIdentifier(stamp('labor', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'wound',
+          attributeName: 'location',
+          operator: '::equals',
+          operand: 'arm',
+          anyMap: {
+            victim: false,
+            wound: false
+          }
+        }
+      ]);
+
+      expect(builder.query()).toEqual([
+        'labor',
+        [
+          'monster',
+          'victim',
+          ['wound', ['location', '::equals', 'arm'], '::every'],
+          '::every'
+        ],
+        '::all',
+        [['name']]
+      ]);
+    });
+
+    it('deep paths in filters with branching models only', () => {
+      builder.addRootIdentifier(stamp('monster', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'wound',
+          attributeName: 'location',
+          operator: '::equals',
+          operand: 'arm',
+          anyMap: {
+            victim: false,
+            wound: false
+          }
+        }
+      ]);
+
+      expect(builder.query()).toEqual([
+        'monster',
+        [
+          'victim',
+          ['wound', ['location', '::equals', 'arm'], '::every'],
+          '::every'
+        ],
+        '::all',
+        [['name']]
+      ]);
+    });
+
+    it('shallow paths in filters with branching models', () => {
+      builder.addRootIdentifier(stamp('monster', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'victim',
+          attributeName: 'name',
+          operator: '::equals',
+          operand: 'Hercules',
+          anyMap: {
+            victim: false
+          }
+        }
+      ]);
+
+      expect(builder.query()).toEqual([
+        'monster',
+        ['victim', ['name', '::equals', 'Hercules'], '::every'],
+        '::all',
+        [['name']]
+      ]);
+    });
+
+    it('paths that go up and down the tree', () => {
+      builder.addRootIdentifier(stamp('prize', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'wound',
+          attributeName: 'location',
+          operator: '::equals',
+          operand: 'arm',
+          anyMap: {
+            victim: false,
+            wound: false
+          }
+        }
+      ]);
+
+      expect(builder.query()).toEqual([
+        'prize',
+        [
+          'labor',
+          'monster',
+          'victim',
+          ['wound', ['location', '::equals', 'arm'], '::every'],
+          '::every'
+        ],
+        '::all',
+        [['name']]
+      ]);
+    });
+
+    it('paths that go up and down and terminate in a table', () => {
+      builder.addRootIdentifier(stamp('monster', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'prize',
+          attributeName: 'name',
+          operator: '::equals',
+          operand: 'Apples',
+          anyMap: {
+            prize: false
+          }
+        }
+      ]);
+
+      expect(builder.query()).toEqual([
+        'monster',
+        ['labor', 'prize', ['name', '::equals', 'Apples'], '::every'],
+        '::all',
+        [['name']]
+      ]);
+    });
+
+    it('paths that go up the tree', () => {
+      builder.addRootIdentifier(stamp('prize', 'name'));
+      builder.addRecordFilters([
+        {
+          modelName: 'labor',
+          attributeName: 'name',
+          operator: '::in',
+          operand: 'Lion,Hydra',
+          anyMap: {}
+        }
+      ]);
 
       expect(builder.query()).toEqual([
         'prize',


### PR DESCRIPTION
This PR adds in some functionality to Timur Query page:

* Adds UI widget for toggling between `::every` and `::any` when adding Filters, so user can specify at each step of the path how they want the filters enforced.
* Toggling nested - flattened does not change the filter verbs.
* Fixes Magma query API to account for nested `::every` and `::any` subqueries.