### PR TITLE
Use the root view for Vulcan

### DIFF
--- a/vulcan/lib/client/jsx/vulcan_ui.jsx
+++ b/vulcan/lib/client/jsx/vulcan_ui.jsx
@@ -13,6 +13,7 @@ import {selectUser} from 'etna-js/selectors/user-selector';
 
 import {showMessages} from 'etna-js/actions/message_actions';
 import {updateLocation} from 'etna-js/actions/location_actions';
+import RootView from 'etna-js/components/RootView';
 
 import {ModalDialogContainer} from 'etna-js/components/ModalDialogContainer';
 import {Notifications} from 'etna-js/components/Notifications';
@@ -21,18 +22,23 @@ import ReactModal from "react-modal";
 const ROUTES = [
   {
     template: '',
+    component: RootView,
+    mode: ''
+  },
+  {
+    template: ':project_name/',
     component: Dashboard,
-    mode: 'home'
+    mode: ''
   },
   {
     name: 'workflows',
-    template: 'workflow',
+    template: ':project_name/workflow',
     component: Browser,
     mode: 'workflow'
   },
   {
     name: 'workflow',
-    template: 'workflow/:projectName/:workflowName',
+    template: ':projectName/workflow/:workflowName',
     component: Browser,
     mode: 'workflow'
   }

--- a/vulcan/lib/server.rb
+++ b/vulcan/lib/server.rb
@@ -11,11 +11,6 @@ class Vulcan
       erb_view(:no_auth)
     end
 
-    # root path
-    get '/', as: :root do
-      erb_view(:client)
-    end
-
     get 'api/workflows', action: 'workflows#fetch', as: :workflows_view, auth: { user: { active?: true, has_flag?: 'vulcan' } }
     get 'api/:project_name/data/:cell_hash/:data_filename', action: 'data#fetch', as: :data_view, match_ext: true, auth: { user: { can_view?: :project_name, has_flag?: 'vulcan' } }
     post 'api/:project_name/session/:workflow_name/status', action: 'sessions#status', as: :status_view, match_ext: true, auth: { user: { can_view?: :project_name, has_flag?: 'vulcan' } }
@@ -24,14 +19,18 @@ class Vulcan
     with auth: { user: { active?: true, has_flag?: 'vulcan' } } do
 
       # remaining view routes are parsed by the client and must also be set there
-      get 'workflow', as: :workflow do
+      get '/:project_name/workflow', as: :workflow do
         erb_view(:client)
       end
 
-      get 'workflow/*view_path', as: :workflow_view do
+      get '/:project_name/workflow/*view_path', as: :workflow_view do
         erb_view(:client)
       end
     end
+
+    # root path
+    get '/', as: :root do erb_view(:client) end
+    get '/:project_name', as: :root do erb_view(:client) end
 
     def initialize
       super


### PR DESCRIPTION
A small one which adds the default root view to Vulcan and splits the workflows by project, similar to the way other etna apps are setup. This has the disadvantage of disappearing a "see all the workflows even if you can't run them" view, which seems ok to me, but I solicit your opinions on the tradeoff.