### PR TITLE
add input to edit column display labels

### DIFF
--- a/polyphemus/lib/etls/ipi/file_processors/ipi_rna_seq_matrix_processor.rb
+++ b/polyphemus/lib/etls/ipi/file_processors/ipi_rna_seq_matrix_processor.rb
@@ -35,7 +35,6 @@ class Polyphemus::IpiRnaSeqMatrixProcessor < Polyphemus::IpiRnaSeqProcessorBase
       csv.each.with_index do |col, index|
         next if index == 0
 
-        logger.info("Instantiating matrix class for index #{index.to_s}.")
         matrix = MagmaRnaSeqMatrix.new(
           raw_data: col,
           magma_gene_ids: magma_gene_ids,
@@ -45,14 +44,12 @@ class Polyphemus::IpiRnaSeqMatrixProcessor < Polyphemus::IpiRnaSeqProcessorBase
 
         next if @helper.is_non_cancer_sample?(matrix.tube_name)
 
-        logger.info("Preparing revision request for #{matrix.tube_name}.")
         update_for_cursor(cursor) do |update_request|
           update_request.update_revision(MAGMA_MODEL, matrix.tube_name, {
             "#{attribute_name}": matrix.to_array,
           })
           logger.info("Updating #{attribute_name} for record #{matrix.tube_name}.")
         end
-        logger.info("Update complete.")
       end
     end
 

--- a/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, useContext} from 'react';
 import Grid from '@material-ui/core/Grid';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
@@ -18,6 +18,7 @@ import {selectTemplate} from 'etna-js/selectors/magma';
 import {Attribute} from '../../models/model_types';
 
 import useSliceMethods from './query_use_slice_methods';
+import {QueryContext} from '../../contexts/query/query_context';
 import {QueryColumn} from '../../contexts/query/query_types';
 import {selectAllowedModelAttributes} from '../../selectors/query_selector';
 import QuerySlicePane from './query_slice_pane';
@@ -124,7 +125,16 @@ const AttributeSelector = ({
 }) => {
   const classes = useStyles();
 
-  if (!canEdit) return <Typography>{column.attribute_name}</Typography>;
+  if (!canEdit)
+    return (
+      <TextField
+        disabled
+        variant='outlined'
+        label='Attribute'
+        value={column.attribute_name}
+        className='query-column-attribute'
+      />
+    );
 
   return (
     <FormControl className={classes.fullWidth}>
@@ -173,6 +183,8 @@ const QueryModelAttributeSelector = ({
   //   with the model / attribute as a "label".
   // Matrices will have modelName + attributeName.
   const [updateCounter, setUpdateCounter] = useState(0);
+
+  const {patchQueryColumn} = useContext(QueryContext);
 
   let reduxState = useReduxState();
 
@@ -231,14 +243,29 @@ const QueryModelAttributeSelector = ({
             direction='column'
             key={column.model_name}
           >
-            <Grid item xs={4}>
-              <AttributeSelector
-                onSelect={onSelectAttribute}
-                canEdit={canEdit}
-                label={label}
-                attributeChoiceSet={selectableModelAttributes}
-                column={column}
-              />
+            <Grid item container>
+              <Grid item xs={4}>
+                <AttributeSelector
+                  onSelect={onSelectAttribute}
+                  canEdit={canEdit}
+                  label={label}
+                  attributeChoiceSet={selectableModelAttributes}
+                  column={column}
+                />
+              </Grid>
+              <Grid item xs={4}>
+                <TextField
+                  label='Display Label'
+                  variant='outlined'
+                  value={column.display_label}
+                  onChange={(e) =>
+                    patchQueryColumn(columnIndex, {
+                      ...column,
+                      display_label: e.target.value
+                    })
+                  }
+                />
+              </Grid>
             </Grid>
             {isSliceable && canEdit ? (
               <Grid item>

--- a/timur/lib/client/scss/query.scss
+++ b/timur/lib/client/scss/query.scss
@@ -122,3 +122,7 @@
 button.query-add-column-btn {
   margin-top: 1rem;
 }
+
+div.query-column-attribute input {
+  color: black;
+}

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -380,13 +380,81 @@ exports[`QueryBuilder renders 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-9"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                class="MuiGrid-root MuiGrid-container MuiGrid-item"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
                 >
-                  name
-                </p>
+                  <div
+                    class="MuiFormControl-root MuiTextField-root query-column-attribute"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-disabled MuiInputLabel-disabled MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      Attribute
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-disabled MuiOutlinedInput-disabled MuiInputBase-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-disabled MuiOutlinedInput-disabled"
+                        disabled=""
+                        type="text"
+                        value="name"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                        >
+                          <span>
+                            Attribute
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      Display Label
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiOutlinedInput-input"
+                        type="text"
+                        value="monster.name"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                        >
+                          <span>
+                            Display Label
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
             <div
@@ -444,109 +512,149 @@ exports[`QueryBuilder renders 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-9"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                class="MuiGrid-root MuiGrid-container MuiGrid-item"
               >
                 <div
-                  class="MuiFormControl-root makeStyles-fullWidth"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
                 >
                   <div
-                    aria-expanded="false"
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-                    role="combobox"
-                    style="width: 300px;"
+                    class="MuiFormControl-root makeStyles-fullWidth"
                   >
                     <div
-                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                      aria-expanded="false"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                      role="combobox"
+                      style="width: 300px;"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
-                        data-shrink="false"
-                        for="Join Model-0.5-attribute"
-                        id="Join Model-0.5-attribute-label"
-                      >
-                        Attribute
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                       >
-                        <input
-                          aria-autocomplete="list"
-                          aria-invalid="false"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                          id="Join Model-0.5-attribute"
-                          spellcheck="false"
-                          type="text"
-                          value=""
-                        />
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                          data-shrink="false"
+                          for="Join Model-0.5-attribute"
+                          id="Join Model-0.5-attribute-label"
+                        >
+                          Attribute
+                        </label>
                         <div
-                          class="MuiAutocomplete-endAdornment"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                         >
-                          <button
-                            aria-label="Clear"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                            tabindex="-1"
-                            title="Clear"
-                            type="button"
+                          <input
+                            aria-autocomplete="list"
+                            aria-invalid="false"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                            id="Join Model-0.5-attribute"
+                            spellcheck="false"
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            class="MuiAutocomplete-endAdornment"
                           >
-                            <span
-                              class="MuiIconButton-label"
+                            <button
+                              aria-label="Clear"
+                              class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                              tabindex="-1"
+                              title="Clear"
+                              type="button"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                                focusable="false"
-                                viewBox="0 0 24 24"
+                              <span
+                                class="MuiIconButton-label"
                               >
-                                <path
-                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
-                          <button
-                            aria-label="Open"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                            tabindex="-1"
-                            title="Open"
-                            type="button"
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                            <button
+                              aria-label="Open"
+                              class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                              tabindex="-1"
+                              title="Open"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
                           >
-                            <span
-                              class="MuiIconButton-label"
+                            <legend
+                              class="PrivateNotchedOutline-legendLabelled"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M7 10l5 5 5-5z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
+                              <span>
+                                Attribute
+                              </span>
+                            </legend>
+                          </fieldset>
                         </div>
-                        <fieldset
-                          aria-hidden="true"
-                          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                        >
-                          <legend
-                            class="PrivateNotchedOutline-legendLabelled"
-                          >
-                            <span>
-                              Attribute
-                            </span>
-                          </legend>
-                        </fieldset>
                       </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      Display Label
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiOutlinedInput-input"
+                        type="text"
+                        value="prize.name"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                        >
+                          <span>
+                            Display Label
+                          </span>
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>
@@ -879,109 +987,149 @@ exports[`QueryBuilder renders 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-9"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                class="MuiGrid-root MuiGrid-container MuiGrid-item"
               >
                 <div
-                  class="MuiFormControl-root makeStyles-fullWidth"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
                 >
                   <div
-                    aria-expanded="false"
-                    class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-                    role="combobox"
-                    style="width: 300px;"
+                    class="MuiFormControl-root makeStyles-fullWidth"
                   >
                     <div
-                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                      aria-expanded="false"
+                      class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                      role="combobox"
+                      style="width: 300px;"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
-                        data-shrink="false"
-                        for="Join Model-0.5-attribute"
-                        id="Join Model-0.5-attribute-label"
-                      >
-                        Attribute
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                       >
-                        <input
-                          aria-autocomplete="list"
-                          aria-invalid="false"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                          id="Join Model-0.5-attribute"
-                          spellcheck="false"
-                          type="text"
-                          value=""
-                        />
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                          data-shrink="false"
+                          for="Join Model-0.5-attribute"
+                          id="Join Model-0.5-attribute-label"
+                        >
+                          Attribute
+                        </label>
                         <div
-                          class="MuiAutocomplete-endAdornment"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                         >
-                          <button
-                            aria-label="Clear"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                            tabindex="-1"
-                            title="Clear"
-                            type="button"
+                          <input
+                            aria-autocomplete="list"
+                            aria-invalid="false"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                            id="Join Model-0.5-attribute"
+                            spellcheck="false"
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            class="MuiAutocomplete-endAdornment"
                           >
-                            <span
-                              class="MuiIconButton-label"
+                            <button
+                              aria-label="Clear"
+                              class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                              tabindex="-1"
+                              title="Clear"
+                              type="button"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                                focusable="false"
-                                viewBox="0 0 24 24"
+                              <span
+                                class="MuiIconButton-label"
                               >
-                                <path
-                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
-                          <button
-                            aria-label="Open"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                            tabindex="-1"
-                            title="Open"
-                            type="button"
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                            <button
+                              aria-label="Open"
+                              class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                              tabindex="-1"
+                              title="Open"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
                           >
-                            <span
-                              class="MuiIconButton-label"
+                            <legend
+                              class="PrivateNotchedOutline-legendLabelled"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M7 10l5 5 5-5z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
+                              <span>
+                                Attribute
+                              </span>
+                            </legend>
+                          </fieldset>
                         </div>
-                        <fieldset
-                          aria-hidden="true"
-                          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                        >
-                          <legend
-                            class="PrivateNotchedOutline-legendLabelled"
-                          >
-                            <span>
-                              Attribute
-                            </span>
-                          </legend>
-                        </fieldset>
                       </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      Display Label
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiOutlinedInput-input"
+                        type="text"
+                        value="prize.name"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                        >
+                          <span>
+                            Display Label
+                          </span>
+                        </legend>
+                      </fieldset>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This PR adds a text input field for each column, that lets the user edit the column heading. Default value is `model.attribute`, but since that may lead to duplicate headings, users may want to edit those and provide more clarity. i.e. if you have two flow population columns with counts, you might label the `population.count.nktb.cd8` and `population.count.treg.cd8` to differentiate the stains used in the slicing.