### PR TITLE
Timur query limit filter and slice operators

### DIFF
--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -104,7 +104,7 @@ const QueryFilterControl = ({
       ) {
         case 'string':
           return 'text';
-        case 'datetime':
+        case 'date_time':
           return 'date';
         case 'integer':
         case 'float':
@@ -122,8 +122,8 @@ const QueryFilterControl = ({
   }, [filter.attributeName, filter.modelName, reduxState]);
 
   const filterOperator = useMemo(() => {
-    return new FilterOperator(attributeType, filter.operator);
-  }, [attributeType, filter.operator]);
+    return new FilterOperator(attributeType, filter.operator, isColumnFilter);
+  }, [attributeType, filter.operator, isColumnFilter]);
 
   const handleModelSelect = useCallback(
     (modelName: string) => {
@@ -141,7 +141,9 @@ const QueryFilterControl = ({
     (attributeName: string) =>
       patchFilter({
         ...filter,
-        attributeName
+        attributeName,
+        operator: '',
+        operand: ''
       }),
     [filter, patchFilter]
   );
@@ -217,7 +219,7 @@ const QueryFilterControl = ({
             onChange={(e) => handleOperatorSelect(e.target.value as string)}
             displayEmpty
           >
-            {Object.keys(filterOperator.options(isColumnFilter))
+            {Object.keys(filterOperator.options())
               .sort()
               .map((operator: string, index: number) => (
                 <MenuItem key={index} value={operator}>

--- a/timur/lib/client/jsx/components/query/query_filter_operator.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_operator.tsx
@@ -5,22 +5,8 @@ export default class FilterOperator {
   operator: string;
   isColumnFilter: boolean;
 
-  static allOptions: {[key: string]: string} = {
-    Slice: '::slice',
-    Equals: '::equals',
-    Contains: '::matches',
-    In: '::in',
-    'Less than': '::<',
-    'Greater than': '::>',
-    'Is present': '::has',
-    'Is missing': '::lacks',
-    'Is true': '::true',
-    'Is false': '::false',
-    'Is untrue': '::untrue'
-  };
-
-  static allOptionsByType: {[key: string]: {[key: string]: string}} = {
-    present: {
+  static queryOperatorsByType: {[key: string]: {[key: string]: string}} = {
+    base: {
       'Is present': '::has',
       'Is missing': '::lacks'
     },
@@ -82,30 +68,30 @@ export default class FilterOperator {
     );
   }
 
-  optionsForFilterType(): {[key: string]: string} {
+  optionsForAttribute(): {[key: string]: string} {
     return this.isColumnFilter &&
       this.attributeType in FilterOperator.columnOptionsByType
       ? FilterOperator.columnOptionsByType[this.attributeType]
-      : this.optionsWithPresent();
+      : this.attrOptionsWithBaseOptions();
   }
 
-  optionsWithPresent(): {[key: string]: string} {
+  attrOptionsWithBaseOptions(): {[key: string]: string} {
     return {
-      ...FilterOperator.allOptionsByType.present,
-      ...(FilterOperator.allOptionsByType[this.attributeType] || {})
+      ...FilterOperator.queryOperatorsByType.base,
+      ...(FilterOperator.queryOperatorsByType[this.attributeType] || {})
     };
   }
 
   prettify(): string {
-    return _.invert(this.optionsForFilterType())[this.operator];
+    return _.invert(this.optionsForAttribute())[this.operator];
   }
 
   magmify(newOperator: string): string {
-    return this.optionsForFilterType()[newOperator];
+    return this.optionsForAttribute()[newOperator];
   }
 
   options(): {[key: string]: string} {
-    return this.optionsForFilterType();
+    return this.optionsForAttribute();
   }
 
   formatOperand(operand: string): number | string {

--- a/timur/lib/client/jsx/components/query/query_filter_operator.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_operator.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 export default class FilterOperator {
   attributeType: string;
   operator: string;
+  isColumnFilter: boolean;
 
   static allOptions: {[key: string]: string} = {
     Slice: '::slice',
@@ -18,15 +19,60 @@ export default class FilterOperator {
     'Is untrue': '::untrue'
   };
 
+  static allOptionsByType: {[key: string]: {[key: string]: string}} = {
+    present: {
+      'Is present': '::has',
+      'Is missing': '::lacks'
+    },
+    boolean: {
+      'Is true': '::true',
+      'Is false': '::false',
+      'Is untrue': '::untrue'
+    },
+    number: {
+      In: '::in',
+      Equals: '::=',
+      'Greater than': '::>',
+      'Greater than or equals': '::>=',
+      'Less than': '::<',
+      'Less than or equals': '::<=',
+      'Not equals': '::!='
+    },
+    date: {
+      Equals: '::=',
+      'Greater than': '::>',
+      'Greater than or equals': '::>=',
+      'Less than': '::<',
+      'Less than or equals': '::<=',
+      'Not equals': '::!='
+    },
+    text: {
+      In: '::in',
+      Equals: '::equals',
+      Contains: '::matches'
+    }
+  };
+
+  static columnOptionsByType: {[key: string]: {[key: string]: string}} = {
+    matrix: {
+      Slice: '::slice'
+    }
+  };
+
   static terminalOperators: string[] = ['::true', '::false', '::untrue'];
 
   static terminalInvertOperators: string[] = ['::has', '::lacks'];
 
   static commaSeparatedOperators: string[] = ['::in', '::slice'];
 
-  constructor(attributeType: string, operator: string) {
+  constructor(
+    attributeType: string,
+    operator: string,
+    isColumnFilter: boolean
+  ) {
     this.attributeType = attributeType;
     this.operator = operator;
+    this.isColumnFilter = isColumnFilter;
   }
 
   hasOperand(): boolean {
@@ -36,43 +82,30 @@ export default class FilterOperator {
     );
   }
 
+  optionsForFilterType(): {[key: string]: string} {
+    return this.isColumnFilter &&
+      this.attributeType in FilterOperator.columnOptionsByType
+      ? FilterOperator.columnOptionsByType[this.attributeType]
+      : this.optionsWithPresent();
+  }
+
+  optionsWithPresent(): {[key: string]: string} {
+    return {
+      ...FilterOperator.allOptionsByType.present,
+      ...(FilterOperator.allOptionsByType[this.attributeType] || {})
+    };
+  }
+
   prettify(): string {
-    if (this.attributeType === 'number' && this.operator === '::=') {
-      return 'Equals';
-    }
-    return _.invert(FilterOperator.allOptions)[this.operator];
+    return _.invert(this.optionsForFilterType())[this.operator];
   }
 
   magmify(newOperator: string): string {
-    if (this.attributeType === 'number' && newOperator === 'Equals') {
-      return '::=';
-    }
-
-    return FilterOperator.allOptions[newOperator];
+    return this.optionsForFilterType()[newOperator];
   }
 
-  options(isColumnFilter: boolean): {[key: string]: string} {
-    if ('matrix' === this.attributeType && isColumnFilter) {
-      return Object.keys(FilterOperator.allOptions).reduce(
-        (acc: {[key: string]: string}, key: string) => {
-          if ('Slice' === key) {
-            acc[key] = FilterOperator.allOptions[key];
-          }
-          return acc;
-        },
-        {}
-      );
-    } else {
-      return Object.keys(FilterOperator.allOptions).reduce(
-        (acc: {[key: string]: string}, key: string) => {
-          if ('Slice' !== key) {
-            acc[key] = FilterOperator.allOptions[key];
-          }
-          return acc;
-        },
-        {}
-      );
-    }
+  options(): {[key: string]: string} {
+    return this.optionsForFilterType();
   }
 
   formatOperand(operand: string): number | string {

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -1487,7 +1487,7 @@ exports[`QueryBuilder renders 1`] = `
                 tabindex="-1"
               >
                 <div
-                  style="min-width: 1px; height: 90px;"
+                  style="min-width: 1px; height: 89px;"
                 />
               </div>
               <div
@@ -1540,7 +1540,7 @@ exports[`QueryBuilder renders 1`] = `
                               role="presentation"
                               style="padding-right: .1px;"
                             >
-                              ["monster",["labor",["year","::equals",2],"::any"],"::all",["name",["labor","prize",["name","::equals","Athens"],"::first","name"],["labor","prize",["name","::equals","Sparta"],"::first","name"]]]
+                              ["monster",["labor",["year","::=",2],"::any"],"::all",["name",["labor","prize",["name","::equals","Athens"],"::first","name"],["labor","prize",["name","::equals","Sparta"],"::first","name"]]]
                             </span>
                           </pre>
                         </div>

--- a/timur/test/javascript/components/query/query_builder.test.tsx
+++ b/timur/test/javascript/components/query/query_builder.test.tsx
@@ -97,7 +97,7 @@ describe('QueryBuilder', () => {
         {
           modelName: 'labor',
           attributeName: 'year',
-          operator: '::equals',
+          operator: '::=',
           operand: 2
         }
       ]


### PR DESCRIPTION
This PR only shows the valid operators for a filter or slice, in the query UI, based on the selected attribute's type. This should make it less confusing for users what operators they can use to generate a valid query.