### PR TITLE
check that newParams exists

### DIFF
--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -107,7 +107,7 @@ const RunPane = ({run_interval,update,params,param_opts,selected}:{run_interval:
             <Grid alignItems='center' key={param_name} className={classes.param} container>
               <Grid item xs={4}>{param_name}</Grid>
               <Grid item xs={5}>
-                <Param name={param_name} value={newParams[param_name]} opts={param_opts[param_name]} update={
+                <Param name={param_name} value={newParams && newParams[param_name]} opts={param_opts[param_name]} update={
                   (name,value) => {
                     console.log({name, value});
                     setParams({...newParams, [name]: value});


### PR DESCRIPTION
When testing locally, I was getting a `TypeError: newParams is undefined` on this line when opening up an existing config, which caused a white-screen / crashed app. It might have been because I had a config created with an earlier version of the code? Anyways, seems like adding this check shouldn't hurt.