### PR TITLE
Adds websocket tunnel to the apache config

### DIFF
--- a/docker/etna-apache/httpd.conf
+++ b/docker/etna-apache/httpd.conf
@@ -92,7 +92,7 @@ LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
 #LoadModule proxy_fdpass_module modules/mod_proxy_fdpass.so
-#LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
 #LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 #LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 #LoadModule proxy_express_module modules/mod_proxy_express.so


### PR DESCRIPTION
As part of the prefect.io test rollout, loads the websocket proxy module to apache to support, well, websockets. ;)