### PR TITLE
Allow environmental variable control of config

### DIFF
--- a/etna/Gemfile.lock
+++ b/etna/Gemfile.lock
@@ -120,6 +120,7 @@ DEPENDENCIES
   jwt
   mimemagic (~> 0.3.10)
   multipart-post
+  net-ssh
   nokogiri
   prometheus-client
   pry (~> 0.13.0)
@@ -141,4 +142,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.2.24
+   2.2.26

--- a/etna/Makefile
+++ b/etna/Makefile
@@ -11,3 +11,7 @@ release-test::
 	docker network create monoetna_default
 	docker run --rm -e APP_NAME=etna -e RELEASE_TEST=1 -e CI_SECRET=$${CI_SECRET} -e IS_CI=$${IS_CI} --network monoetna_default $(fullTag) /entrypoints/development.sh bundle exec rspec
 	docker run --rm -e APP_NAME=etna -e RELEASE_TEST=1 -e IS_CI=$${IS_CI} --network monoetna_default $(fullTag) /entrypoints/development.sh npm test
+
+update::
+	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bundle install
+	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bash -c 'cd packages/etna-js && npm install'

--- a/etna/packages/etna-js/package-lock.json
+++ b/etna/packages/etna-js/package-lock.json
@@ -2276,6 +2276,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/node": {
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",

--- a/etna/spec/application_spec.rb
+++ b/etna/spec/application_spec.rb
@@ -1,0 +1,35 @@
+describe Etna::Application do
+  before(:each) do
+    class TestApp
+      include Etna::Application
+    end
+  end
+
+  after(:each) do
+    Object.send(:remove_const, :TestApp)
+  end
+
+  describe 'environment based configuration' do
+    before(:each) do
+      @orig_ENV = {}.update(ENV)
+    end
+    after(:each) do
+      ENV.clear.update(@orig_ENV)
+    end
+
+    it 'loads all kinds of keys successfully, merging them with existing items' do
+      ENV['TESTAPP__PRODUCTION__DB__PASSWORD'] = 'password'
+      ENV['TESTAPP__PRODUCTION__DB__NO_OVERRIDE'] = 'blah'
+      ENV['TESTAPP__PRODUCTION__KEY'] = 'value'
+      app = TestApp.instance
+      app.configure({:production => { :db => {:host => 'm', :no_override => 'thing'}} })
+
+      expect(app.config(:key, :production)).to eql('value')
+      expect(app.config(:db, :production)).to eql({
+        :no_override => 'thing',
+        :host => 'm',
+        :password => 'password'
+      })
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to configure etna apps with formatted environment variables.  This allows me to use docker swarm secrets to configure sensitive bits: the private RSA and database passwords, for instances.  This will get read from a locked down secret file into the process environment, and will not be readable by anyone after being set.