### PR TITLE
fix the 404 / invalid folder message in Metis UI

### DIFF
--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -6,6 +6,8 @@ import ListHead  from './list/list-head';
 import FolderBreadcrumb from './folder-breadcrumb';
 import ControlBar from './control-bar';
 
+import {selectCurrentFolder} from '../selectors/directory-selector';
+
 const COLUMNS = [
   { name: 'type', width: '60px' },
   { name: 'name', width: '60%' },
@@ -75,8 +77,8 @@ class FolderView extends React.Component {
   }
 
   render() {
-    let { bucket_name, folder_name } = this.props;
-    if (folder_name == INVALID) return <InvalidFolder/>;
+    let { bucket_name, folder_name, current_folder } = this.props;
+    if (current_folder == INVALID) return <InvalidFolder/>;
 
     let buttons = [
       { onClick: this.selectFolder.bind(this), title: 'Create folder', icon: 'folder', overlay: 'plus', role: 'editor' },
@@ -128,7 +130,7 @@ const downloadFilesZip = (files, folder_name, bucket_name) => ({ type: 'DOWNLOAD
 
 export default connect(
   // map state
-  null,
+  state => ({ current_folder: selectCurrentFolder(state) }),
 
   // map dispatch
   { retrieveFiles, fileSelected, createFolder, showUploadModal, listFilesRecursive, downloadFilesZip }

--- a/metis/lib/client/jsx/selectors/directory-selector.jsx
+++ b/metis/lib/client/jsx/selectors/directory-selector.jsx
@@ -1,0 +1,2 @@
+export const selectCurrentFolder = ({directory: {current_folder}}) =>
+  current_folder;


### PR DESCRIPTION
This is a small PR to fix the "invalid folder" behavior in the Metis UI. Now, non-existent folders should show the below message, instead of what looks like an empty folder.

![Screenshot from 2021-08-05 13-33-10](https://user-images.githubusercontent.com/4930129/128395200-cad4f53d-9efe-4b51-a2db-9dd66d7966a0.png)
