### PR TITLE
warn on ipi rna_seq record fail and move on

### DIFF
--- a/polyphemus/spec/etls/ipi/ipi_rna_seq_create_record_names_etl_spec.rb
+++ b/polyphemus/spec/etls/ipi/ipi_rna_seq_create_record_names_etl_spec.rb
@@ -59,6 +59,13 @@ describe Polyphemus::IpiRnaSeqCreateRecordNamesEtl do
                                          "rna_seq_plate": "Plate1",
                                          "sample": "IPIADR001.N1",
                                        },
+                                     },
+                                   },
+                                 }))
+      expect(WebMock).to have_requested(:post, /#{MAGMA_HOST}\/update/)
+                           .with(body: hash_including({
+                                   "revisions": {
+                                     "rna_seq": {
                                        "IPIBLAD001.T1.rna.live": {
                                          "rna_seq_plate": "Plate2",
                                          "sample": "IPIBLAD001.T1",
@@ -145,6 +152,13 @@ describe Polyphemus::IpiRnaSeqCreateRecordNamesEtl do
                                        "Control_Jurkat.Plate1": {
                                          "rna_seq_plate": "Plate1",
                                        },
+                                     },
+                                   },
+                                 }))
+      expect(WebMock).to have_requested(:post, /#{MAGMA_HOST}\/update/)
+                           .with(body: hash_including({
+                                   "revisions": {
+                                     "rna_seq": {
                                        "Control_UHR.Plate2": {
                                          "rna_seq_plate": "Plate2",
                                        },


### PR DESCRIPTION
For the IPI rna_seq create record ETL, warn on record creation failure and move on, instead of getting stuck. Currently stuck on IPIHNSC064.L1 records because that sample doesn't exist, and it's unclear right now what the right name should be...but we should be able to continue and process the remaining records.