### PR TITLE
add slack notifications to ingest pipeline

### DIFF
--- a/polyphemus/lib/etls/sftp_ingest_cat_to_c4_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_cat_to_c4_triage_files_etl.rb
@@ -31,6 +31,7 @@ class Polyphemus::SftpIngestCatToC4TriageFilesEtl < Polyphemus::DbTriageFileEtl
       ) do |file_name|
         logger.info("#{file_name} completed.")
         update_ingested_timestamp(file_name)
+        `post-to-slack "C4 Triage from CAT ETL" "bioinformatics-ping" "Successfully downloaded #{file_name} from the CAT to C4. It is available at #{c4_config[:root]} and ready for triage." || true`
       end
     end
 

--- a/polyphemus/lib/etls/sftp_ingest_cat_to_c4_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_cat_to_c4_triage_files_etl.rb
@@ -31,7 +31,7 @@ class Polyphemus::SftpIngestCatToC4TriageFilesEtl < Polyphemus::DbTriageFileEtl
       ) do |file_name|
         logger.info("#{file_name} completed.")
         update_ingested_timestamp(file_name)
-        `post-to-slack "C4 Triage from CAT ETL" "bioinformatics-ping" "Successfully downloaded #{file_name} from the CAT to C4. It is available at #{c4_config[:root]} and ready for triage." || true`
+        `post-to-slack "C4 Triage from CAT ETL" "data-ingest-ping" "Successfully downloaded #{file_name} from the CAT to C4. It is available at #{c4_config[:root]} and ready for triage." || true`
       end
     end
 

--- a/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
@@ -31,7 +31,7 @@ class Polyphemus::SftpIngestMetisTriageFilesEtl < Polyphemus::DbTriageFileEtl
       workflow.copy_files(file_names) do |file_name|
         puts "#{file_name} finished uploading."
         update_ingested_timestamp(host, file_name)
-        `post-to-slack "Metis Archive from CAT ETL" "bioinformatics-ping" "Successfully archived #{file_name} from the CAT on Metis." || true`
+        `post-to-slack "Metis Archive from CAT ETL" "data-ingest-ping" "Successfully archived #{file_name} from the CAT on Metis." || true`
       end
     end
 

--- a/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
+++ b/polyphemus/lib/etls/sftp_ingest_metis_triage_files_etl.rb
@@ -31,6 +31,7 @@ class Polyphemus::SftpIngestMetisTriageFilesEtl < Polyphemus::DbTriageFileEtl
       workflow.copy_files(file_names) do |file_name|
         puts "#{file_name} finished uploading."
         update_ingested_timestamp(host, file_name)
+        `post-to-slack "Metis Archive from CAT ETL" "bioinformatics-ping" "Successfully archived #{file_name} from the CAT on Metis." || true`
       end
     end
 

--- a/polyphemus/lib/etls/sync_gne_metis_files_etl.rb
+++ b/polyphemus/lib/etls/sync_gne_metis_files_etl.rb
@@ -33,7 +33,7 @@ class Polyphemus::SyncGneMetisFilesEtl < Polyphemus::MetisFileEtl
           file_path = file.file_path
           logger.info "Writing #{file_path}"
           workflow.copy_file(dest: file_path, url: file.download_url)
-          `post-to-slack "bioinformatics-ping" "Successfully uploaded metis://mvir1/#{BUCKET}/#{file_path} to genentech" || true`
+          `post-to-slack "Sync GNE Metis files ETL" "bioinformatics-ping" "Successfully uploaded metis://mvir1/#{BUCKET}/#{file_path} to genentech" || true`
         rescue => e
           errors << e
         ensure


### PR DESCRIPTION
This PR adds some Slack notifications to the ingest pipelines, on the `data-ingest-ping` channel, so we can kind of track which files are available on C4, and when. 