### PR TITLE
IPI Single Cell Processed Pool

### DIFF
--- a/polyphemus/lib/etls/add_watch_folder_base_etl.rb
+++ b/polyphemus/lib/etls/add_watch_folder_base_etl.rb
@@ -36,8 +36,8 @@ class Polyphemus::AddWatchFolderBaseEtl < Polyphemus::MetisFolderFilteringBaseEt
     {}.tap do |watch_type_groups|
       folders.each do |folder|
         bucket_config(cursor).find_matching_watches(folder.folder_path).each do |watch_config|
-          folders = watch_type_groups[watch_config.watch_type] ||= []
-          folders << folder
+          f = watch_type_groups[watch_config.watch_type] ||= []
+          f << folder
         end
       end
     end

--- a/polyphemus/lib/etls/add_watch_folder_base_etl.rb
+++ b/polyphemus/lib/etls/add_watch_folder_base_etl.rb
@@ -44,8 +44,7 @@ class Polyphemus::AddWatchFolderBaseEtl < Polyphemus::MetisFolderFilteringBaseEt
   end
 
   def process(cursor, folders)
-    # We'll need to filter out the folders based on folder_name here, using the
-    #   supplied regexes
+    # We'll need to filter out the folders based on folder_name here, using the supplied regexes.
     logger.info("Found #{folders.length} updated matching folders: #{folders.map { |f| f.folder_path }.join(",")}")
 
     target_folders = filter_target_folders(cursor, folders)

--- a/polyphemus/lib/etls/ipi/ipi_etls.rb
+++ b/polyphemus/lib/etls/ipi/ipi_etls.rb
@@ -17,19 +17,32 @@ class Polyphemus
         process_watch_type_with(
           bucket('data')
             .watcher('single_cell_pool_processed')
-            .watch(/^single_cell_GEX\/.*\/[^\/]*POOL[^\/]*\/.*$/),
+            .watch(/^single_cell_[^\/]*\/processed\/.*\/[^\/]+POOL[^\/]+\/.*$/),
           Polyphemus::LinkerProcessor.new(
             linker: SingleCellLinker.new,
             model_name: 'sc_rna_seq_pool'
           ),
         )
+
+        process_watch_type_with(
+          bucket('data')
+            .watcher('single_cell_processed')
+            .watch(/^single_cell_[^\/]*\/processed\/((?!POOL).)*$/),
+          Polyphemus::LinkerProcessor.new(
+            linker: SingleCellLinker.new(
+              record_name_regex: /.*\/(?<record_name>.*)\/.*$/
+            ),
+            model_name: 'sc_rna_seq',
+          ),
+        )
       end
 
       class SingleCellLinker < Polyphemus::SingleCellProcessedLinker
-        def initialize
+        def initialize(**kwds)
           super(
             project_name: 'ipi',
             bucket_name: 'data',
+            **kwds
           )
         end
 

--- a/polyphemus/lib/etls/ipi/linkers/ipi_rna_seq_files_linker_base.rb
+++ b/polyphemus/lib/etls/ipi/linkers/ipi_rna_seq_files_linker_base.rb
@@ -9,7 +9,7 @@ class Polyphemus::IpiRnaSeqFilesLinkerBase < Polyphemus::MetisFilesLinkerBase
     @helper = IpiHelper.new
   end
 
-  def link(model_name:, files:)
+  def link(model_name:, files:, cursor: nil)
     super(
       model_name: model_name,
       files_by_record_name: organize_metis_files_by_magma_record(
@@ -18,6 +18,7 @@ class Polyphemus::IpiRnaSeqFilesLinkerBase < Polyphemus::MetisFilesLinkerBase
         path_regex: @record_name_regex,
       ),
       attribute_regex: @attribute_regex,
+      cursor: cursor,
     )
   end
 

--- a/polyphemus/lib/etls/ipi/record_creators/ipi_rna_seq_and_plate_record_creator.rb
+++ b/polyphemus/lib/etls/ipi/record_creators/ipi_rna_seq_and_plate_record_creator.rb
@@ -69,7 +69,9 @@ class Polyphemus::IpiRnaSeqAndPlateRecordCreator
       unless @helper.is_control?(folder_name)
         attrs[:sample] = sample_name(record_name)
         if attrs[:sample].nil?
-          notify_slack("Skipping non control record without valid sample name #{record_name}.", channel: 'data-ingest-errors')
+          notify_slack(
+            "Skipping non control record without valid sample name #{record_name}.",
+            channel: 'data-ingest-errors')
           next
         end
       end
@@ -82,7 +84,9 @@ class Polyphemus::IpiRnaSeqAndPlateRecordCreator
         logger.info("Creating rna_seq records: #{update_request.revisions["rna_seq"].keys.join(",")}")
         magma_client.update_json(update_request)
       rescue Exception => e
-        notify_slack("Error creating IPI rna_seq record #{record_name}.\n#{e.message}.", channel: 'data-ingest-ping')
+        notify_slack(
+          "Error creating IPI rna_seq record #{record_name}.\n#{e.message}.",
+          channel: 'data-ingest-errors')
         logger.log_error(e)
       end
     end

--- a/polyphemus/lib/etls/linker_processor.rb
+++ b/polyphemus/lib/etls/linker_processor.rb
@@ -14,6 +14,7 @@ class Polyphemus::LinkerProcessor
     linker.link(
       model_name: model_name,
       files: files,
+      cursor: cursor,
     )
   end
 end

--- a/polyphemus/lib/etls/metis_files_linker_base.rb
+++ b/polyphemus/lib/etls/metis_files_linker_base.rb
@@ -137,7 +137,9 @@ class Polyphemus::MetisFilesLinkerBase
   end
 
   def is_file_collection?(project_name, model_name, attribute_name)
-    magma_models(project_name).model(model_name).template.attributes.attribute(attribute_name.to_s).attribute_type == Etna::Clients::Magma::AttributeType::FILE_COLLECTION
+    attribute = magma_models(project_name).model(model_name).template.attributes.attribute(attribute_name.to_s)
+    raise "Unknown linker attribute #{attribute_name}" if attribute.nil?
+    attribute.attribute_type == Etna::Clients::Magma::AttributeType::FILE_COLLECTION
   end
 
   def corrected_record_name(record_name)
@@ -156,15 +158,14 @@ class Polyphemus::MetisFilesLinkerBase
     path_regex:,
     record_name_gsub_pair: nil
   )
+    logger.info("Files #{metis_files}")
     metis_files_by_record_name = metis_files.group_by do |file|
       next if file.file_path.nil?
       match = file.file_path.match(path_regex)
 
       if match
         record_name = corrected_record_name(match[:record_name])
-
         record_name = record_name.gsub(record_name_gsub_pair.first, record_name_gsub_pair.last) if record_name_gsub_pair
-
         record_name
       else
         nil

--- a/polyphemus/lib/etls/metis_files_linker_base.rb
+++ b/polyphemus/lib/etls/metis_files_linker_base.rb
@@ -53,7 +53,7 @@ class Polyphemus::MetisFilesLinkerBase
       linked_models[record_name] = 1
     end
 
-    Yabeda.linker.identified_records.set({
+    Yabeda.linker.linked_attributes.set({
       project_name: project_name,
       model_name: model_name,
       attribute_name: attribute_name,

--- a/polyphemus/lib/etls/metis_files_linker_base.rb
+++ b/polyphemus/lib/etls/metis_files_linker_base.rb
@@ -29,10 +29,10 @@ class Polyphemus::MetisFilesLinkerBase
       cur_records[file_record.record_name] = 0
     end
 
-    Yabeda.linker.identified_records.set(cur_records.length, {
+    Yabeda.linker.identified_records.set({
       project_name: project_name,
       model_name: model_name
-    })
+    }, cur_records.length)
   end
 
   def count_attribute_links(cursor, model_name, attribute_name, record_name, payloads_for_attr)
@@ -53,12 +53,12 @@ class Polyphemus::MetisFilesLinkerBase
       linked_models[record_name] = 1
     end
 
-    Yabeda.linker.identified_records.set(linked_models.length, {
+    Yabeda.linker.identified_records.set({
       project_name: project_name,
       model_name: model_name,
       attribute_name: attribute_name,
       attribute_type: attribute.attribute_type
-    })
+    }, linked_models.length)
   end
 
   # Important!  If files_by_record_name includes files to be included in a file collection, /all files belonging to that collection must be present/.

--- a/polyphemus/lib/etls/metis_files_linker_base.rb
+++ b/polyphemus/lib/etls/metis_files_linker_base.rb
@@ -158,7 +158,6 @@ class Polyphemus::MetisFilesLinkerBase
     path_regex:,
     record_name_gsub_pair: nil
   )
-    logger.info("Files #{metis_files}")
     metis_files_by_record_name = metis_files.group_by do |file|
       next if file.file_path.nil?
       match = file.file_path.match(path_regex)
@@ -172,12 +171,15 @@ class Polyphemus::MetisFilesLinkerBase
       end
     end
 
-    magma_record_names.map do |magma_record_name|
-      next if metis_files_by_record_name[magma_record_name].nil?
+    metis_files_by_record_name.keys.map do |matched_record_name|
+      unless magma_record_names.include?(matched_record_name)
+        logger.info("Could not find magma record matching file record #{matched_record_name}")
+        next
+      end
 
       MetisFilesForMagmaRecord.new(
-        magma_record_name,
-        metis_files_by_record_name[magma_record_name]
+        matched_record_name,
+        metis_files_by_record_name[matched_record_name]
       )
     end.compact
   end

--- a/polyphemus/lib/etls/project_watch_folders_etl.rb
+++ b/polyphemus/lib/etls/project_watch_folders_etl.rb
@@ -19,8 +19,10 @@ class Polyphemus::ProjectWatchFoldersEtl < Polyphemus::AddWatchFolderBaseEtl
     bucket_name = cursor[:bucket_name]
 
     processors = config.file_processors(bucket_name, watch_type)
+    logger.info("Found #{processors.length} processors to handle folder files, running")
     return if processors.empty?
     files = folders_files(cursor, folders)
+    logger.info("Found #{files.length} inside #{folders.length} folders")
     processors.each { |p| p.process(cursor, files) }
   end
 
@@ -28,6 +30,7 @@ class Polyphemus::ProjectWatchFoldersEtl < Polyphemus::AddWatchFolderBaseEtl
     bucket_name = cursor[:bucket_name]
 
     processors = config.folder_processors(bucket_name, watch_type)
+    logger.info("Found #{processors.length} processors to handle folders, running")
     return if processors.empty?
     processors.each { |p| p.process(cursor, folders) }
   end

--- a/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
+++ b/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
@@ -1,0 +1,58 @@
+class Polyphemus
+  class SingleCellRawLinker < Polyphemus::MetisFilesLinkerBase
+  end
+
+  class SingleCellProcessedLinker < Polyphemus::MetisFilesLinkerBase
+    # Record name is two directories above a file
+    RECORD_NAME_REGEX = /.*\/(?<record_name>.*)\/[^\/]*\/[^\/]*$/
+
+    def initialize(
+      project_name:,
+      bucket_name:,
+      attribute_regex_overrides: {},
+      record_name_regex: RECORD_NAME_REGEX
+    )
+      super(project_name: project_name, bucket_name: bucket_name)
+      @attribute_regex_overrides = attribute_regex_overrides
+      @record_name_regex = record_name_regex
+    end
+
+    def link(model_name:, files:)
+      super(
+        model_name: model_name,
+        files_by_record_name: organize_metis_files_by_magma_record(
+          metis_files: files,
+          magma_record_names: current_magma_record_names(project_name, model_name),
+          path_regex: @record_name_regex,
+        ),
+        attribute_regex: attribute_regex,
+      )
+    end
+
+    def attribute_regex
+      {
+        # # only if CITE-seq
+        "cite_antibody_key": /^ADT_keep_features\.list$/,
+        "mux_index_key": /^IDX_map\.tsv$/,
+        "processed_robject_rdata": /.*_scTransformed_processed\.RData$/,
+        "processed_umap": /.*_umap\.pdf$/,
+        "processing_pipeline_parameters": /^cutoffs\.yml$/,
+        "filtered_counts_h5": /^filtered_feature_bc_matrix\.h5$/,
+        "raw_counts_h5": /^raw_feature_bc_matrix\.h5$/,
+        "tenx_aligned_bam": /^possorted_genome_bam\.bam$/,
+        "tenx_aligned_bam_index": /^possorted_genome_bam\.bam\.bai$/,
+        "tenx_cloupe_file": /^cloupe\.cloupe$/,
+        "tenx_metrics_csv": /^metrics_summary\.csv$/,
+        "tenx_molecule_info_h5": /^molecule_info\.h5$/,
+        "tenx_web_summary": /^web_summary\.html$/,
+      }.update(@attribute_regex_overrides)
+    end
+
+    def corrected_record_name(record_name)
+    end
+
+    def should_skip_record?(record_name)
+      false
+    end
+  end
+end

--- a/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
+++ b/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
@@ -17,7 +17,7 @@ class Polyphemus
       @record_name_regex = record_name_regex
     end
 
-    def link(model_name:, files:)
+    def link(model_name:, files:, cursor: nil)
       super(
         model_name: model_name,
         files_by_record_name: organize_metis_files_by_magma_record(
@@ -26,6 +26,7 @@ class Polyphemus
           path_regex: @record_name_regex,
         ),
         attribute_regex: attribute_regex,
+        cursor: cursor,
       )
     end
 

--- a/polyphemus/lib/polyphemus.rb
+++ b/polyphemus/lib/polyphemus.rb
@@ -28,6 +28,24 @@ class Polyphemus
     require_relative 'models/models'
   end
 
+  def setup_yabeda
+    Yabeda.configure do
+      group :linker do
+        gauge :linked_attributes do
+          comment "The number of files linked for each attribute"
+          tags [:project_name, :model_name, :attribute_type, :attribute_name]
+        end
+
+        gauge :identified_records do
+          comment "The number of records identified by the linker"
+          tags [:project_name, :model_name]
+        end
+      end
+    end
+
+    super
+  end
+
   def setup_ssh
     ssh_dir = ::File.expand_path(".ssh", "~")
     FileUtils.mkdir_p(ssh_dir)


### PR DESCRIPTION
This introduces the ability to process and link single cell pool data attributes.

It is missing a few computed attributes, and the raw fast q linkage which requires a change in magma attribute to file collection.  It also is missing non pool data, and the prometheus metrics.  But, this core bit works (tested in production) so wanted to ship this part first, to be followed up on.