### PR TITLE
Etna apps will run as non root, but make /tmp related folders writeab…

### DIFF
--- a/docker/etna-base-dev/entrypoints/build.sh
+++ b/docker/etna-base-dev/entrypoints/build.sh
@@ -11,6 +11,15 @@ mkdir -p /app/public/images
 mkdir -p /app/log
 mkdir -p /app/vendor/bundle
 mkdir -p /app/data/
+mkdir -p /tmp/metrics.prom/
+
+# Often, etna is built as root, but the processes are not run as root.
+# Certain, and only certain, directories should be writable.
+# Especially with source code in script-based servers, we don't want to
+# generally allow write-ability into the source code by any logic.
+chmod -R 777 /app/tmp
+chmod -R 777 /app/log
+chmod -R 777 /tmp/metrics.prom/
 
 shopt -s globstar
 

--- a/docker/etna-base/Makefile
+++ b/docker/etna-base/Makefile
@@ -2,5 +2,6 @@ baseTag:=$(shell basename "$$(pwd)")
 fullTag:=$(IMAGES_PREFIX)$(baseTag)$(IMAGES_POSTFIX)
 
 image:
+	make -C ../etna-base-dev
 	../build_image Dockerfile ?../../etna
 	if [ -n "$$PUSH_IMAGES" ]; then docker push $(fullTag); fi


### PR DESCRIPTION
…le permissively.

Similar pattern should be used for any state folders.  Vulcan and metis state folders (/app/data) are handled specially.