### PR TITLE
Mount the vulcan cache in archimedes instances

### DIFF
--- a/vulcan/lib/orchestration.rb
+++ b/vulcan/lib/orchestration.rb
@@ -102,6 +102,8 @@ class Vulcan
         "-v",
         "/var/run/docker.sock:/var/run/docker.sock:ro",
         "-v",
+        "/app/data/built/#{session.project_name}:/app/built:ro",
+        "-v",
         "#{Vulcan.instance.config(:archimedes_exec_volume)}:/archimedes-exec",
         Vulcan.instance.config(:archimedes_run_image),
         "poetry",

--- a/vulcan/lib/server/workflows/scdge.cwl
+++ b/vulcan/lib/server/workflows/scdge.cwl
@@ -48,7 +48,7 @@ steps:
     run: scripts/dge_grab_obs.cwl
     label: 'Extract metadata Options'
     in:
-      scdata.h5ad: mockSetup/scdata.h5ad
+      data_url: 1_Data_Selection__vulcan_cache_url
     out: [metadata]
     
   setDEMethods:

--- a/vulcan/lib/server/workflows/scripts/dge_grab_obs.py
+++ b/vulcan/lib/server/workflows/scripts/dge_grab_obs.py
@@ -1,7 +1,11 @@
 from archimedes.functions.dataflow import input_path, output_path
 from archimedes.functions.scanpy import scanpy as sc
+from archimedes.functions.environment import project_name
 
-scdata = sc.read(input_path('scdata.h5ad'))
+data_target = "/app/built" + input_path('data_url').split(project_name)[1]
+
+# scdata = sc.read(input_path('data_url'))
+scdata = sc.read(data_target)
 metadata = scdata.obs
 
 metadata.to_json(output_path("metadata"))


### PR DESCRIPTION
Pairing with @graft, we discussed an idea for sharing data between workflows which we think is fairly simple, and which can be made safe if we set up vulcan to rely on 'viewer-level-only + non-PHI' task tokens.  We could then, safely, make the project's cache available, read-only, to the archimedes instances created for running workflow steps.  And then, sharing data across workflows could be as simple as having a `copy url` button next to the data output of workflow 1 (eg: the umap_workflow_anndata.h5ad of the UMAP workflow) which a user would then provide as a string input to workflow 2 (eg: the dge workflow).

This cache sharing idea is exemplified in the current commits, although it doesn't quite work.