### PR TITLE
fix issue with bypassing validation

### DIFF
--- a/magma/lib/magma/loader.rb
+++ b/magma/lib/magma/loader.rb
@@ -390,6 +390,8 @@ class Magma
         # Run the record updates.
         multi_update(model, update_records)
       end
+    rescue Exception => e
+      raise Magma::LoadFailed.new([e.message])
     end
 
     def multi_insert(model, insert_records)

--- a/magma/lib/magma/loader/record_entry.rb
+++ b/magma/lib/magma/loader/record_entry.rb
@@ -33,9 +33,9 @@ class Magma
     def complaints
       return @complaints if @complaints
       check_document_validity
-      check_record_name_validity if valid_new_entry?
+      check_record_name_validity unless record_exists?
 
-      return @complaints
+      return @complaints.uniq
     end
 
     def valid_new_entry?

--- a/magma/lib/magma/loader/record_entry.rb
+++ b/magma/lib/magma/loader/record_entry.rb
@@ -33,6 +33,7 @@ class Magma
     def complaints
       return @complaints if @complaints
       check_document_validity
+      check_record_name_validity if valid_new_entry?
 
       return @complaints
     end
@@ -143,6 +144,21 @@ class Magma
       @loader.validator.validate(@model, @record_name, @record) do |complaint|
         @complaints << complaint
       end
+    end
+
+    def check_record_name_validity
+      # On create, make sure the record_name is valid
+      @loader.validator.validate(@model, @record_name, {
+        identifier_attribute_name => @record_name
+      }) do |complaint|
+        @complaints << complaint
+      end
+    end
+
+    def identifier_attribute_name
+      @model.attributes.values.select do |attribute|
+        attribute.is_a?(Magma::IdentifierAttribute)
+      end.first.name.to_sym
     end
   end
 end

--- a/magma/lib/magma/validation/attribute.rb
+++ b/magma/lib/magma/validation/attribute.rb
@@ -23,20 +23,9 @@ class Magma
             yield error
           end
         end
-        # Also validate the record name separately, if it
-        #   is not included in the document.
-        attribute_validations(identifier_attribute_name).validate(record_name) do |error|
-          yield error
-        end unless document.key?(identifier_attribute_name)
       end
 
       private
-
-      def identifier_attribute_name
-        @model.attributes.values.select do |attribute|
-          attribute.is_a?(Magma::IdentifierAttribute)
-        end.first.name.to_sym
-      end
 
       def attribute_validations(att_name)
         @attribute_validations[att_name] ||= validation(@model.attributes[att_name]).new(

--- a/magma/lib/magma/validation/attribute.rb
+++ b/magma/lib/magma/validation/attribute.rb
@@ -23,9 +23,20 @@ class Magma
             yield error
           end
         end
+        # Also validate the record name separately, if it
+        #   is not included in the document.
+        attribute_validations(identifier_attribute_name).validate(record_name) do |error|
+          yield error
+        end unless document.key?(identifier_attribute_name)
       end
 
       private
+
+      def identifier_attribute_name
+        @model.attributes.values.select do |attribute|
+          attribute.is_a?(Magma::IdentifierAttribute)
+        end.first.name.to_sym
+      end
 
       def attribute_validations(att_name)
         @attribute_validations[att_name] ||= validation(@model.attributes[att_name]).new(

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -342,3 +342,17 @@ def setup_metis_bucket_stubs(project_name)
   stub_request(:post, /https:\/\/metis.test\/#{project_name}\/bucket\/create/).
     to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
 end
+
+def stub_validation(model, att_name, new_validation)
+  validation_stubs[model] ||= {}
+  validation_stubs[model][att_name] = model.attributes[att_name].validation
+  model.attributes[att_name].validation = new_validation
+end
+
+def remove_validation_stubs
+  validation_stubs.each do |model,atts|
+    atts.each do |att_name, old_validation|
+      model.attributes[att_name].validation = old_validation
+    end
+  end
+end

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -2130,7 +2130,7 @@ describe UpdateController do
       expect(lion.name).to eq('Nemean Lion')
     end
 
-    it 'cannot update an invalid record' do
+    it 'can update other attributes for an invalid record' do
       lion = create(:monster, name: 'nemean lion')
       expect(lion.species).to eq(nil)
       update(
@@ -2142,7 +2142,8 @@ describe UpdateController do
       )
 
       lion.refresh
-      expect(last_response.status).to eq(422)
+      expect(last_response.status).to eq(200)
+      expect(lion.species).to eq('lion')
     end
   end
 

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -2099,7 +2099,7 @@ describe UpdateController do
       remove_validation_stubs
     end
 
-    it 'fails on validation checks' do
+    it 'fails on validation checks for attributes' do
       # The actual validation is defined in spec/fixtures/labors_model_attributes.yml
       lion = create(:monster, name: 'Nemean Lion', species: 'lion')
       update(

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -2115,6 +2115,18 @@ describe UpdateController do
       expect(lion.species).to eq('lion')
     end
 
+    it 'fails on validation checks for the record name, on create' do
+      update(
+        monster: {
+          'nemean lion': {
+            species: 'lion'
+          }
+        }
+      )
+
+      expect(last_response.status).to eq(422)
+    end
+
     it 'allows you to rename an invalid record' do
       lion = create(:monster, name: 'nemean lion')
       update(

--- a/magma/spec/validation_spec.rb
+++ b/magma/spec/validation_spec.rb
@@ -12,32 +12,18 @@ describe Magma::Validation do
     @validation_stubs ||= {}
   end
 
-  def stub_validation(model, att_name, new_validation)
-    validation_stubs[model] ||= {}
-    validation_stubs[model][att_name] = model.attributes[att_name].validation
-    model.attributes[att_name].validation = new_validation
-  end
-
-  def remove_validation_stubs
-    validation_stubs.each do |model,atts|
-      atts.each do |att_name, old_validation|
-        model.attributes[att_name].validation = old_validation
-      end
-    end
-  end
-
   context 'model record validations' do
     after(:each) do
       remove_validation_stubs
     end
     
-    it 'validates its own record name' do
+    it 'validates its own record name for update' do
       stub_validation(Labors::Monster, :name, {
         type: "Regexp", value: /^[A-Z][a-z]+ [A-Z][a-z]+$/
       })
 
       # fails
-      errors = validate(Labors::Monster, 'nemean lion', labor: 'Nemean Lion')
+      errors = validate(Labors::Monster, 'Nemean Lion', name: 'nemean lion', labor: 'Nemean Lion')
       expect(errors).to eq(["On name, 'nemean lion' is improperly formatted."])
 
       # passes

--- a/magma/spec/validation_spec.rb
+++ b/magma/spec/validation_spec.rb
@@ -43,6 +43,9 @@ describe Magma::Validation do
       # passes
       errors = validate(Labors::Monster, 'Nemean Lion', name: 'Nemean Lion', labor: 'Nemean Lion')
       expect(errors).to be_empty
+
+      errors = validate(Labors::Monster, 'nemean lion',  name: 'Nemean Lion', labor: 'Nemean Lion')
+      expect(errors).to be_empty
     end
   end
 

--- a/magma/spec/validation_spec.rb
+++ b/magma/spec/validation_spec.rb
@@ -26,6 +26,26 @@ describe Magma::Validation do
     end
   end
 
+  context 'model record validations' do
+    after(:each) do
+      remove_validation_stubs
+    end
+    
+    it 'validates its own record name' do
+      stub_validation(Labors::Monster, :name, {
+        type: "Regexp", value: /^[A-Z][a-z]+ [A-Z][a-z]+$/
+      })
+
+      # fails
+      errors = validate(Labors::Monster, 'nemean lion', labor: 'Nemean Lion')
+      expect(errors).to eq(["On name, 'nemean lion' is improperly formatted."])
+
+      # passes
+      errors = validate(Labors::Monster, 'Nemean Lion', name: 'Nemean Lion', labor: 'Nemean Lion')
+      expect(errors).to be_empty
+    end
+  end
+
   context 'attribute validations' do
     after(:each) do
       remove_validation_stubs


### PR DESCRIPTION
This PR fixes the issue with magmaR bypassing validations that we noticed today at standup.

Basically, existing validations only work from the parent-direction down to the child, because they only check the key-value pairs in the update payload document.

But, that means an update to a "child" record itself (disconnected or connected, doesn't matter), would not have its identifier validated if the attribute were not duplicated in the payload, like:

```
"revisions": {
    "sample": {
        "IPIADR001.T1.12": {
            "patient": "IPIADR001"
        }
    }
}
```
Actually creates a record.

This PR adds an identifier check on the record_name, if that identifier attribute is left out of the update document.