### PR TITLE
update magic string etl to scan entire filename with path

### DIFF
--- a/polyphemus/config.yml.template
+++ b/polyphemus/config.yml.template
@@ -95,7 +95,7 @@
   :redcap:
     :host: https://redcap.test
   :ingest:
-    :filename_regex: ^oligo
+    :filename_regex: oligo
     :sftp:
       - :host: sftp.example.com
         :username: user

--- a/polyphemus/lib/etls/sync_cat_files_etl.rb
+++ b/polyphemus/lib/etls/sync_cat_files_etl.rb
@@ -79,7 +79,7 @@ class Polyphemus::SyncCatFilesEtl < Polyphemus::RsyncFilesEtl
     existing_names = existing_file_names(records)
 
     new_records = records.select do |record|
-      !existing_names.include?(record.filename) && ::File.basename(record.filename) =~ Regexp.new(filename_regex)
+      !existing_names.include?(record.filename) && record.filename =~ Regexp.new(filename_regex)
     end
 
     logger.info("Found #{new_records.length} new files matching the regex: #{filename_regex}.")

--- a/polyphemus/spec/etls/sync_cat_files_etl_spec.rb
+++ b/polyphemus/spec/etls/sync_cat_files_etl_spec.rb
@@ -8,8 +8,8 @@ describe Polyphemus::SyncCatFilesEtl do
       MockChange.new("foo/bar/oligo-test1.txt"),
       MockChange.new("foo/bar/oligo-test2.txt"),
       MockChange.new("foo/bar/oligo-test3.txt"),
-      MockChange.new("wrong-oligo-file.txt"),
-      MockChange.new("oligo-file-to-add.txt"),
+      MockChange.new("wrong-olino-file.txt"),
+      MockChange.new("foo/oligo/file-to-add.txt"),
     ])
     sync_etl = Polyphemus::SyncCatFilesEtl.new
 
@@ -19,7 +19,7 @@ describe Polyphemus::SyncCatFilesEtl do
 
     expect(Polyphemus::IngestFile.count).to eq(4)
     expect(Polyphemus::IngestFile.last[:should_ingest]).to eq(true)
-    expect(Polyphemus::IngestFile.last[:name]).to eq("oligo-file-to-add.txt")
+    expect(Polyphemus::IngestFile.last[:name]).to eq("foo/oligo/file-to-add.txt")
   end
 
   it "should remove old, uningested records" do


### PR DESCRIPTION
This PR tweaks the CAT-scanning ETL to run the regex against the entire file path, instead of just the file name. This is based on our conversation with Delsy on Wednesday.