### PR TITLE
raise better error type

### DIFF
--- a/magma/lib/magma/query/predicate/subquery_filter.rb
+++ b/magma/lib/magma/query/predicate/subquery_filter.rb
@@ -76,7 +76,7 @@ class Magma
     def validate_attribute(model, attribute_name)
       attribute = model.attributes[attribute_name.to_sym]
 
-      raise ArgumentError, "Invalid attribute, #{attribute_name}" if attribute.nil?
+      raise Magma::QuestionError, "Invalid attribute, #{attribute_name}" if attribute.nil?
     end
 
     def has_nested_subquery?(args, model_name)


### PR DESCRIPTION
Small PR to get better error reporting if the resulting subquery is invalid. Should be more informative to the user, otherwise currently an invalid Attribute results in a generic "Serve Error" in the UI (which is what you saw in your bug report, @dtm2451 )