### PR TITLE
Etl cursor groups should not stop for the first cursor with no work.

### DIFF
--- a/polyphemus/lib/etl.rb
+++ b/polyphemus/lib/etl.rb
@@ -123,8 +123,6 @@ class Polyphemus
         cursor.save_to_db
         next true
       end
-
-      false
     end
 
     # Subclasses should override with their processing loop.

--- a/polyphemus/lib/etl.rb
+++ b/polyphemus/lib/etl.rb
@@ -116,12 +116,12 @@ class Polyphemus
         logger.info("Attempting to process")
         if batch.empty? || process(cursor, batch) == :stop
           logger.info("No more work found, stopping.")
-          return false
+          next false
         end
 
         logger.info("Saving cursor to database")
         cursor.save_to_db
-        return true
+        next true
       end
 
       false

--- a/polyphemus/lib/etl_cursor.rb
+++ b/polyphemus/lib/etl_cursor.rb
@@ -79,17 +79,16 @@ class Polyphemus
     end
 
     def with_next(&block)
-      n = @cursors.inject(nil) do |acc, n|
-        if acc.nil?
-          n
-        elsif n.updated_at < acc.updated_at
-          n
-        else
-          acc
+      sorted_cursors = @cursors.sort_by(&:updated_at)
+
+      sorted_cursors.each do |cursor|
+        processed = yield cursor
+        if processed
+          return true
         end
       end
 
-      yield n unless n.nil?
+      false
     end
 
     def reset_all!

--- a/polyphemus/spec/etl_cursor_spec.rb
+++ b/polyphemus/spec/etl_cursor_spec.rb
@@ -106,10 +106,16 @@ describe Polyphemus::EtlCursorGroup do
         ]
       end
 
-      it 'yields the oldest cursor' do
+      it 'yields the oldest cursor first' do
         @yielded = false
-        group.with_next { |v| @yielded = v }
+        expect(group.with_next { |v| @yielded = v; true }).to eql(true)
         expect(@yielded).to eql(cursors.last)
+      end
+
+      it 'continues yielding on false' do
+        @yielded = []
+        expect(group.with_next { |v| @yielded << v; false }).to eql(false)
+        expect(@yielded).to eql([cursors[2], cursors[0], cursors[1]])
       end
     end
   end


### PR DESCRIPTION
Cursor groups can contain multiple cursors used to process an etl (such as when processing across different buckets).

Previously, the select one method would return the oldest cursor as part of the group for processing.  However, if that processing returns false from an empty batch, the etl would simply stop processing for the next cursor.

In this change, it still prefers processing one cursor at a time in order from oldest to newest, but, if any cursor ends up returning false with no processing, it continues forward.

ALSO:  Found out my yabeda metrics don't work quite due to the way metrics are dropping their files and competing.  I need to think a bit on this and come up with a better approach for etl metrics.  Coming soon.