### PR TITLE
Move Etna request logging from Route to Controller

### DIFF
--- a/etna/lib/etna/controller.rb
+++ b/etna/lib/etna/controller.rb
@@ -106,7 +106,11 @@ module Etna
         [ key, @censor.redact(key, value) ]
       end.to_h
 
-      log("User #{@user ? @user.email : :unknown} calling #{self.class.name.sub("Kernel::", "").sub("Controller", "").downcase}##{@action} with params #{redacted_params}")
+      log("User #{@user ? @user.email : :unknown} calling #{controller_name}##{@action} with params #{redacted_params}")
+    end
+
+    def controller_name
+      self.class.name.sub("Kernel::", "").sub("Controller", "").downcase
     end
 
     def success(msg, content_type='text/plain')

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -14,6 +14,7 @@ module Etna
       @route = route.gsub(/\A(?=[^\/])/, '/')
       @block = block
       @match_ext = options[:match_ext]
+      @log_redact_keys = options[:log_redact_keys]
     end
 
     def to_hash
@@ -125,6 +126,8 @@ module Etna
         return [ 403, { 'Content-Type' => 'application/json' }, [ { error: 'You are forbidden from performing this action.' }.to_json ] ]
       end
 
+      request.env['etna.route_log_redact_keys'] = @log_redact_keys
+
       if @action
         controller, action = @action.split('#')
         controller_class = Kernel.const_get(
@@ -132,9 +135,6 @@ module Etna
         )
         logger = request.env['etna.logger']
         user = request.env['etna.user']
-        require 'pry'
-        binding.pry
-        request.env['etna.route_log_redact_keys'] = @log_redact_keys
 
         return controller_class.new(request, action).response
       elsif @block

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -14,8 +14,6 @@ module Etna
       @route = route.gsub(/\A(?=[^\/])/, '/')
       @block = block
       @match_ext = options[:match_ext]
-
-      @censor = Etna::Censor.new(options[:log_redact_keys])
     end
 
     def to_hash
@@ -134,12 +132,10 @@ module Etna
         )
         logger = request.env['etna.logger']
         user = request.env['etna.user']
+        require 'pry'
+        binding.pry
+        request.env['etna.route_log_redact_keys'] = @log_redact_keys
 
-        params = request.env['rack.request.params'].map do |key,value|
-          [ key, @censor.redact(key, value) ]
-        end.to_h
-
-        logger.warn("User #{user ? user.email : :unknown} calling #{controller}##{action} with params #{params}")
         return controller_class.new(request, action).response
       elsif @block
         application = Etna::Application.find(app.class).class

--- a/etna/spec/controller_spec.rb
+++ b/etna/spec/controller_spec.rb
@@ -67,6 +67,7 @@ describe Etna::Controller do
 
       output = <<EOT
 # Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {}
 ERROR:2000-01-01T00:00:00+00:00 8fzmq8 Exiting with 403, You cannot do that.
 EOT
       expect(File.read(@log_file)).to eq(output)
@@ -90,16 +91,17 @@ EOT
       expect(last_response.status).to eq(500)
       output = <<EOT
 # Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {}
 ERROR:2000-01-01T00:00:00+00:00 8fzmq8 Caught unspecified error
 ERROR:2000-01-01T00:00:00+00:00 8fzmq8 Something broke.
 EOT
       # it reports the error
       log_contents = File.foreach(@log_file).to_a
-      expect(log_contents[0..2].join).to eq(output)
+      expect(log_contents[0..3].join).to eq(output)
 
       # it reports backtraces
       BACKTRACE = %r!(/[^/]+)+:[0-9]+:in `.*'!
-      expect(log_contents[3..-1]).to all( match(BACKTRACE) )
+      expect(log_contents[4..-1]).to all( match(BACKTRACE) )
     end
 
     it 'redacts keys defined in route' do

--- a/etna/spec/controller_spec.rb
+++ b/etna/spec/controller_spec.rb
@@ -118,33 +118,20 @@ EOT
 
       get('/test')
       expect(last_response.status).to eq(200)
-      output = <<EOT
-# Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
-WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {}
-EOT
-      # it reports the error
-      log_contents = File.foreach(@log_file).to_a
-      expect(log_contents[0..1].join).to eq(output)
 
       get('/test?secret=foo')
       expect(last_response.status).to eq(200)
-      output = <<EOT
-# Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
-WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {:secret => "*"}
-EOT
-      # it reports the error
-      log_contents = File.foreach(@log_file).to_a
-      expect(log_contents[1..2].join).to eq(output)
 
       get('/test?not_secret=bar')
       expect(last_response.status).to eq(200)
       output = <<EOT
-# Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
-WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {:not_secret => "bar"}
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {}
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {:secret=>"*"}
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User janus@two-faces.org calling etna::# with params {:not_secret=>"bar"}
 EOT
-      # it reports the error
+      # it reports the requests
       log_contents = File.foreach(@log_file).to_a
-      expect(log_contents[2..3].join).to eq(output)
+      expect(log_contents[1..3].join).to eq(output)
     end
   end
 end

--- a/magma/lib/magma/server/update.rb
+++ b/magma/lib/magma/server/update.rb
@@ -34,11 +34,11 @@ class UpdateController < Magma::Controller
   end
 
   def redact_keys
-    route_redact_keys = super
-    route_redact_keys ? route_redact_keys.concat(dateshift_redact_keys).uniq : dateshift_redact_keys
+    dateshift_redact_keys.concat(@route_log_redact_keys || []).uniq
   end
 
   def dateshift_redact_keys
+    # Make sure the keys are symbols?
     []
   end
 end

--- a/magma/lib/magma/server/update.rb
+++ b/magma/lib/magma/server/update.rb
@@ -32,4 +32,13 @@ class UpdateController < Magma::Controller
     @errors.concat(m.complaints)
     return nil
   end
+
+  def redact_keys
+    route_redact_keys = super
+    route_redact_keys ? route_redact_keys.concat(dateshift_redact_keys).uniq : dateshift_redact_keys
+  end
+
+  def dateshift_redact_keys
+    []
+  end
 end


### PR DESCRIPTION
In preparation of doing date-shifting in Magma itself, this PR moves the request logging from the Route definition into the Controller. This allows the Magma update controller to add in additional keys to redact from the log -- so my thought (not fully formed yet, though), is that once we define a "shifted date" type attribute (and possibly a "shifted age" type dictionary entry?), the update controller can find all of those for a given project and redact those keys, too, so we're not accidentally storing the raw, unshifted data? Hopefully that seems reasonable and makes sense.

Current logging behavior for all apps and routes should be the exact same as now, except we might see some additional logging for routes without the `#action` parameter in the route definitions. Typically things like root path requests, where the server is just rendering an ERB template.