### PR TITLE
Metis client set peek cmds

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1088,6 +1088,14 @@ EOT
     end
   end
 
+  class Exit < Command
+    usage "exit"
+
+    def run
+      exit
+    end
+  end
+
   class ShellError < StandardError
   end
 
@@ -1260,14 +1268,14 @@ EOT
     @shell_options[opt] = value
   end
 
+  def errexit
+    !!@shell_options[:e]
+  end
+
   private
 
   def self.log_error(e)
     STDERR.puts(e.message)
-  end
-
-  def errexit
-    !!@shell_options[:e]
   end
 
   def run_command(command=nil, *args)

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -216,7 +216,6 @@ class MetisClient < Client
       Net::HTTPHeaderSyntaxError,
       Net::ProtocolError,
       Net::HTTPRequestTimeOut,
-      Net::HTTPRequestTimeout,
       Net::HTTPGatewayTimeout,
       Net::HTTPGatewayTimeOut,
       Net::HTTPBadRequest,

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -216,6 +216,7 @@ class MetisClient < Client
       Net::HTTPHeaderSyntaxError,
       Net::ProtocolError,
       Net::HTTPRequestTimeOut,
+      Net::HTTPRequestTimeout,
       Net::HTTPGatewayTimeout,
       Net::HTTPGatewayTimeOut,
       Net::HTTPBadRequest,

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1337,7 +1337,7 @@ EOT
   end
 
   private
-  
+
   def errexit?
     !!@shell_options[:e]
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1328,11 +1328,11 @@ EOT
     @shell_options[opt] = value
   end
 
+  private
+  
   def errexit
     !!@shell_options[:e]
   end
-
-  private
 
   def self.log_error(e)
     STDERR.puts(e.message)

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -962,7 +962,7 @@ EOT
       elsif ::File.file?(file_or_folder)
         upload_file(file_or_folder, folder_path, folder)
       else
-        puts "Invalid input #{file_or_folder}"
+        raise ShellError, "Invalid input #{file_or_folder}"
       end
     end
 
@@ -1073,6 +1073,21 @@ EOT
     end
   end
 
+  class Set < Command
+    usage "set <options>"
+
+    def parse(args)
+      parse_opts(args) do |opts|
+        opts.on("-e", "Exit on error") do |n|
+          @shell.set_shell_option(:e, true)
+        end
+      end
+    end
+
+    def run
+    end
+  end
+
   class ShellError < StandardError
   end
 
@@ -1104,6 +1119,8 @@ EOT
     if match&.[](:path)
       set_path(match[:path])
     end
+
+    @shell_options = {}
   end
 
   attr_reader :project_name
@@ -1239,10 +1256,18 @@ EOT
     end
   end
 
+  def set_shell_option(opt, value)
+    @shell_options[opt] = value
+  end
+
   private
 
   def self.log_error(e)
     STDERR.puts(e.message)
+  end
+
+  def errexit
+    !!@shell_options[:e]
   end
 
   def run_command(command=nil, *args)
@@ -1260,13 +1285,17 @@ EOT
       cmd.run(*args) unless cmd.done?
     rescue ShellError => e
       MetisShell.log_error(e)
+      exit(1) if errexit
     rescue MetisClient::Error => e
       MetisShell.log_error(e)
+      exit(1) if errexit
     rescue ArgumentError => e
       puts(command.usage ? "Usage:\n#{command.usage}" : e.message)
       MetisShell.log_error(e)
+      exit(1) if errexit
     rescue Net::ReadTimeout => e
       MetisShell.log_error(e)
+      exit(1) if errexit
     end
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -131,8 +131,8 @@ class Client
 
   private
 
-  def get(path)
-    request(path, Net::HTTP::Get)
+  def get(path, headers=nil)
+    request(path, Net::HTTP::Get, headers)
   end
 
   def post(path)
@@ -357,6 +357,16 @@ class MetisClient < Client
     end
   end
 
+  def get_partial_file(path, start_byte, end_byte, &block)
+    https.request(get(path, {
+      "Range" => "bytes=#{start_byte}-#{end_byte}"
+    })) do |response|
+      response.read_body do |chunk|
+        yield chunk
+      end
+    end
+  end
+
   def remove_folder(project_name, folder_path)
     response = delete_request("/#{project_name}/folder/remove/#{URI.encode(folder_path)}")
     raise MetisClient::Error, "Could not remove folder #{folder_path}\n#{error(response)}" unless response.code == "200"
@@ -416,7 +426,7 @@ class MetisClient < Client
     https.request(req)
   end
 
-  def request(path, method)
+  def request(path, method, headers=nil)
     begin
       @token = janus.refresh_token
 
@@ -427,9 +437,15 @@ class MetisClient < Client
 
     uri = URI.parse("https://#{@host}#{path}")
     req = method.new(uri.request_uri)
+
+    headers.keys.each do |header|
+      req[header] = headers[header]
+    end if headers
+
     req['Authorization'] = "Etna #{@token}"
     cookie = CGI::Cookie.new(MetisConfig[:metis_uid_name], MetisConfig[:metis_uid])
     req['Cookie'] = cookie.to_s
+
     return req
   end
 
@@ -1093,6 +1109,37 @@ EOT
 
     def run
       exit
+    end
+  end
+
+  class Peek < Command
+    usage "peek <byte_offset> <num_bytes> <remote_file_path>"
+
+    def run(byte_offset, num_bytes, file_path)
+      raise ShellError, 'No project is selected' if !@shell.project_name
+
+      file_path = @shell.relative_path(file_path)
+
+      name = ::File.basename(file_path)
+      folder_name = ::File.dirname(file_path)
+
+      parent_folder = @shell.client.list_folder(@shell.project_name, folder_name)
+
+      raise ShellError, "Invalid path, cannot peek at #{file_path}" unless parent_folder
+      raise ShellError, "No files in folder #{folder_name}" unless parent_folder[:files]
+
+      file = parent_folder[:files].find do |f|
+        f[:file_name] == name
+      end
+
+      raise ShellError, "File does not exist, #{file_path}" unless file
+
+      @shell.client.get_partial_file(
+        file[:download_url].sub(%r!^https://[^/]*?/!, '/'),
+        byte_offset,
+        byte_offset.to_i + num_bytes.to_i - 1) do |chunk|
+        puts chunk
+      end
     end
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1329,7 +1329,7 @@ EOT
 
   private
   
-  def errexit
+  def errexit?
     !!@shell_options[:e]
   end
 
@@ -1352,17 +1352,17 @@ EOT
       cmd.run(*args) unless cmd.done?
     rescue ShellError => e
       MetisShell.log_error(e)
-      exit(1) if errexit
+      exit(1) if errexit?
     rescue MetisClient::Error => e
       MetisShell.log_error(e)
-      exit(1) if errexit
+      exit(1) if errexit?
     rescue ArgumentError => e
       puts(command.usage ? "Usage:\n#{command.usage}" : e.message)
       MetisShell.log_error(e)
-      exit(1) if errexit
+      exit(1) if errexit?
     rescue Net::ReadTimeout => e
       MetisShell.log_error(e)
-      exit(1) if errexit
+      exit(1) if errexit?
     end
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1119,14 +1119,27 @@ EOT
       raise ShellError, 'No project is selected' if !@shell.project_name
 
       file_path = @shell.relative_path(file_path)
-
       name = ::File.basename(file_path)
+
+      buckets = @shell.client.list_buckets(@shell.project_name)
+      bucket = buckets.find do |b|
+        b[:bucket_name] == name
+      end
+
+      raise ShellError, "Cannot peek at buckets" if bucket
+
       folder_name = ::File.dirname(file_path)
 
       parent_folder = @shell.client.list_folder(@shell.project_name, folder_name)
 
       raise ShellError, "Invalid path, cannot peek at #{file_path}" unless parent_folder
       raise ShellError, "No files in folder #{folder_name}" unless parent_folder[:files]
+
+      folder = parent_folder[:folders].find do |f|
+        f[:folder_name] == name
+      end
+
+      raise ShellError, "Cannot peek at folders" if folder
 
       file = parent_folder[:files].find do |f|
         f[:file_name] == name

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -176,7 +176,7 @@ class JanusClient < Client
     https.request(req)
   end
 
-  def request(path, method)
+  def request(path, method, headers=nil)
     uri = URI.parse("https://#{@host}#{path}")
     req = method.new(uri.request_uri)
     req['Authorization'] = "Etna #{@token}"

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -445,7 +445,6 @@ class MetisClient < Client
     req['Authorization'] = "Etna #{@token}"
     cookie = CGI::Cookie.new(MetisConfig[:metis_uid_name], MetisConfig[:metis_uid])
     req['Cookie'] = cookie.to_s
-
     return req
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1112,9 +1112,9 @@ EOT
   end
 
   class Peek < Command
-    usage "peek <byte_offset> <num_bytes> <remote_file_path>"
+    usage "peek <byte_offset> <num_bytes> <remote_file_path> [<local_file_path>]"
 
-    def run(byte_offset, num_bytes, file_path)
+    def run(byte_offset, num_bytes, file_path, local_file_path=nil)
       raise ShellError, 'No project is selected' if !@shell.project_name
 
       file_path = @shell.relative_path(file_path)
@@ -1146,11 +1146,20 @@ EOT
 
       raise ShellError, "File does not exist, #{file_path}" unless file
 
-      @shell.client.get_partial_file(
-        file[:download_url].sub(%r!^https://[^/]*?/!, '/'),
-        byte_offset,
-        byte_offset.to_i + num_bytes.to_i - 1) do |chunk|
-        puts chunk
+      begin
+        if local_file_path
+          FileUtils::mkdir_p(::File.dirname(local_file_path))
+          local_file = ::File.open(local_file_path, "w")
+        end
+        @shell.client.get_partial_file(
+          file[:download_url].sub(%r!^https://[^/]*?/!, '/'),
+          byte_offset,
+          byte_offset.to_i + num_bytes.to_i - 1) do |chunk|
+          puts chunk
+          local_file.write(chunk) if local_file
+        end
+      ensure
+        local_file.close if local_file
       end
     end
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -200,7 +200,7 @@ class MetisClient < Client
   end
 
   def net_exceptions
-    [
+    retry_exceptions = [
       Errno::ECONNREFUSED,
       Errno::ECONNRESET,
       Errno::ENETRESET,
@@ -216,8 +216,6 @@ class MetisClient < Client
       Net::HTTPHeaderSyntaxError,
       Net::ProtocolError,
       Net::HTTPRequestTimeOut,
-      Net::HTTPRequestTimeout,
-      Net::HTTPGatewayTimeout,
       Net::HTTPGatewayTimeOut,
       Net::HTTPBadRequest,
       Net::HTTPBadGateway,
@@ -233,6 +231,13 @@ class MetisClient < Client
       EOFError,
       Timeout::Error
     ]
+
+    begin
+      retry_exceptions << Net::HTTPRequestTimeout
+      retry_exceptions << Net::HTTPGatewayTimeout
+    end if RUBY_VERSION > "2.5.8"
+
+    retry_exceptions
   end
 
   def authorize_upload(project_name, bucket_name, file_path)

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -438,8 +438,8 @@ class MetisClient < Client
     uri = URI.parse("https://#{@host}#{path}")
     req = method.new(uri.request_uri)
 
-    headers.keys.each do |header|
-      req[header] = headers[header]
+    headers.each do |header, value|
+      req[header] = value
     end if headers
 
     req['Authorization'] = "Etna #{@token}"

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -1,5 +1,4 @@
 load 'bin/metis_client'
-require 'pty'
 
 def expect_output(path, *args)
   expect {

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -98,21 +98,7 @@ describe MetisShell do
       create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
     end
 
-    it 'can set errexit flag' do
-      shell = MetisShell.new("metis:://athena/armor", "set", "-e")
-      shell.run
-
-      expect(shell.errexit).to equal(true)
-    end
-
-    it 'does not have errexit set by default' do
-      shell = MetisShell.new("metis:://athena/armor", "ls")
-
-      shell.run
-      expect(shell.errexit).to equal(false)
-    end
-
-    it 'exits if errexit option is true' do
+    it 'exits upon error, if errexit option is true' do
       stub_metis_list_bucket
 
       with_temp_stdio do |stdin, stdout|
@@ -141,7 +127,7 @@ describe MetisShell do
       end
     end
 
-    it 'does not exit if errexit option is false' do
+    it 'does not exit upon error, if errexit option is false' do
       stub_metis_list_bucket
 
       with_temp_stdio do |stdin, stdout|

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -131,24 +131,11 @@ describe MetisShell do
       stub_metis_list_bucket
 
       with_temp_stdio do |stdin, stdout|
-        input_file_name = ::File.basename(stdin.path)
-
         stdin.write("project athena\n")
         stdin.write("cd armor\n")
         stdin.write("cd jabberwocky\n") # <- this folder doesn't exist, but shell ignores that and moves on to the next command
         stdin.write("put #{stdin.path} .\n")
         stdin.flush
-
-        stub_upload_file({
-          project: "athena",
-          authorize_body: JSON.generate({
-            url: "#{METIS_HOST}\/athena\/upload/armor/#{input_file_name}",
-          }),
-          upload_body: JSON.generate({
-            current_byte_position: stdin.size,
-            next_blob_size: 0,
-          }),
-        })
 
         shell = MetisShell.new("metis:://athena/armor")
         replace_stdio(stdin.path, stdout.path) do
@@ -163,7 +150,7 @@ describe MetisShell do
           with(body: hash_including({
             "project_name": "athena",
             "bucket_name": "armor",
-            "file_path": input_file_name
+            "file_path": ::File.basename(stdin.path)
           }))
       end
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -110,8 +110,13 @@ describe MetisShell do
         stdin.flush
 
         shell = MetisShell.new("metis:://athena/armor")
-        replace_stdio(stdin.path, stdout.path) do
-          shell.run
+        begin
+          replace_stdio(stdin.path, stdout.path) do
+            shell.run
+          end
+        rescue Exception => e
+          # Catch the exception / exit that will get thrown by the shell
+          #  otherwise, this test exits, too...
         end
 
         # Shell exited before it even tried processing the put command

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -438,8 +438,8 @@ end
 # From Ruby stdlib tests
 # https://fossies.org/linux/ruby/test/readline/test_readline.rb
 def with_temp_stdio
-  Tempfile.create("test_readline_stdin") {|stdin|
-    Tempfile.create("test_readline_stdout") {|stdout|
+  Tempfile.create("test_metis_client_stdin") {|stdin|
+    Tempfile.create("test_metis_client_stdout") {|stdout|
       yield stdin, stdout
     }
   }

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -199,6 +199,27 @@ def stub_metis_download(path, file_data)
     })
 end
 
+def stub_metis_list_bucket
+  stub_request(:get, /list\/bucket/)
+    .to_return({
+      status: 200,
+      body: {files: [], folders: []}.to_json
+    })
+end
+
+def stub_upload_file(params={})
+  stub_request(:post, /#{METIS_HOST}\/authorize\/upload/)
+  .to_return({
+    status: params[:status] || 200,
+    body: params[:authorize_body] || JSON.generate({})
+  })
+  stub_request(:post, /#{METIS_HOST}\/#{params[:project] || PROJECT}\/upload/)
+  .to_return({
+    status: params[:status] || 200,
+    body: params[:upload_body] || JSON.generate({})
+  })
+end
+
 class Stubs
   def initialize
     @stubs = []
@@ -412,4 +433,39 @@ def create_file(project_name, file_name, contents, params={})
       data_block: data_block
     }.merge(params)
   )
+end
+
+# From Ruby stdlib tests
+# https://fossies.org/linux/ruby/test/readline/test_readline.rb
+def with_temp_stdio
+  Tempfile.create("test_readline_stdin") {|stdin|
+    Tempfile.create("test_readline_stdout") {|stdout|
+      yield stdin, stdout
+    }
+  }
+end
+
+def replace_stdio(stdin_path, stdout_path)
+  open(stdin_path, "r"){|stdin|
+    open(stdout_path, "w"){|stdout|
+      orig_stdin = STDIN.dup
+      orig_stdout = STDOUT.dup
+      orig_stderr = STDERR.dup
+      STDIN.reopen(stdin)
+      STDOUT.reopen(stdout)
+      STDERR.reopen(stdout)
+      begin
+        Readline.input = STDIN
+        Readline.output = STDOUT
+        yield
+      ensure
+        STDERR.reopen(orig_stderr)
+        STDIN.reopen(orig_stdin)
+        STDOUT.reopen(orig_stdout)
+        orig_stdin.close
+        orig_stdout.close
+        orig_stderr.close
+      end
+    }
+  }
 end

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -207,19 +207,6 @@ def stub_metis_list_bucket
     })
 end
 
-def stub_upload_file(params={})
-  stub_request(:post, /#{METIS_HOST}\/authorize\/upload/)
-  .to_return({
-    status: params[:status] || 200,
-    body: params[:authorize_body] || JSON.generate({})
-  })
-  stub_request(:post, /#{METIS_HOST}\/#{params[:project] || PROJECT}\/upload/)
-  .to_return({
-    status: params[:status] || 200,
-    body: params[:upload_body] || JSON.generate({})
-  })
-end
-
 class Stubs
   def initialize
     @stubs = []


### PR DESCRIPTION
This PR adds two requested commands to metis_client:

* `set -e` in a script will make the client exit upon encountering any error. This will help prevent the scenario given by Arjun, where files are uploaded to the incorrect folder because his `cd <non-existent-folder>` command failed, but the client continued on to the next command.
* `peek <offset> <num bytes> <file>` will show you the specified byte range from a given file.

