### PR TITLE
Fix redcap_loader bug involving ontologies

### DIFF
--- a/polyphemus/lib/etls/redcap/lib/entity.rb
+++ b/polyphemus/lib/etls/redcap/lib/entity.rb
@@ -23,6 +23,10 @@ module Redcap
           :field
         end
       end
+
+      def flat_key?
+        false
+      end
     end
 
     def self.create(entity)
@@ -41,6 +45,10 @@ module Redcap
 
     def filtered_key(key, value=nil)
       key unless @filter && (value || key) !~ @filter
+    end
+
+    def flat_key?
+      true
     end
   end
 end

--- a/polyphemus/lib/etls/redcap/lib/project.rb
+++ b/polyphemus/lib/etls/redcap/lib/project.rb
@@ -41,8 +41,8 @@ module Redcap
       @flat_records ||= client.get_record_flat(
         field_opts([ 'record_id' ] + valid_fields)
       ).map do |record|
-        [ record[:record_id], record ]
-      end.to_h
+        record.merge(record: record[:record_id])
+      end
     end
 
     private

--- a/polyphemus/spec/etls/redcap/loader_spec.rb
+++ b/polyphemus/spec/etls/redcap/loader_spec.rb
@@ -1,23 +1,97 @@
-describe Polyphemus::RedcapEtlScriptRunner do
-  context 'entity iteration' do
+describe Redcap::Loader do
+  def run_loader(models)
+    Redcap::Loader.new(
+      {
+        project_name: 'test2',
+        models_to_build: models.keys.map(&:to_s),
+        tokens: ["faketoken"],
+        dateshift_salt: '123',
+        redcap_host: REDCAP_HOST,
+        magma_host: MAGMA_HOST,
+        models: models
+      }, 'test', @magma_client, STDERR
+    ).run.first
+  end
+
+  context 'flat records' do
     before(:each) do
       stub_magma_models(fixture: 'spec/fixtures/magma_test2_models.json')
-      stub_redcap_test2_data
       @magma_client = Etna::Clients::Magma.new(host: MAGMA_HOST, token: TEST_TOKEN)
     end
 
-    def run_loader(models)
-      Redcap::Loader.new(
-        {
-          project_name: 'test2',
-          models_to_build: models.keys.map(&:to_s),
-          tokens: ["faketoken"],
-          dateshift_salt: '123',
-          redcap_host: REDCAP_HOST,
-          magma_host: MAGMA_HOST,
-          models: models
-        }, 'test', @magma_client, STDERR
-      ).run.first
+    it 'uses flat record values to replace regular values' do
+      Redcap::Model.define("Model").class_eval do
+        def identifier(record_name, event_name)
+          event_name
+        end
+      end
+
+      stub_redcap(
+        hash_including(content: 'metadata') => redcap_metadata(
+          cars: [
+            [ "car_class" ]
+          ]
+        ),
+        /eav/ => redcap_records(
+          { field_name: "car_class" },
+          [
+            { "record": "Caudillac", "redcap_event_name": "El Corazon", "value": "1" },
+            { "record": "Jatsun", "redcap_event_name": "Thunderer", "value": "2" },
+          ]
+        ).to_json,
+        /flat/ => flat_records(
+          redcap_records(
+            { field_name: "car_class" },
+            [
+              { "record": "Caudillac", "redcap_event_name": "El Corazon", "value": "coupe" },
+              { "record": "Jatsun", "redcap_event_name": "Thunderer", "value": "sedan" },
+            ]
+          )
+        ).to_json
+      )
+
+
+      records = run_loader(
+        model: {
+          each: [ "record", "event" ],
+          scripts: [
+            {
+              attributes: {
+                type: "car_class"
+              }
+            }
+          ]
+        }
+      )
+
+      expect(records.keys).to match_array([:model])
+      expect(records[:model].keys).to match_array(["Thunderer", "El Corazon"])
+      expect(records[:model].values).to match_array([{type: "coupe"}, {type: "sedan"}])
+
+      Kernel.send(:remove_const,:Model)
+    end
+  end
+
+  context 'entity iteration' do
+    before(:each) do
+      stub_magma_models(fixture: 'spec/fixtures/magma_test2_models.json')
+      stub_redcap(
+        hash_including(content: 'metadata') => redcap_metadata(
+          cars: [
+            [ "company_name" ],
+            [ "dof", "date of founding" ],
+            [ "car_class" ],
+            [ "year", "calendar year", "date" ],
+            {
+              field_name: "feature",
+              field_type: "checkbox",
+              select_choices_or_calculations: redcap_choices("Window", "Door", "Spoiler", "Radio", "Engine", "Carbuerator", "Wheels")
+            },
+            [ "award_name", "Awards" ]
+          ]
+        )
+      )
+      @magma_client = Etna::Clients::Magma.new(host: MAGMA_HOST, token: TEST_TOKEN)
     end
 
     it 'iterates across records' do
@@ -26,6 +100,17 @@ describe Polyphemus::RedcapEtlScriptRunner do
           record_name
         end
       end
+
+      stub_redcap(
+        /fields/ => redcap_records(
+          { redcap_event_name: "Base", field_name: "dof" },
+          [
+            { record: "Jatsun", "value": "1956-02-03" },
+            { "record": "ToyoT", "value": "1933-08-11" },
+            { "record": "Caudillac", "value": "1901-03-01" },
+          ]
+        ).to_json
+      )
 
       records = run_loader(
         make: {
@@ -53,6 +138,16 @@ describe Polyphemus::RedcapEtlScriptRunner do
         end
       end
 
+      stub_redcap(
+        /fields/ => redcap_records(
+          { field_name: "car_class" },
+          [
+            { "record": "Caudillac", "redcap_event_name": "El Corazon", "value": "sedan" },
+            { "record": "Jatsun", "redcap_event_name": "Thunderer", "value": "coupe" },
+          ]
+        ).to_json
+      )
+
       records = run_loader(
         model: {
           each: [ "record", "event" ],
@@ -68,6 +163,7 @@ describe Polyphemus::RedcapEtlScriptRunner do
 
       expect(records.keys).to match_array([:model])
       expect(records[:model].keys).to match_array(["Thunderer", "El Corazon"])
+      expect(records[:model].values).to match_array([{type: "coupe"}, {type: "sedan"}])
 
       Kernel.send(:remove_const,:Model)
     end
@@ -78,6 +174,30 @@ describe Polyphemus::RedcapEtlScriptRunner do
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end
+
+      stub_redcap(
+        /fields/ => redcap_records(
+          { "redcap_repeat_instrument": "model_versions", "field_name": "year" },
+          [
+            {
+              "record": "Jatsun", "redcap_event_name": "Thunderer",
+              "redcap_repeat_instance": 1, "value": "1968"
+            },
+            {
+              "record": "Jatsun", "redcap_event_name": "Thunderer",
+              "redcap_repeat_instance": 2, "value": "1969"
+            },
+            {
+              "record": "ToyoT", "redcap_event_name": "CorolloroC",
+              "redcap_repeat_instance": 1, "value": "1979"
+            },
+            {
+              "record": "ToyoT", "redcap_event_name": "CorolloroC",
+              "redcap_repeat_instance": 2, "value": "1980"
+            }
+          ]
+        ).to_json
+      )
 
       records = run_loader(
         year: {
@@ -104,6 +224,23 @@ describe Polyphemus::RedcapEtlScriptRunner do
           record[:year] = magma_record_name.split('-').values_at(1,2,4).join(' ')
         end
       end
+
+      stub_redcap(
+        /fields/ => (redcap_records(
+          { "redcap_repeat_instrument": "model_versions", "field_name": "feature", "redcap_event_name": "CorolloroC" },
+          [
+            { "record": "ToyoT", "redcap_repeat_instance": 1, "value": "Door" },
+            { "record": "ToyoT", "redcap_repeat_instance": 1, "value": "Engine" },
+            { "record": "ToyoT", "redcap_repeat_instance": 2, "value": "Wheels" }
+          ]
+        ) + redcap_records(
+          { "redcap_repeat_instrument": "model_versions", "field_name": "year", "record": "ToyoT", "redcap_event_name": "CorolloroC" },
+          [
+            { "redcap_repeat_instance": 1, "value": "1979" },
+            { "redcap_repeat_instance": 2, "value": "1980" }
+          ]
+        )).to_json
+      )
 
       records = run_loader(
         feature: {
@@ -138,6 +275,29 @@ describe Polyphemus::RedcapEtlScriptRunner do
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end
+
+      stub_redcap(
+        /fields/ => (redcap_records(
+          { "redcap_repeat_instrument": "model_versions", "field_name": "feature", "redcap_event_name": "CorolloroC" },
+          [
+            { "record": "ToyoT", "redcap_repeat_instance": 1, "value": "Door" },
+            { "record": "ToyoT", "redcap_repeat_instance": 1, "value": "Engine" },
+            { "record": "ToyoT", "redcap_repeat_instance": 2, "value": "Wheels" }
+          ]
+        ) + redcap_records(
+          { "redcap_repeat_instrument": "model_versions", "field_name": "year", "record": "ToyoT", "redcap_event_name": "CorolloroC" },
+          [
+            { "redcap_repeat_instance": 1, "value": "1979" },
+            { "redcap_repeat_instance": 2, "value": "1980" }
+          ]
+        ) + redcap_records(
+          { "record": "Jatsun", "redcap_event_name": "Thunderer", "redcap_repeat_instrument": "model_versions", "field_name": "year" },
+          [
+            { "redcap_repeat_instance": 1, "value": "1968" },
+            { "redcap_repeat_instance": 2, "value": "1969" }
+          ]
+        ) ).to_json
+      )
 
       records = run_loader(
         year: {
@@ -176,6 +336,17 @@ describe Polyphemus::RedcapEtlScriptRunner do
           record[:model] = magma_record_name.split('-')[2]
         end
       end
+
+      stub_redcap(
+        /fields/ => (redcap_records(
+          { "record": "ToyoT", "redcap_event_name": "CorolloroC", "redcap_repeat_instance": 1, "field_name": "award_name" },
+          [
+            { "redcap_repeat_instrument": "awards", "value": "Car of the Year 1977" },
+            { "redcap_repeat_instrument": "rejected", "value": "Car of the Year 1978" }
+          ]
+        ) ).to_json
+      )
+
       records = run_loader(
         award: {
           each: [ "record", "event", { repeat: /awards/  } ],


### PR DESCRIPTION
This fixes a bug involving the flat_record stuff, which stopped working due to a regression caused by the updates to the redcap entity iteration stuff. Now there is at least a test to cover this; also the specs are a little easier to make redcap fixtures. Magma fixtures (also required by the loader) are still in common, unfortunately.