### PR TITLE
work around error raised by autocomplete about uncontrolled / controlled

### DIFF
--- a/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
@@ -122,9 +122,11 @@ const AttributeSelector = React.memo(
       <FormControl className={classes.fullWidth}>
         <Autocomplete
           id={`${id(label)}-attribute`}
-          value={attributeChoiceSet.find(
-            (a: Attribute) => a.attribute_name === column.attribute_name
-          )}
+          value={
+            attributeChoiceSet.find(
+              (a: Attribute) => a.attribute_name === column.attribute_name
+            ) || null
+          }
           options={attributeChoiceSet}
           getOptionLabel={(option) => option.attribute_name}
           style={{width: 300}}


### PR DESCRIPTION
This PR should close #554. Turns out the Autocomplete component was throwing an error when you deleted a column, because for a brief moment in time, the selected `value` would be invalid, since the column model may have changed. Related to this [GH issue](https://github.com/mui-org/material-ui/issues/18173).

So this PR just sets to `null` when no valid match is found, which allows Autocomplete to behave properly when the attribute choice set lines up with the right column definition.