### PR TITLE
fix issue with redacting hashes

### DIFF
--- a/etna/lib/etna/censor.rb
+++ b/etna/lib/etna/censor.rb
@@ -1,0 +1,36 @@
+module Etna
+  class Censor
+    def initialize(log_redact_keys)
+      @log_redact_keys = log_redact_keys
+    end
+
+    def redact_keys
+      @log_redact_keys
+    end
+
+    def redact(key, value)
+      # Redact any values for the supplied key values, so they
+      #   don't appear in the logs.
+      return compact(value) unless redact_keys
+
+      if redact_keys.include?(key)
+        return "*"
+      elsif value.is_a?(Hash)
+        redacted_value = value.map do |value_key, value_value|
+          [value_key, redact(value_key, value_value)]
+        end.to_h
+        return redacted_value
+      end
+
+      return compact(value)
+    end
+
+    private
+
+    def compact(value)
+      value = value.to_s
+      value = value[0..500] + "..." + value[-100..-1] if value.length > 600
+      value
+    end
+  end
+end

--- a/etna/spec/censor_spec.rb
+++ b/etna/spec/censor_spec.rb
@@ -1,0 +1,19 @@
+describe Etna::Censor do
+  it "redacts keys if they are hashes" do
+    censor = Etna::Censor.new([:secret_hash])
+
+    result = censor.redact(:secret_hash, {
+      something: ["I don't want to reveal"],
+    })
+
+    expect(result).to eq("*")
+  end
+
+  it "redacts keys if they are strings" do
+    censor = Etna::Censor.new([:secret_value])
+
+    result = censor.redact(:secret_value, "I don't want to reveal")
+
+    expect(result).to eq("*")
+  end
+end


### PR DESCRIPTION
So, turns out that the log redaction wasn't actually working because the key was a hash (verified locally and on production), because the if / else statement was not catching the polyphemus route's case. This updates the logic so that hashes are redacted, too, by checking the key first against `log_redact_keys` before attempting to recursively check nested hash keys. Previous behavior only worked when the log_redact_key was a "leaf" key.

Also extracts the redaction to a censor module, for easier testing.