### PR TITLE
Timur query fix crash changing column model

### DIFF
--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -120,12 +120,12 @@ export const getPath = (
   currentPath: number[]
 ): number[] => {
   if (!array) return [];
+  if (!Array.isArray(array)) array = [array];
 
   let index = array.indexOf(heading);
   if (index > -1) return currentPath.concat([index]);
 
   let innerPath: number[] = [];
-
   array.forEach((ele, index: number) => {
     if (Array.isArray(ele)) {
       let tempPath = getPath(ele, heading, currentPath.concat(index));

--- a/timur/lib/client/jsx/utils/query_graph.ts
+++ b/timur/lib/client/jsx/utils/query_graph.ts
@@ -75,14 +75,16 @@ export class QueryGraph {
     let results: string[][] = [];
 
     Object.keys(this.graph.parents[modelName]).forEach((p: string) => {
-      let innerPaths = this.parentPaths(p);
-      if (innerPaths.length === 0) {
-        results.push([p]);
-      } else {
-        innerPaths.forEach((parentPath: string[]) => {
-          parentPath.unshift(p);
-          results.push(parentPath);
-        });
+      if (p !== modelName) {
+        let innerPaths = this.parentPaths(p);
+        if (innerPaths.length === 0) {
+          results.push([p]);
+        } else {
+          innerPaths.forEach((parentPath: string[]) => {
+            parentPath.unshift(p);
+            results.push(parentPath);
+          });
+        }
       }
     });
 

--- a/timur/test/javascript/selectors/query_selectors.test.ts
+++ b/timur/test/javascript/selectors/query_selectors.test.ts
@@ -124,70 +124,94 @@ describe('selectMatrixAttributes', () => {
 });
 
 describe('pathToColumn', () => {
-  it('finds top-level headings', () => {
-    let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
-    expect(pathToColumn(input, 'bim@2', false)).toEqual('2');
+  describe('when expandMatrices is false', () => {
+    it('finds top-level headings', () => {
+      let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
+      expect(pathToColumn(input, 'bim@2', false)).toEqual('2');
+    });
+
+    it('returns -1 when no match', () => {
+      let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
+      expect(pathToColumn(input, 'kapow@1', false)).toEqual('-1');
+    });
+
+    it('finds root index for nested headings', () => {
+      let input = [
+        'foo',
+        ['bar', ['shallow']],
+        'bim',
+        ['blah', 'zap', ['deep', ['nesting']]]
+      ];
+      expect(pathToColumn(input, 'nesting@3', false)).toEqual('3');
+    });
   });
 
-  it('returns -1 when no match', () => {
-    let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
-    expect(pathToColumn(input, 'kapow@1', false)).toEqual('-1');
-  });
+  describe('when expandMatrices is true', () => {
+    it('finds top-level headings', () => {
+      let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
+      expect(pathToColumn(input, 'bim@2', true)).toEqual('2');
+    });
 
-  it('finds root index for nested headings', () => {
-    let input = [
-      'foo',
-      ['bar', ['shallow']],
-      'bim',
-      ['blah', 'zap', ['deep', ['nesting']]]
-    ];
-    expect(pathToColumn(input, 'nesting@3', false)).toEqual('3');
-  });
+    it('returns -1 when no match', () => {
+      let input = ['foo', 'bar', 'bim', ['blah', 'zap']];
+      expect(pathToColumn(input, 'kapow@1', true)).toEqual('-1');
+    });
 
-  it('returns full path when expanding matrices', () => {
-    let input = [
-      'foo',
-      ['bar', ['shallow']],
-      'bim',
-      ['blah', 'zap', ['deep', ['something', 'nesting']]]
-    ];
+    it('finds root index for nested headings', () => {
+      let input = [
+        'foo',
+        ['bar', ['shallow']],
+        'bim',
+        ['blah', 'zap', ['deep', ['nesting']]]
+      ];
+      expect(pathToColumn(input, 'nesting@3', true)).toEqual('3');
+    });
 
-    // Note that the values may seem counterintuitive, but the
-    //   query answer actually compacts out the "attribute",
-    //   which in these cases would be "bar" and "deep".
-    // Answer would be something like:
-    // answer = [
-    //  1,
-    //  [2],
-    //  3,
-    //  [4, 5, [6, 7]]
-    // ]
-    expect(pathToColumn(input, 'bar@1.shallow', true)).toEqual('1.0');
-    expect(pathToColumn(input, 'deep@3.nesting', true)).toEqual('3.2.1');
-  });
+    it('returns full path when expanding matrices', () => {
+      let input = [
+        'foo',
+        ['bar', ['shallow']],
+        'bim',
+        ['blah', 'zap', ['deep', ['something', 'nesting']]]
+      ];
 
-  it('returns correct path for duplicate values', () => {
-    let input = [
-      'foo',
-      ['bar', ['shallow', 'deep']],
-      ['bar', ['shallow', 'deep']],
-      ['blah', 'zap', ['deep', ['something', 'nesting']]]
-    ];
+      // Note that the values may seem counterintuitive, but the
+      //   query answer actually compacts out the "attribute",
+      //   which in these cases would be "bar" and "deep".
+      // Answer would be something like:
+      // answer = [
+      //  1,
+      //  [2],
+      //  3,
+      //  [4, 5, [6, 7]]
+      // ]
+      expect(pathToColumn(input, 'bar@1.shallow', true)).toEqual('1.0');
+      expect(pathToColumn(input, 'deep@3.nesting', true)).toEqual('3.2.1');
+    });
 
-    // Note that the values may seem counterintuitive, but the
-    //   query answer actually compacts out the "attribute",
-    //   which in these cases would be "bar".
-    // Answer would be something like:
-    // answer = [
-    //  1,
-    //  [2, 3],
-    //  [4, 5],
-    //  [6, 7, [8, 9]]
-    // ]
-    expect(pathToColumn(input, 'bar@1.shallow', true)).toEqual('1.0');
-    expect(pathToColumn(input, 'bar@1.deep', true)).toEqual('1.1');
-    expect(pathToColumn(input, 'bar@2.shallow', true)).toEqual('2.0');
-    expect(pathToColumn(input, 'bar@2.deep', true)).toEqual('2.1');
+    it('returns correct path for duplicate values', () => {
+      let input = [
+        'foo',
+        ['bar', ['shallow', 'deep']],
+        ['bar', ['shallow', 'deep']],
+        ['blah', 'zap', ['deep', ['something', 'nesting']]]
+      ];
+
+      // Note that the values may seem counterintuitive, but the
+      //   query answer actually compacts out the "attribute",
+      //   which in these cases would be "bar".
+      // Answer would be something like:
+      // answer = [
+      //  1,
+      //  [2, 3],
+      //  [4, 5],
+      //  [6, 7, [8, 9]]
+      // ]
+      expect(pathToColumn(input, 'bar@1.shallow', true)).toEqual('1.0');
+      expect(pathToColumn(input, 'bar@1.deep', true)).toEqual('1.1');
+      expect(pathToColumn(input, 'bar@2.shallow', true)).toEqual('2.0');
+      expect(pathToColumn(input, 'bar@2.deep', true)).toEqual('2.1');
+    });
   });
 });
 


### PR DESCRIPTION
This PR fixes an issue where, when switching column models after the data frame is populated would cause the application to crash. Small change to insure that the path-finding always checks against an array, and add specs to account for the failing case.