### PR TITLE
Add notion of submission state, to improve stale input handling

### DIFF
--- a/vulcan/lib/client/jsx/actions/vulcan_actions.ts
+++ b/vulcan/lib/client/jsx/actions/vulcan_actions.ts
@@ -14,8 +14,8 @@ export function setWorkflow(workflow: Workflow, projectName: string) {
     return actionObject('SET_WORKFLOW', {workflow, projectName});
 }
 
-export function setStatus(status: SessionStatusResponse['status'], clearStaleInputs = true) {
-    return actionObject('SET_STATUS', {status, clearStaleInputs});
+export function setStatus(status: SessionStatusResponse['status'], submittingStep: Maybe<string> = null) {
+    return actionObject('SET_STATUS', {status, submittingStep});
 }
 
 export function setDownloadedData(url: string, data: any) {

--- a/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
@@ -28,7 +28,7 @@ export default function WorkflowManager({workflowName, projectName}: { workflowN
           dispatch(setSession(session));
         }
 
-        requestPoll(false, false);
+        requestPoll();
       });
     }
   }, [cancelPolling, dispatch, getLocalSession, projectName, workflow]);

--- a/vulcan/lib/client/jsx/contexts/input_state_management.tsx
+++ b/vulcan/lib/client/jsx/contexts/input_state_management.tsx
@@ -8,7 +8,7 @@ import {useActionInvoker} from "etna-js/hooks/useActionInvoker";
 import {dismissMessages, showMessages} from "etna-js/actions/message_actions";
 import {clearBufferedInput, setBufferedInput, setInputs, VulcanAction} from "../actions/vulcan_actions";
 import {allSourcesForStepName} from "../selectors/workflow_selectors";
-import {mapSome, Maybe} from "../selectors/maybe";
+import {mapSome, Maybe, maybeOfNullable, some, withDefault} from "../selectors/maybe";
 import {DataEnvelope} from "../components/workflow/user_interactions/inputs/input_types";
 import {VulcanContext} from "./vulcan_context";
 
@@ -129,7 +129,7 @@ export function useInputStateManagement(invoke: ReturnType<typeof useActionInvok
       mapSome(inputs[source] || null, inner => newInputs[source] = inner);
     })
     dispatch(setInputs(newInputs))
-    requestPoll();
+    requestPoll(false, maybeOfNullable(stepName));
     return true;
   }, [dispatch, requestPoll, stateRef, validateInputs]);
 

--- a/vulcan/lib/client/jsx/contexts/session_sync.tsx
+++ b/vulcan/lib/client/jsx/contexts/session_sync.tsx
@@ -5,9 +5,10 @@ import {finishPolling, setSession, setStatus, startPolling, VulcanAction} from "
 import {SessionStatusResponse} from "../api_types";
 import {hasNoRunningSteps} from "../selectors/workflow_selectors";
 import {runPromise, useAsyncCallback} from "etna-js/utils/cancellable_helpers";
+import {Maybe} from "../selectors/maybe";
 
 export const defaultSessionSyncHelpers = {
-  requestPoll(post = false, clearStaleInputs = true): Promise<unknown> {
+  requestPoll(post = false, submittingStep: Maybe<string> = null): Promise<unknown> {
     return Promise.resolve();
   }, cancelPolling() {
   }
@@ -17,9 +18,13 @@ export function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function updateFromSessionResponse(response: SessionStatusResponse, dispatch: Dispatch<VulcanAction>, clearStaleInputs: boolean) {
+function updateFromSessionResponse(
+  response: SessionStatusResponse,
+  dispatch: Dispatch<VulcanAction>,
+  submittingStep: Maybe<string>,
+) {
   dispatch(setSession(response.session));
-  dispatch(setStatus(response.status, clearStaleInputs));
+  dispatch(setStatus(response.status, submittingStep));
 }
 
 export function useSessionSync(state: MutableRefObject<VulcanState>,
@@ -34,7 +39,10 @@ export function useSessionSync(state: MutableRefObject<VulcanState>,
      For non post requests, the inputs are sent but work is not scheduled.
      After that, it continues to poll until all steps are not running.
    */
-  const [requestPoll, cancelPolling] = useAsyncCallback(function* (post = false, clearStaleInputs = false) {
+  const [requestPoll, cancelPolling] = useAsyncCallback(function* (
+    post = false,
+    submittingStep: Maybe<string> = null,
+  ) {
     dispatch(startPolling());
     if (!state.current.session.workflow_name) {
       return;
@@ -42,12 +50,14 @@ export function useSessionSync(state: MutableRefObject<VulcanState>,
 
     const baseWork = post ? postInputs(state.current.session) : pollStatus(state.current.session);
     const response = yield* runPromise(showErrors(baseWork));
-    updateFromSessionResponse(response, dispatch, clearStaleInputs);
+    updateFromSessionResponse(response, dispatch, submittingStep);
 
     while (!hasNoRunningSteps(state.current.status)) {
       yield delay(3000);
       const response = yield* runPromise(showErrors(pollStatus(state.current.session)));
-      updateFromSessionResponse(response, dispatch, clearStaleInputs);
+      // Notably, after the first submission, changes in hash that occur do not have authority
+      // to clear stale inputs.
+      updateFromSessionResponse(response, dispatch, null);
     }
   }, [dispatch, pollStatus, postInputs, state], () => {
     dispatch(finishPolling())

--- a/vulcan/lib/client/jsx/test_utils/workflow_utils.tsx
+++ b/vulcan/lib/client/jsx/test_utils/workflow_utils.tsx
@@ -85,7 +85,7 @@ export class WorkflowUtils {
       this.stateRef.current.status,
       status
     );
-    this.dispatch(setStatus(updatedStatus, false));
+    this.dispatch(setStatus(updatedStatus, null));
 
     return status;
   }
@@ -121,7 +121,7 @@ export class WorkflowUtils {
       ...status, name: stepName, status: 'complete', downloads: {...status.downloads, [outputName]: url}
     }));
 
-    this.dispatch(setStatus(newStatus, false));
+    this.dispatch(setStatus(newStatus, null));
     this.dispatch(setDownloadedData(url, value));
     return newStatus;
   }


### PR DESCRIPTION
Explicitly thread the step that is being "updated" in submission (commit) so that stale input handling works correctly.

Previously, false was being passed to clearStaleInputs (default argument was wrong womp womp).  But changing that to true revealed another problem -- stale input handling was too aggressive when changing inputs.

This change ensures that stale inputs are correctly cleared on commit, and only for inputs that are not changed _by_ that commit (since we won't have the hash until the first server exchange).