### PR TITLE
Ensure js routes are created in timur.

### DIFF
--- a/timur/Makefile
+++ b/timur/Makefile
@@ -5,3 +5,6 @@ include ../make-base/etna-ruby.mk
 include ../make-base/docker-compose.mk
 include ../make-base/node.mk
 
+# Ensure that routes.js is generated in the build output.
+release-test::
+	docker run --rm $(EXTRA_DOCKER_ARGS) -e $(app_name_capitalized)_ENV=test -e APP_NAME=$(app_name) -e RELEASE_TEST=1 $(fullTag) cat /app/public/js/routes.js

--- a/timur/build/create-js-routes
+++ b/timur/build/create-js-routes
@@ -2,20 +2,10 @@
 
 set -e
 
-# The webpack build process depends on gem setup in order to build the routes, but it cannot run the bundle install
-# itself without conflicting with the ruby server, so it merely checks and waits before invoking.
-if [ -n "$RUN_NPM_INSTALL" ]; then
-  while true; do
-    bundle check && break
-    echo "Waiting for ruby process to finish bundle install before create_routes can be invoked..."
-    wait 1
-  done
-
+if [ -n "$FULL_BUILD" ]; then
   if ! [ -e config.yml ]; then
     cp config.yml.template config.yml
-    ./bin/timur create_routes
-    rm config.yml
-  else
-    ./bin/timur create_routes
   fi
+
+  ./bin/timur create_routes
 fi


### PR DESCRIPTION
So,

The issue was that the timur image was not being created with public/js/routes.js, which depends on an invocation to timur the ruby app.

Before, this worked via build hook and was running successfully.  After changing how our build works, the environment variable it depended on had changed, but no tests existed to verify this integration.

Fix:  I added an integration test that fails with the current image, then adjusted the environment variable, and verified the integration test passes.