### PR TITLE
Whoops, when de-escalating privilege don't change project name while …

### DIFF
--- a/janus/lib/models/token.rb
+++ b/janus/lib/models/token.rb
@@ -74,7 +74,7 @@ module Token
         payload[:perm] = "v:#{project_name}" if read_only
       elsif payload[:perm] =~ /^[Aa]/
         # degrade admin permissions
-        payload[:perm] = payload[:perm].tr('Aa', 'Ee')
+        payload[:perm] = payload[:perm].sub(/^[Aa]/) { |c| c == 'A' ? 'E' : 'e' }
       end
 
       # Ensure the resulting permission is valid.

--- a/janus/spec/token_spec.rb
+++ b/janus/spec/token_spec.rb
@@ -151,9 +151,11 @@ describe "Token Generation" do
       @user = create(:user, name: 'Zeus Almighty', email: 'zeus@olympus.org')
       gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway')
       tunnel = create(:project, project_name: 'tunnel', project_name_full: 'Tunnel')
+      tannel = create(:project, project_name: 'tannel', project_name_full: 'Tunnel with an a')
       mirror = create(:project, project_name: 'mirror', project_name_full: 'Mirror')
 
       perm = create(:permission, project: tunnel, user: @user, role: 'administrator', privileged: true)
+      perm = create(:permission, project: tannel, user: @user, role: 'administrator', privileged: true)
       perm = create(:permission, project: mirror, user: @user, role: 'viewer')
     end
 
@@ -185,7 +187,7 @@ describe "Token Generation" do
       Timecop.freeze
 
       header('Authorization', "Etna #{@user.create_token!}")
-      post('/api/tokens/generate', project_name: 'tunnel', token_type: 'task')
+      post('/api/tokens/generate', project_name: 'tannel', token_type: 'task')
       expect(last_response.status).to eq(200)
 
       payload = header = nil
@@ -195,7 +197,7 @@ describe "Token Generation" do
       }.not_to raise_error
 
       # there is only one project on the token, with reduced permissions
-      expect(payload["perm"]).to eq('E:tunnel')
+      expect(payload["perm"]).to eq('E:tannel')
 
       expect(payload["task"]).to be_truthy
 


### PR DESCRIPTION
…we're at it, hehe.

A simple oversight, `tr` is aggressive in string replacement and was changing the project name underlying the task token.  Use `sub` which only effects the first character at most.