### PR TITLE
Timur reset data frame on query

### DIFF
--- a/timur/lib/client/jsx/components/query/query_control_buttons.tsx
+++ b/timur/lib/client/jsx/components/query/query_control_buttons.tsx
@@ -75,6 +75,8 @@ const QueryControlButtons = () => {
   const [lastOrFilterIndices, setLastOrFilterIndices] = useState(
     defaultQueryWhereParams.orRecordFilterIndices
   );
+  const [lastExpandMatrices, setLastExpandMatrices] = useState(expandMatrices);
+  const [lastFlattenQuery, setLastFlattenQuery] = useState(flattenQuery);
   const [lastPage, setLastPage] = useState(page);
   const [lastPageSize, setLastPageSize] = useState(pageSize);
 
@@ -137,13 +139,29 @@ const QueryControlButtons = () => {
   useEffect(() => {
     // At some point, we can probably cache data and only
     //   fetch when needed?
-    if (lastPage !== page || lastPageSize !== pageSize) {
-      runQuery().then(() => {
-        setLastPage(page);
-        setLastPageSize(pageSize);
-      });
+    if (
+      lastPage !== page ||
+      lastPageSize !== pageSize ||
+      lastExpandMatrices !== expandMatrices ||
+      lastFlattenQuery !== flattenQuery
+    ) {
+      runQuery();
+      setLastPage(page);
+      setLastPageSize(pageSize);
+      setLastExpandMatrices(expandMatrices);
+      setLastFlattenQuery(flattenQuery);
     }
-  }, [page, pageSize, lastPage, lastPageSize, runQuery]);
+  }, [
+    page,
+    pageSize,
+    lastPage,
+    lastPageSize,
+    runQuery,
+    expandMatrices,
+    flattenQuery,
+    lastExpandMatrices,
+    lastFlattenQuery
+  ]);
 
   useEffect(() => {
     if (JSON.stringify(query) !== queryString)
@@ -177,11 +195,10 @@ const QueryControlButtons = () => {
   ]);
 
   const handleRunQuery = useCallback(() => {
-    runQuery().then(() => {
-      setLastColumns(columns);
-      setLastFilters(recordFilters);
-      setLastOrFilterIndices(orRecordFilterIndices);
-    });
+    runQuery();
+    setLastColumns(columns);
+    setLastFilters(recordFilters);
+    setLastOrFilterIndices(orRecordFilterIndices);
   }, [runQuery, columns, recordFilters, orRecordFilterIndices]);
 
   if (!rootModel) return null;

--- a/timur/lib/client/jsx/components/query/query_control_buttons.tsx
+++ b/timur/lib/client/jsx/components/query/query_control_buttons.tsx
@@ -1,5 +1,7 @@
 import React, {useMemo, useContext, useEffect, useState} from 'react';
 import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ReplayIcon from '@material-ui/icons/Replay';
 import ShareIcon from '@material-ui/icons/Share';
 
@@ -25,7 +27,7 @@ import useResultsActions from './query_use_results_actions';
 
 const useStyles = makeStyles((theme) => ({
   button: {
-    marginRight: '5px'
+    marginLeft: '5px'
   }
 }));
 
@@ -47,13 +49,20 @@ const QueryControlButtons = () => {
     setWhereState
   } = useContext(QueryWhereContext);
   const {
-    state: {pageSize, page, data, expandMatrices, flattenQuery, queryString},
+    state: {
+      pageSize,
+      page,
+      data,
+      expandMatrices,
+      flattenQuery,
+      queryString,
+      maxColumns
+    },
     setQueryString,
     setDataAndNumRecords,
     setResultsState
   } = useContext(QueryResultsContext);
   const classes = useStyles();
-  const maxColumns = 10;
 
   useEffect(() => {
     setLastPage(page);
@@ -95,11 +104,13 @@ const QueryControlButtons = () => {
     return builder.count();
   }, [builder]);
 
-  const {
-    columns: formattedColumns,
-    rows,
-    formatRowData
-  } = useTableEffects({columns, data, graph, expandMatrices, maxColumns});
+  const {columns: formattedColumns, formatRowData} = useTableEffects({
+    columns,
+    data,
+    graph,
+    expandMatrices,
+    maxColumns
+  });
 
   const {runQuery, downloadData} = useResultsActions({
     countQuery: count,
@@ -141,29 +152,47 @@ const QueryControlButtons = () => {
   if (!rootModel) return null;
 
   return (
-    <React.Fragment>
-      <Button
-        className={classes.button}
-        color='default'
-        onClick={resetQuery}
-        startIcon={<ReplayIcon />}
-      >
-        Reset Query
-      </Button>
-      <Button className={classes.button} color='secondary' onClick={runQuery}>
-        Query
-      </Button>
-      <Button className={classes.button} onClick={downloadData}>
-        {'\u21af TSV'}
-      </Button>
-      <Button
-        className={classes.button}
-        onClick={copyLink}
-        startIcon={<ShareIcon />}
-      >
-        Copy Link
-      </Button>
-    </React.Fragment>
+    <Grid
+      item
+      container
+      direction='column'
+      justify='flex-end'
+      alignItems='flex-end'
+    >
+      <Grid item>
+        <Button
+          className={classes.button}
+          color='default'
+          onClick={resetQuery}
+          startIcon={<ReplayIcon />}
+        >
+          Reset Query
+        </Button>
+        <Button className={classes.button} color='secondary' onClick={runQuery}>
+          Query
+        </Button>
+        <Button className={classes.button} onClick={downloadData}>
+          {'\u21af TSV'}
+        </Button>
+        <Button
+          className={classes.button}
+          onClick={copyLink}
+          startIcon={<ShareIcon />}
+        >
+          Copy Link
+        </Button>
+      </Grid>
+      <Grid item>
+        {formattedColumns.length > maxColumns ? (
+          <Typography align='right' color='error'>
+            *** NOTE ***{' '}
+            {(formattedColumns.length - maxColumns).toLocaleString()} columns
+            not rendered. Add slices to your matrix columns or download the TSV
+            to see the whole data frame.
+          </Typography>
+        ) : null}
+      </Grid>
+    </Grid>
   );
 };
 

--- a/timur/lib/client/jsx/components/query/query_control_buttons.tsx
+++ b/timur/lib/client/jsx/components/query/query_control_buttons.tsx
@@ -24,10 +24,6 @@ import {
   QueryWhereContext,
   defaultQueryWhereParams
 } from '../../contexts/query/query_where_context';
-import {
-  QueryResultsContext,
-  defaultQueryResultsParams
-} from '../../contexts/query/query_results_context';
 import {QueryBuilder} from '../../utils/query_builder';
 import {
   QueryResponse,
@@ -65,15 +61,15 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const QueryResults = () => {
+const QueryControlButtons = () => {
   const [expandMatrices, setExpandMatrices] = useState(true);
   const [flattenQuery, setFlattenQuery] = useState(true);
   const [lastPage, setLastPage] = useState(0);
-  // const [page, setPage] = useState(0);
+  const [page, setPage] = useState(0);
   const [lastPageSize, setLastPageSize] = useState(10);
-  // const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(10);
   const [data, setData] = useState({} as QueryResponse);
-  // const [numRecords, setNumRecords] = useState(0);
+  const [numRecords, setNumRecords] = useState(0);
   const {
     state: {graph, rootModel},
     setRootModel
@@ -86,11 +82,6 @@ const QueryResults = () => {
     state: {recordFilters, orRecordFilterIndices},
     setWhereState
   } = useContext(QueryWhereContext);
-  const {
-    state: {pageSize, page, numRecords},
-    setPageSize,
-    setPage
-  } = useContext(QueryResultsContext);
   const classes = useStyles();
   const maxColumns = 10;
 
@@ -184,51 +175,30 @@ const QueryResults = () => {
   if (!rootModel) return null;
 
   return (
-    <Grid container className={classes.resultsPane}>
-      <CodeMirror
-        className={classes.result}
-        options={{
-          readOnly: 'no-cursor',
-          lineWrapping: true,
-          mode: 'application/json',
-          autoCloseBrackets: true,
-          lint: false,
-          background: 'none',
-          tabSize: 2
-        }}
-        value={JSON.stringify(query)}
-        onBeforeChange={(editor, data, value) => {}}
-      />
-      <Grid xs={12} item container direction='column'>
-        <Grid className={classes.config} item container justify='flex-end'>
-          <AntSwitch
-            checked={expandMatrices}
-            onChange={() => setExpandMatrices(!expandMatrices)}
-            name='expand-matrices-query'
-            leftOption='Nest matrices'
-            rightOption='Expand matrices'
-          />
-          <AntSwitch
-            checked={flattenQuery}
-            onChange={() => setFlattenQuery(!flattenQuery)}
-            name='flatten-query'
-            leftOption='Nested'
-            rightOption='Flattened'
-          />
-        </Grid>
-        <QueryTable
-          maxColumns={maxColumns}
-          columns={formattedColumns}
-          rows={rows}
-          pageSize={pageSize}
-          numRecords={numRecords}
-          page={page}
-          handlePageChange={handlePageChange}
-          handlePageSizeChange={handlePageSizeChange}
-        />
-      </Grid>
-    </Grid>
+    <React.Fragment>
+      <Button
+        className={classes.button}
+        color='default'
+        onClick={resetQuery}
+        startIcon={<ReplayIcon />}
+      >
+        Reset Query
+      </Button>
+      <Button className={classes.button} color='secondary' onClick={runQuery}>
+        Query
+      </Button>
+      <Button className={classes.button} onClick={downloadData}>
+        {'\u21af TSV'}
+      </Button>
+      <Button
+        className={classes.button}
+        onClick={copyLink}
+        startIcon={<ShareIcon />}
+      >
+        Copy Link
+      </Button>
+    </React.Fragment>
   );
 };
 
-export default QueryResults;
+export default QueryControlButtons;

--- a/timur/lib/client/jsx/components/query/query_from_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_from_pane.tsx
@@ -1,9 +1,14 @@
 import React, {useCallback, useContext} from 'react';
 
+import Grid from '@material-ui/core/Grid';
+
 import {QueryGraphContext} from '../../contexts/query/query_graph_context';
 import {QueryColumnContext} from '../../contexts/query/query_column_context';
+import {QueryResultsContext} from '../../contexts/query/query_results_context';
+import {EmptyQueryResponse} from '../../contexts/query/query_types';
 import QueryModelSelector from './query_model_selector';
 import QueryClause from './query_clause';
+import QueryControlButtons from './query_control_buttons';
 
 const QueryFromPane = () => {
   const {
@@ -11,6 +16,7 @@ const QueryFromPane = () => {
     setRootModel
   } = useContext(QueryGraphContext);
   const {setRootIdentifierColumn} = useContext(QueryColumnContext);
+  const {setDataAndNumRecords} = useContext(QueryResultsContext);
 
   const onRootModelSelect = useCallback(
     (modelName: string) => {
@@ -22,18 +28,26 @@ const QueryFromPane = () => {
         display_label: `${modelName}.${template.identifier}`,
         slices: []
       });
+      setDataAndNumRecords(EmptyQueryResponse, 0);
     },
-    [graph, setRootModel, setRootIdentifierColumn]
+    [graph, setRootModel, setRootIdentifierColumn, setDataAndNumRecords]
   );
 
   return (
     <QueryClause title='From'>
-      <QueryModelSelector
-        label='Root Model'
-        modelValue={rootModel || ''}
-        modelChoiceSet={[...graph.allowedModels]}
-        onSelectModel={(modelName) => onRootModelSelect(modelName)}
-      />
+      <Grid item container>
+        <Grid item xs={8}>
+          <QueryModelSelector
+            label='Root Model'
+            modelValue={rootModel || ''}
+            modelChoiceSet={[...graph.allowedModels]}
+            onSelectModel={(modelName) => onRootModelSelect(modelName)}
+          />
+        </Grid>
+        <Grid item container alignItems='center' justify='flex-end' xs={4}>
+          {rootModel ? <QueryControlButtons /> : null}
+        </Grid>
+      </Grid>
     </QueryClause>
   );
 };

--- a/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
@@ -1,11 +1,11 @@
 import React, {useCallback, useState, useContext, useEffect} from 'react';
 import Grid from '@material-ui/core/Grid';
-import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import ClearIcon from '@material-ui/icons/Clear';
+import FileCopyIcon from '@material-ui/icons/FileCopyOutlined';
 import Tooltip from '@material-ui/core/Tooltip';
 import {makeStyles} from '@material-ui/core/styles';
 import Autocomplete from '@material-ui/lab/Autocomplete';
@@ -29,6 +29,20 @@ const useStyles = makeStyles((theme) => ({
     minWidth: 120
   }
 }));
+
+const CopyColumnIcon = React.memo(
+  ({canEdit, copyColumn}: {canEdit: boolean; copyColumn: () => void}) => {
+    if (!canEdit) return null;
+
+    return (
+      <Tooltip title='Copy column' aria-label='copy column'>
+        <IconButton aria-label='copy column' onClick={copyColumn}>
+          <FileCopyIcon color='action' />
+        </IconButton>
+      </Tooltip>
+    );
+  }
+);
 
 const RemoveColumnIcon = React.memo(
   ({canEdit, removeColumn}: {canEdit: boolean; removeColumn: () => void}) => {
@@ -139,7 +153,8 @@ const QueryModelAttributeSelector = React.memo(
     onSelectModel,
     onSelectAttribute,
     onChangeLabel,
-    onRemoveColumn
+    onRemoveColumn,
+    onCopyColumn
   }: {
     label: string;
     column: QueryColumn;
@@ -151,6 +166,7 @@ const QueryModelAttributeSelector = React.memo(
     onSelectAttribute: (attributeName: string) => void;
     onChangeLabel: (label: string) => void;
     onRemoveColumn: () => void;
+    onCopyColumn: () => void;
   }) => {
     const [selectableModelAttributes, setSelectableModelAttributes] = useState(
       [] as Attribute[]
@@ -235,6 +251,7 @@ const QueryModelAttributeSelector = React.memo(
             <Grid item xs={7}></Grid>
           )}
           <Grid item container justify='flex-end' xs={1}>
+            <CopyColumnIcon canEdit={canEdit} copyColumn={onCopyColumn} />
             <RemoveColumnIcon canEdit={canEdit} removeColumn={onRemoveColumn} />
           </Grid>
         </Grid>

--- a/timur/lib/client/jsx/components/query/query_page.tsx
+++ b/timur/lib/client/jsx/components/query/query_page.tsx
@@ -7,6 +7,7 @@ import {requestModels} from 'etna-js/actions/magma_actions';
 import {QueryColumnProvider} from '../../contexts/query/query_column_context';
 import {QueryWhereProvider} from '../../contexts/query/query_where_context';
 import {QueryGraphProvider} from '../../contexts/query/query_graph_context';
+import {QueryResultsProvider} from '../../contexts/query/query_results_context';
 import QueryBuilder from './query_builder';
 
 const QueryPage = ({}) => {
@@ -21,11 +22,13 @@ const QueryPage = ({}) => {
       <QueryGraphProvider>
         <QueryColumnProvider>
           <QueryWhereProvider>
-            <Grid container direction='column' className='query-page'>
-              <Grid item xs={12}>
-                <QueryBuilder />
+            <QueryResultsProvider>
+              <Grid container direction='column' className='query-page'>
+                <Grid item xs={12}>
+                  <QueryBuilder />
+                </Grid>
               </Grid>
-            </Grid>
+            </QueryResultsProvider>
           </QueryWhereProvider>
         </QueryColumnProvider>
       </QueryGraphProvider>

--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -25,7 +25,10 @@ import {
   defaultQueryWhereParams
 } from '../../contexts/query/query_where_context';
 import {QueryBuilder} from '../../utils/query_builder';
-import {QueryResponse} from '../../contexts/query/query_types';
+import {
+  QueryResponse,
+  EmptyQueryResponse
+} from '../../contexts/query/query_types';
 import QueryTable from './query_table';
 import useTableEffects from './query_use_table_effects';
 import useResultsActions from './query_use_results_actions';
@@ -65,7 +68,6 @@ const QueryResults = () => {
   const [page, setPage] = useState(0);
   const [lastPageSize, setLastPageSize] = useState(10);
   const [pageSize, setPageSize] = useState(10);
-  const [queries, setQueries] = useState([] as string[][]);
   const [data, setData] = useState({} as QueryResponse);
   const [numRecords, setNumRecords] = useState(0);
   const {
@@ -161,6 +163,7 @@ const QueryResults = () => {
 
   function resetQuery() {
     setRootModel(null);
+    setData(EmptyQueryResponse);
     setQueryColumns(defaultQueryColumnParams.columns);
     setWhereState(defaultQueryWhereParams);
   }
@@ -203,9 +206,6 @@ const QueryResults = () => {
             leftOption='Nested'
             rightOption='Flattened'
           />
-          <Button className={classes.button} disabled>
-            Previous Queries
-          </Button>
           <Button
             className={classes.button}
             color='default'

--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -83,8 +83,6 @@ const QueryResults = () => {
 
   if (!rootModel) return null;
 
-  console.log('numRecords', numRecords);
-
   return (
     <Grid container className={classes.resultsPane}>
       <CodeMirror

--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -50,7 +50,8 @@ const QueryResults = () => {
       queryString,
       data,
       expandMatrices,
-      flattenQuery
+      flattenQuery,
+      maxColumns
     },
     setPageSize,
     setPage,
@@ -58,7 +59,6 @@ const QueryResults = () => {
     setFlattenQuery
   } = useContext(QueryResultsContext);
   const classes = useStyles();
-  const maxColumns = 10;
 
   const {columns: formattedColumns, rows} = useTableEffects({
     columns,

--- a/timur/lib/client/jsx/components/query/query_select_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_select_pane.tsx
@@ -147,6 +147,7 @@ const QuerySelectPane = () => {
             }
             onChangeLabel={(label) => handleOnChangeLabel(index, column, label)}
             onRemoveColumn={() => handleOnRemoveColumn(index)}
+            onCopyColumn={() => addQueryColumn({...column})}
           />
         );
       })}

--- a/timur/lib/client/jsx/components/query/query_slice_model_attribute_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_model_attribute_pane.tsx
@@ -69,7 +69,7 @@ const QuerySliceModelAttributePane = ({
       </Tooltip>
       <Grid container direction='column' className={classes.grid}>
         {column?.slices.map((slice: QuerySlice, index: number) => (
-          <Paper className={classes.paper}>
+          <Paper className={classes.paper} key={index}>
             <Grid container spacing={1} alignItems='center'>
               <QueryFilterControl
                 key={`model-${column.model_name}-${index}-${updateCounter}`}

--- a/timur/lib/client/jsx/components/query/query_table.tsx
+++ b/timur/lib/client/jsx/components/query/query_table.tsx
@@ -16,10 +16,6 @@ import {QueryTableColumn} from '../../contexts/query/query_types';
 const useStyles = makeStyles({
   table: {
     minWidth: 650
-  },
-  columnWarning: {
-    color: 'red',
-    paddingRight: '0.6rem'
   }
 });
 
@@ -57,13 +53,6 @@ const QueryTable = ({
         direction='column'
         alignItems='flex-end'
       >
-        {columns.length > maxColumns ? (
-          <Typography className={classes.columnWarning}>
-            *** NOTE *** {(columns.length - maxColumns).toLocaleString()}{' '}
-            columns not rendered. Add slices to your matrix columns or download
-            the TSV to see the whole data frame.
-          </Typography>
-        ) : null}
         <TablePagination
           rowsPerPageOptions={[10, 25, 50, 200]}
           component='div'

--- a/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
@@ -8,6 +8,7 @@ import {downloadTSV, MatrixDatum} from 'etna-js/utils/tsv';
 import {ReactReduxContext} from 'react-redux';
 import {
   QueryResponse,
+  EmptyQueryResponse,
   QueryTableColumn
 } from '../../contexts/query/query_types';
 
@@ -39,6 +40,7 @@ const useResultsActions = ({
     if ('' === countQuery || '' === query) return;
 
     let exchange = new Exchange(store.dispatch, 'query-post-magma');
+    setData(EmptyQueryResponse);
     getAnswer({query: countQuery}, exchange)
       .then((countData) => {
         setNumRecords(countData.answer);

--- a/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
@@ -41,7 +41,7 @@ const useResultsActions = ({
 
     let exchange = new Exchange(store.dispatch, 'query-post-magma');
     setDataAndNumRecords(EmptyQueryResponse, 0);
-    return getAnswer({query: countQuery}, exchange)
+    getAnswer({query: countQuery}, exchange)
       .then((countData) => {
         numRecords = countData.answer;
         return getAnswer(

--- a/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
@@ -35,13 +35,13 @@ const useResultsActions = ({
   const invoke = useActionInvoker();
 
   const runQuery = useCallback(() => {
-    if ('' === countQuery || '' === query) return;
+    if ('' === countQuery || '' === query) return new Promise(() => {});
 
     let numRecords = 0;
 
     let exchange = new Exchange(store.dispatch, 'query-post-magma');
     setDataAndNumRecords(EmptyQueryResponse, 0);
-    getAnswer({query: countQuery}, exchange)
+    return getAnswer({query: countQuery}, exchange)
       .then((countData) => {
         numRecords = countData.answer;
         return getAnswer(

--- a/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
@@ -35,7 +35,7 @@ const useResultsActions = ({
   const invoke = useActionInvoker();
 
   const runQuery = useCallback(() => {
-    if ('' === countQuery || '' === query) return new Promise(() => {});
+    if ('' === countQuery || '' === query) return;
 
     let numRecords = 0;
 

--- a/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_results_actions.tsx
@@ -19,8 +19,7 @@ const useResultsActions = ({
   pageSize,
   rootModel,
   formattedColumns,
-  setData,
-  setNumRecords,
+  setDataAndNumRecords,
   formatRowData
 }: {
   countQuery: string | any[];
@@ -29,8 +28,7 @@ const useResultsActions = ({
   pageSize: number;
   rootModel: string | null;
   formattedColumns: QueryTableColumn[];
-  setData: (data: QueryResponse) => void;
-  setNumRecords: (count: number) => void;
+  setDataAndNumRecords: (data: QueryResponse, count: number) => void;
   formatRowData: (data: QueryResponse, columns: QueryTableColumn[]) => any[];
 }) => {
   let {store} = useContext(ReactReduxContext);
@@ -39,18 +37,20 @@ const useResultsActions = ({
   const runQuery = useCallback(() => {
     if ('' === countQuery || '' === query) return;
 
+    let numRecords = 0;
+
     let exchange = new Exchange(store.dispatch, 'query-post-magma');
-    setData(EmptyQueryResponse);
+    setDataAndNumRecords(EmptyQueryResponse, 0);
     getAnswer({query: countQuery}, exchange)
       .then((countData) => {
-        setNumRecords(countData.answer);
+        numRecords = countData.answer;
         return getAnswer(
           {query, page_size: pageSize, page: page + 1},
           exchange
         );
       })
       .then((answerData) => {
-        setData(answerData);
+        setDataAndNumRecords(answerData, numRecords);
         // setQueries([...queries].splice(0, 0, builder));
       })
       .catch((e) => {
@@ -59,7 +59,15 @@ const useResultsActions = ({
           invoke(showMessages(error.errors || [error.error] || error));
         });
       });
-  }, [query, countQuery, pageSize, page, invoke, store.dispatch]);
+  }, [
+    query,
+    countQuery,
+    pageSize,
+    page,
+    invoke,
+    store.dispatch,
+    setDataAndNumRecords
+  ]);
 
   const downloadData = useCallback(() => {
     if ('' === query) return;

--- a/timur/lib/client/jsx/components/query/query_use_table_effects.tsx
+++ b/timur/lib/client/jsx/components/query/query_use_table_effects.tsx
@@ -98,7 +98,7 @@ const useTableEffects = ({
   );
 
   const rows = useMemo(() => {
-    if (!data || !data.answer) return;
+    if (!data || !data.answer || data.answer.length === 0) return;
 
     // Need to order the results the same as `formattedColumns`
     return formatRowData(data, formattedColumns.slice(0, maxColumns));

--- a/timur/lib/client/jsx/contexts/query/query_results_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_results_context.tsx
@@ -5,12 +5,11 @@ import {QueryResponse} from './query_types';
 export const defaultQueryResultsParams = {
   expandMatrices: true,
   flattenQuery: true,
-  lastPage: 0,
   page: 0,
-  lastPageSize: 10,
   pageSize: 10,
   data: {} as QueryResponse,
-  numRecords: 0
+  numRecords: 0,
+  queryString: ''
 };
 
 const defaultQueryResultsState = {
@@ -23,12 +22,11 @@ export const defaultQueryResultsContext = {
   state: defaultQueryResultsState as QueryResultsState,
   setExpandMatrices: (expandMatrices: boolean) => {},
   setFlattenQuery: (flattenQuery: boolean) => {},
-  setLastPage: (lastPage: number) => {},
   setPage: (page: number) => {},
-  setLastPageSize: (lastPageSize: number) => {},
   setPageSize: (pageSize: number) => {},
-  setData: (data: QueryResponse) => {},
-  setNumRecords: (numRecords: number) => {}
+  setDataAndNumRecords: (data: QueryResponse, numRecords: number) => {},
+  setQueryString: (queryString: string) => {},
+  setResultsState: (newState: QueryResultsState) => {}
 };
 
 export type QueryResultsContextData = typeof defaultQueryResultsContext;
@@ -56,73 +54,60 @@ export const QueryResultsProvider = (
 
   const setFlattenQuery = useCallback(
     (flattenQuery: boolean) => {
-      return {
+      setState({
         ...state,
         flattenQuery
-      };
-    },
-    [state]
-  );
-
-  const setLastPage = useCallback(
-    (lastPage: number) => {
-      return {
-        ...state,
-        lastPage
-      };
+      });
     },
     [state]
   );
 
   const setPage = useCallback(
     (page: number) => {
-      return {
+      setState({
         ...state,
         page
-      };
-    },
-    [state]
-  );
-
-  const setLastPageSize = useCallback(
-    (lastPageSize: number) => {
-      return {
-        ...state,
-        lastPageSize
-      };
+      });
     },
     [state]
   );
 
   const setPageSize = useCallback(
     (pageSize: number) => {
-      return {
+      setState({
         ...state,
         pageSize
-      };
+      });
     },
     [state]
   );
 
-  const setData = useCallback(
-    (data: QueryResponse) => {
-      return {
+  const setDataAndNumRecords = useCallback(
+    (data: QueryResponse, numRecords: number) => {
+      setState({
         ...state,
-        data
-      };
-    },
-    [state]
-  );
-
-  const setNumRecords = useCallback(
-    (numRecords: number) => {
-      return {
-        ...state,
+        data,
         numRecords
-      };
+      });
     },
     [state]
   );
+
+  const setQueryString = useCallback(
+    (queryString: string) => {
+      setState({
+        ...state,
+        queryString
+      });
+    },
+    [state]
+  );
+
+  const setResultsState = useCallback((newState: QueryResultsState) => {
+    setState({
+      ...newState
+    });
+  }, []);
 
   return (
     <QueryResultsContext.Provider
@@ -130,12 +115,11 @@ export const QueryResultsProvider = (
         state,
         setExpandMatrices,
         setFlattenQuery,
-        setLastPage,
         setPage,
-        setLastPageSize,
         setPageSize,
-        setData,
-        setNumRecords
+        setDataAndNumRecords,
+        setQueryString,
+        setResultsState
       }}
     >
       {props.children}

--- a/timur/lib/client/jsx/contexts/query/query_results_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_results_context.tsx
@@ -9,7 +9,8 @@ export const defaultQueryResultsParams = {
   pageSize: 10,
   data: {} as QueryResponse,
   numRecords: 0,
-  queryString: ''
+  queryString: '',
+  maxColumns: 10
 };
 
 const defaultQueryResultsState = {

--- a/timur/lib/client/jsx/contexts/query/query_results_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_results_context.tsx
@@ -44,10 +44,10 @@ export const QueryResultsProvider = (
 
   const setExpandMatrices = useCallback(
     (expandMatrices: boolean) => {
-      return {
+      setState({
         ...state,
         expandMatrices
-      };
+      });
     },
     [state]
   );

--- a/timur/lib/client/jsx/contexts/query/query_results_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_results_context.tsx
@@ -1,0 +1,144 @@
+import React, {useState, createContext, useCallback} from 'react';
+
+import {QueryResponse} from './query_types';
+
+export const defaultQueryResultsParams = {
+  expandMatrices: true,
+  flattenQuery: true,
+  lastPage: 0,
+  page: 0,
+  lastPageSize: 10,
+  pageSize: 10,
+  data: {} as QueryResponse,
+  numRecords: 0
+};
+
+const defaultQueryResultsState = {
+  ...defaultQueryResultsParams
+};
+
+export type QueryResultsState = Readonly<typeof defaultQueryResultsState>;
+
+export const defaultQueryResultsContext = {
+  state: defaultQueryResultsState as QueryResultsState,
+  setExpandMatrices: (expandMatrices: boolean) => {},
+  setFlattenQuery: (flattenQuery: boolean) => {},
+  setLastPage: (lastPage: number) => {},
+  setPage: (page: number) => {},
+  setLastPageSize: (lastPageSize: number) => {},
+  setPageSize: (pageSize: number) => {},
+  setData: (data: QueryResponse) => {},
+  setNumRecords: (numRecords: number) => {}
+};
+
+export type QueryResultsContextData = typeof defaultQueryResultsContext;
+
+export const QueryResultsContext = createContext(defaultQueryResultsContext);
+export type QueryResultsContext = typeof QueryResultsContext;
+export type ProviderProps = {params?: {}; children: any};
+
+export const QueryResultsProvider = (
+  props: ProviderProps & Partial<QueryResultsContextData>
+) => {
+  const [state, setState] = useState(
+    props.state || defaultQueryResultsContext.state
+  );
+
+  const setExpandMatrices = useCallback(
+    (expandMatrices: boolean) => {
+      return {
+        ...state,
+        expandMatrices
+      };
+    },
+    [state]
+  );
+
+  const setFlattenQuery = useCallback(
+    (flattenQuery: boolean) => {
+      return {
+        ...state,
+        flattenQuery
+      };
+    },
+    [state]
+  );
+
+  const setLastPage = useCallback(
+    (lastPage: number) => {
+      return {
+        ...state,
+        lastPage
+      };
+    },
+    [state]
+  );
+
+  const setPage = useCallback(
+    (page: number) => {
+      return {
+        ...state,
+        page
+      };
+    },
+    [state]
+  );
+
+  const setLastPageSize = useCallback(
+    (lastPageSize: number) => {
+      return {
+        ...state,
+        lastPageSize
+      };
+    },
+    [state]
+  );
+
+  const setPageSize = useCallback(
+    (pageSize: number) => {
+      return {
+        ...state,
+        pageSize
+      };
+    },
+    [state]
+  );
+
+  const setData = useCallback(
+    (data: QueryResponse) => {
+      return {
+        ...state,
+        data
+      };
+    },
+    [state]
+  );
+
+  const setNumRecords = useCallback(
+    (numRecords: number) => {
+      return {
+        ...state,
+        numRecords
+      };
+    },
+    [state]
+  );
+
+  return (
+    <QueryResultsContext.Provider
+      value={{
+        state,
+        setExpandMatrices,
+        setFlattenQuery,
+        setLastPage,
+        setPage,
+        setLastPageSize,
+        setPageSize,
+        setData,
+        setNumRecords
+      }}
+    >
+      {props.children}
+    </QueryResultsContext.Provider>
+  );
+};

--- a/timur/lib/client/jsx/contexts/query/query_types.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_types.tsx
@@ -29,6 +29,12 @@ export interface QueryResponse {
   type: string;
 }
 
+export const EmptyQueryResponse: QueryResponse = {
+  answer: [],
+  format: [],
+  type: 'none'
+};
+
 export interface QueryTableColumn {
   label: string;
   colId: string;

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -1516,18 +1516,6 @@ exports[`QueryBuilder renders 1`] = `
           </label>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-disabled MuiButtonBase-disabled"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Previous Queries
-          </span>
-        </button>
-        <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
           tabindex="0"
           type="button"

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -17,43 +17,139 @@ exports[`QueryBuilder renders 1`] = `
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11"
       >
         <div
-          class="MuiFormControl-root makeStyles-formControl"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item"
         >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-            data-shrink="true"
-            id="Root Model-0.5"
-          >
-            Root Model
-          </label>
           <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-8"
           >
             <div
-              aria-haspopup="listbox"
-              aria-labelledby="Root Model-0.5"
-              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-              role="button"
-              tabindex="0"
+              class="MuiFormControl-root makeStyles-formControl"
             >
-              monster
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                data-shrink="true"
+                id="Root Model-0.5"
+              >
+                Root Model
+              </label>
+              <div
+                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  aria-labelledby="Root Model-0.5"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                  role="button"
+                  tabindex="0"
+                >
+                  monster
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="monster"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </div>
             </div>
-            <input
-              aria-hidden="true"
-              class="MuiSelect-nativeInput"
-              tabindex="-1"
-              value="monster"
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSelect-icon"
-              focusable="false"
-              viewBox="0 0 24 24"
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-4"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+              tabindex="0"
+              type="button"
             >
-              <path
-                d="M7 10l5 5 5-5z"
+              <span
+                class="MuiButton-label"
+              >
+                <span
+                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                    />
+                  </svg>
+                </span>
+                Reset Query
+              </span>
+              <span
+                class="MuiTouchRipple-root"
               />
-            </svg>
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                Query
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                ↯ TSV
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span
+                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+                    />
+                  </svg>
+                </span>
+                Copy Link
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </div>
       </div>
@@ -1515,90 +1611,6 @@ exports[`QueryBuilder renders 1`] = `
             </div>
           </label>
         </div>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-                />
-              </svg>
-            </span>
-            Reset Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            ↯ TSV
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
-                />
-              </svg>
-            </span>
-            Copy Link
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
       </div>
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end"

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -960,6 +960,31 @@ exports[`QueryBuilder renders 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
             >
               <button
+                aria-label="copy column"
+                class="MuiButtonBase-root MuiIconButton-root"
+                tabindex="0"
+                title="Copy column"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorAction"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
                 aria-label="remove column"
                 class="MuiButtonBase-root MuiIconButton-root"
                 tabindex="0"
@@ -1347,6 +1372,31 @@ exports[`QueryBuilder renders 1`] = `
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
             >
+              <button
+                aria-label="copy column"
+                class="MuiButtonBase-root MuiIconButton-root"
+                tabindex="0"
+                title="Copy column"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorAction"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
               <button
                 aria-label="remove column"
                 class="MuiButtonBase-root MuiIconButton-root"

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -66,90 +66,101 @@ exports[`QueryBuilder renders 1`] = `
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-4"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end"
             >
-              <span
-                class="MuiButton-label"
+              <div
+                class="MuiGrid-root MuiGrid-item"
               >
-                <span
-                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+                  tabindex="0"
+                  type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <span
+                    class="MuiButton-label"
                   >
-                    <path
-                      d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-                    />
-                  </svg>
-                </span>
-                Reset Query
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-label"
-              >
-                Query
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-label"
-              >
-                ↯ TSV
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-label"
-              >
-                <span
-                  class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                    <span
+                      class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                    Reset Query
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
+                  tabindex="0"
+                  type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <span
+                    class="MuiButton-label"
                   >
-                    <path
-                      d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
-                    />
-                  </svg>
-                </span>
-                Copy Link
-              </span>
-              <span
-                class="MuiTouchRipple-root"
+                    Query
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    ↯ TSV
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    <span
+                      class="MuiButton-startIcon MuiButton-iconSizeMedium"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+                        />
+                      </svg>
+                    </span>
+                    Copy Link
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item"
               />
-            </button>
+            </div>
           </div>
         </div>
       </div>

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -219,18 +219,6 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
           </label>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-disabled MuiButtonBase-disabled"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Previous Queries
-          </span>
-        </button>
-        <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
           tabindex="0"
           type="button"
@@ -688,18 +676,6 @@ exports[`QueryResults renders 1`] = `
             </div>
           </label>
         </div>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-disabled MuiButtonBase-disabled"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Previous Queries
-          </span>
-        </button>
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
           tabindex="0"

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
         class="CodeMirror cm-s-default CodeMirror-wrap"
       >
         <div
-          style="overflow: hidden; position: relative; width: 3px; height: 0px; top: 0px; left: 0px;"
+          style="overflow: hidden; position: relative; width: 3px; height: 0px;"
         >
           <textarea
             autocapitalize="off"
@@ -25,11 +25,10 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
         <div
           class="CodeMirror-vscrollbar"
           cm-not-content="true"
-          style="display: block; bottom: 0px;"
           tabindex="-1"
         >
           <div
-            style="min-width: 1px; height: 88px;"
+            style="min-width: 1px;"
           />
         </div>
         <div
@@ -38,7 +37,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
           tabindex="-1"
         >
           <div
-            style="height: 100%; min-height: 1px; width: 0px;"
+            style="height: 100%; min-height: 1px;"
           />
         </div>
         <div
@@ -55,7 +54,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
         >
           <div
             class="CodeMirror-sizer"
-            style="margin-left: 0px; padding-right: 0px; padding-bottom: 0px;"
+            style="margin-left: 0px;"
           >
             <div
               style="position: relative;"
@@ -70,22 +69,18 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
                 >
                   <div
                     class="CodeMirror-measure"
-                  />
-                  <div
-                    class="CodeMirror-measure"
                   >
                     <pre
-                      class="CodeMirror-line"
-                      role="presentation"
+                      class="CodeMirror-line-like"
                     >
-                      <span
-                        role="presentation"
-                        style="padding-right: .1px;"
-                      >
-                        ["monster",["labor",["year","::equals",2],"::any"],"::all",["name",["labor","prize",["name","::equals","Athens"],"::first","name"],["labor","contributions","::slice",["Athens","Sparta"]]]]
+                      <span>
+                        xxxxxxxxxx
                       </span>
                     </pre>
                   </div>
+                  <div
+                    class="CodeMirror-measure"
+                  />
                   <div
                     style="position: relative; z-index: 1;"
                   />
@@ -101,7 +96,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
             </div>
           </div>
           <div
-            style="position: absolute; height: 50px; width: 1px; border-bottom: 0px solid transparent;"
+            style="position: absolute; height: 50px; width: 1px;"
           />
           <div
             class="CodeMirror-gutters"
@@ -218,90 +213,6 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
             </div>
           </label>
         </div>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-                />
-              </svg>
-            </span>
-            Reset Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            ↯ TSV
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
-                />
-              </svg>
-            </span>
-            Copy Link
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
       </div>
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end"
@@ -470,7 +381,7 @@ exports[`QueryResults renders 1`] = `
         class="CodeMirror cm-s-default CodeMirror-wrap"
       >
         <div
-          style="overflow: hidden; position: relative; width: 3px; height: 0px; top: 0px; left: 0px;"
+          style="overflow: hidden; position: relative; width: 3px; height: 0px;"
         >
           <textarea
             autocapitalize="off"
@@ -483,11 +394,10 @@ exports[`QueryResults renders 1`] = `
         <div
           class="CodeMirror-vscrollbar"
           cm-not-content="true"
-          style="display: block; bottom: 0px;"
           tabindex="-1"
         >
           <div
-            style="min-width: 1px; height: 77px;"
+            style="min-width: 1px;"
           />
         </div>
         <div
@@ -496,7 +406,7 @@ exports[`QueryResults renders 1`] = `
           tabindex="-1"
         >
           <div
-            style="height: 100%; min-height: 1px; width: 0px;"
+            style="height: 100%; min-height: 1px;"
           />
         </div>
         <div
@@ -513,7 +423,7 @@ exports[`QueryResults renders 1`] = `
         >
           <div
             class="CodeMirror-sizer"
-            style="margin-left: 0px; padding-right: 0px; padding-bottom: 0px;"
+            style="margin-left: 0px;"
           >
             <div
               style="position: relative;"
@@ -528,22 +438,18 @@ exports[`QueryResults renders 1`] = `
                 >
                   <div
                     class="CodeMirror-measure"
-                  />
-                  <div
-                    class="CodeMirror-measure"
                   >
                     <pre
-                      class="CodeMirror-line"
-                      role="presentation"
+                      class="CodeMirror-line-like"
                     >
-                      <span
-                        role="presentation"
-                        style="padding-right: .1px;"
-                      >
-                        ["monster",["labor",["year","::equals",2],"::any"],"::all",["name",["labor","prize",["name","::equals","Athens"],"::first","name"]]]
+                      <span>
+                        xxxxxxxxxx
                       </span>
                     </pre>
                   </div>
+                  <div
+                    class="CodeMirror-measure"
+                  />
                   <div
                     style="position: relative; z-index: 1;"
                   />
@@ -559,7 +465,7 @@ exports[`QueryResults renders 1`] = `
             </div>
           </div>
           <div
-            style="position: absolute; height: 50px; width: 1px; border-bottom: 0px solid transparent;"
+            style="position: absolute; height: 50px; width: 1px;"
           />
           <div
             class="CodeMirror-gutters"
@@ -676,90 +582,6 @@ exports[`QueryResults renders 1`] = `
             </div>
           </label>
         </div>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-                />
-              </svg>
-            </span>
-            Reset Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button MuiButton-textSecondary"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            Query
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            ↯ TSV
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <span
-              class="MuiButton-startIcon MuiButton-iconSizeMedium"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
-                />
-              </svg>
-            </span>
-            Copy Link
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
       </div>
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end"

--- a/timur/test/javascript/components/query/query_builder.test.tsx
+++ b/timur/test/javascript/components/query/query_builder.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {mockStore, querySpecWrapper} from '../../helpers';
 import QueryBuilder from '../../../../lib/client/jsx/components/query/query_builder';
 import {QueryGraph} from '../../../../lib/client/jsx/utils/query_graph';
+import {defaultQueryResultsParams} from '../../../../lib/client/jsx/contexts/query/query_results_context';
 
 const models = {
   monster: {
@@ -66,7 +67,8 @@ describe('QueryBuilder', () => {
               modelName: 'prize',
               attributeName: 'name',
               operator: '::equals',
-              operand: 'Athens'
+              operand: 'Athens',
+              attributeType: 'text'
             }
           ]
         },
@@ -79,7 +81,8 @@ describe('QueryBuilder', () => {
               modelName: 'prize',
               attributeName: 'name',
               operator: '::equals',
-              operand: 'Sparta'
+              operand: 'Sparta',
+              attributeType: 'text'
             }
           ]
         }
@@ -99,7 +102,8 @@ describe('QueryBuilder', () => {
           attributeName: 'year',
           operator: '::=',
           operand: 2,
-          anyMap: {}
+          anyMap: {},
+          attributeType: 'number'
         }
       ]
     };
@@ -109,6 +113,7 @@ describe('QueryBuilder', () => {
         mockColumnState,
         mockGraphState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });

--- a/timur/test/javascript/components/query/query_results.test.tsx
+++ b/timur/test/javascript/components/query/query_results.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {mockStore, querySpecWrapper} from '../../helpers';
 import QueryResults from '../../../../lib/client/jsx/components/query/query_results';
 import {QueryGraph} from '../../../../lib/client/jsx/utils/query_graph';
+import {defaultQueryResultsParams} from '../../../../lib/client/jsx/contexts/query/query_results_context';
 
 const models = {
   monster: {
@@ -71,7 +72,8 @@ describe('QueryResults', () => {
               modelName: 'prize',
               attributeName: 'name',
               operator: '::equals',
-              operand: 'Athens'
+              operand: 'Athens',
+              attributeType: 'text'
             }
           ]
         }
@@ -86,7 +88,8 @@ describe('QueryResults', () => {
           attributeName: 'year',
           operator: '::equals',
           operand: 2,
-          anyMap: {}
+          anyMap: {},
+          attributeType: 'number'
         }
       ]
     };
@@ -96,6 +99,7 @@ describe('QueryResults', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });
@@ -136,7 +140,8 @@ describe('QueryResults', () => {
               modelName: 'prize',
               attributeName: 'name',
               operator: '::equals',
-              operand: 'Athens'
+              operand: 'Athens',
+              attributeType: 'text'
             }
           ]
         },
@@ -149,7 +154,8 @@ describe('QueryResults', () => {
               modelName: 'labor',
               attributeName: 'contributions',
               operator: '::slice',
-              operand: 'Athens,Sparta'
+              operand: 'Athens,Sparta',
+              attributeType: 'matrix'
             }
           ]
         }
@@ -164,7 +170,8 @@ describe('QueryResults', () => {
           attributeName: 'year',
           operator: '::equals',
           operand: 2,
-          anyMap: {}
+          anyMap: {},
+          attributeType: 'number'
         }
       ]
     };
@@ -174,6 +181,7 @@ describe('QueryResults', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });

--- a/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
+++ b/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
@@ -196,7 +196,8 @@ describe('useSliceMethods', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
-        mockResultsState: defaultQueryResultsParams
+        mockResultsState: defaultQueryResultsParams,
+        store
       })
     });
 

--- a/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
+++ b/timur/test/javascript/components/query/query_use_slice_methods.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {mockStore, querySpecWrapper} from '../../helpers';
 import useSliceMethods from '../../../../lib/client/jsx/components/query/query_use_slice_methods';
 import {QueryGraph} from '../../../../lib/client/jsx/utils/query_graph';
+import {defaultQueryResultsParams} from '../../../../lib/client/jsx/contexts/query/query_results_context';
 
 const models = {
   monster: {
@@ -107,6 +108,7 @@ describe('useSliceMethods', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });
@@ -150,6 +152,7 @@ describe('useSliceMethods', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });
@@ -193,7 +196,7 @@ describe('useSliceMethods', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
-        store
+        mockResultsState: defaultQueryResultsParams
       })
     });
 
@@ -230,6 +233,7 @@ describe('useSliceMethods', () => {
         mockGraphState,
         mockColumnState,
         mockWhereState,
+        mockResultsState: defaultQueryResultsParams,
         store
       })
     });

--- a/timur/test/javascript/components/query/query_use_table_effects.test.tsx
+++ b/timur/test/javascript/components/query/query_use_table_effects.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {mockStore, querySpecWrapper} from '../../helpers';
 import useTableEffects from '../../../../lib/client/jsx/components/query/query_use_table_effects';
 import {QueryGraph} from '../../../../lib/client/jsx/utils/query_graph';
+import {defaultQueryResultsParams} from '../../../../lib/client/jsx/contexts/query/query_results_context';
 
 const models = {
   monster: {
@@ -92,6 +93,7 @@ describe('useTableEffects', () => {
           mockGraphState,
           mockWhereState,
           mockColumnState,
+          mockResultsState: defaultQueryResultsParams,
           store
         })
       }
@@ -163,6 +165,7 @@ describe('useTableEffects', () => {
           mockGraphState,
           mockWhereState,
           mockColumnState,
+          mockResultsState: defaultQueryResultsParams,
           store
         })
       }
@@ -239,6 +242,7 @@ describe('useTableEffects', () => {
           mockGraphState,
           mockWhereState,
           mockColumnState,
+          mockResultsState: defaultQueryResultsParams,
           store
         })
       }
@@ -314,6 +318,7 @@ describe('useTableEffects', () => {
           mockGraphState,
           mockWhereState,
           mockColumnState,
+          mockResultsState: defaultQueryResultsParams,
           store
         })
       }
@@ -401,6 +406,7 @@ describe('useTableEffects', () => {
           mockGraphState,
           mockWhereState,
           mockColumnState,
+          mockResultsState: defaultQueryResultsParams,
           store
         })
       }

--- a/timur/test/javascript/helpers.tsx
+++ b/timur/test/javascript/helpers.tsx
@@ -18,6 +18,10 @@ import {
   QueryGraphProvider,
   QueryGraphState
 } from '../../lib/client/jsx/contexts/query/query_graph_context';
+import {
+  QueryResultsProvider,
+  QueryResultsState
+} from '../../lib/client/jsx/contexts/query/query_results_context';
 
 export const stubUrl = ({
   verb = 'get',
@@ -67,11 +71,13 @@ export const querySpecWrapper =
     mockColumnState,
     mockWhereState,
     mockGraphState,
+    mockResultsState,
     store
   }: {
     mockColumnState: QueryColumnState;
     mockWhereState: QueryWhereState;
     mockGraphState: QueryGraphState;
+    mockResultsState: QueryResultsState;
     store: typeof mockStore;
   }) =>
   ({children}: {children?: any}) =>
@@ -81,7 +87,9 @@ export const querySpecWrapper =
           <QueryGraphProvider state={mockGraphState}>
             <QueryColumnProvider state={mockColumnState}>
               <QueryWhereProvider state={mockWhereState}>
-                {children}
+                <QueryResultsProvider state={mockResultsState}>
+                  {children}
+                </QueryResultsProvider>
               </QueryWhereProvider>
             </QueryColumnProvider>
           </QueryGraphProvider>


### PR DESCRIPTION
This PR updates Query UI based on feedback from last week:

* Adds a "copy column" button to duplicate an existing column definition
* Moves the four buttons (reset, query, download TSV, copy link) to the top of the page (right of where you select the root model)
* Disables the Query button when the filters and columns match the data frame preview. Conversely, enables the button if you change the filters / root model / columns in any way.
* Clears the data frame when you Query, so if you get a Query error, it will be more obvious