### PR TITLE
Polyphemus redcap set record id field

### DIFF
--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.41)
+    etna (0.1.42)
       concurrent-ruby
       curb
       jwt
@@ -185,4 +185,4 @@ DEPENDENCIES
   yabeda-puma-plugin
 
 BUNDLED WITH
-   2.2.25
+   2.2.27

--- a/polyphemus/lib/etls/redcap/lib/loader.rb
+++ b/polyphemus/lib/etls/redcap/lib/loader.rb
@@ -47,8 +47,6 @@ module Redcap
         )
 
         project.fetch_records.each do |model_name, model_records|
-          require 'pry'
-          binding.pry
           records[model_name] = {} unless records.keys.include?(model_name)
           records[model_name].update(
             filter_records(model_name, model_records)

--- a/polyphemus/lib/etls/redcap/lib/loader.rb
+++ b/polyphemus/lib/etls/redcap/lib/loader.rb
@@ -47,6 +47,8 @@ module Redcap
         )
 
         project.fetch_records.each do |model_name, model_records|
+          require 'pry'
+          binding.pry
           records[model_name] = {} unless records.keys.include?(model_name)
           records[model_name].update(
             filter_records(model_name, model_records)

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -29,7 +29,7 @@ module Redcap
 
       # Set some default methods for each model
       Kernel.const_set(model_name, Class.new(Redcap::Model) {
-        def identifier(*record_id, redcap_record: nil)
+        def identifier(*record_id, identifier_fields: nil)
           [
               "::temp", *record_id, rand(36**8).to_s(36)
           ].compact.join('-')

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -23,7 +23,7 @@ module Redcap
 
       # Set some default methods for each model
       Kernel.const_set(model_name, Class.new(Redcap::Model) {
-        def identifier(*record_id)
+        def identifier(*record_id, redcap_record: nil)
           [
               "::temp", *record_id, rand(36**8).to_s(36)
           ].compact.join('-')
@@ -95,7 +95,7 @@ module Redcap
       records
     end
 
-    def offset_id(record_id)
+    def offset_id(record_id, redcap_record: nil)
       raise "offset_id() needs to be implemented for the #{@project.project_name} project, #{@model_name} class. It should return the patient / subject identifier."
     end
 
@@ -103,14 +103,14 @@ module Redcap
       nil
     end
 
-    def offset_days(record_id)
+    def offset_days(record_id, redcap_record: nil)
       @offset_days[record_id] ||=
         begin
           # the offset in days is computed from hmac of the record_id
           signature = OpenSSL::HMAC.hexdigest(
             'SHA256',
             @salt,
-            offset_id(record_id)
+            offset_id(record_id, redcap_record: redcap_record)
           )
 
           # we convert the hexadecimal string to a number in base 16.

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -7,6 +7,12 @@ module Redcap
           properties: {
             each: { "$ref": "#/definitions/each" },
             invert: { type: "boolean" },
+            identifier_fields: {
+              type: "array",
+              items: {
+                type: "string"
+              }
+            },
             scripts: {
               type: "array",
               items: { "$ref": "#/definitions/script" }
@@ -80,6 +86,12 @@ module Redcap
 
     def attribute_names
       @config[:attributes] || 'identifier'
+    end
+
+    def identifier_fields
+      (@config[:identifier_fields] || []).map do |id_field|
+        id_field.to_sym
+      end
     end
 
     def load

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -95,7 +95,7 @@ module Redcap
       records
     end
 
-    def offset_id(record_id, redcap_record: nil)
+    def offset_id(record_id)
       raise "offset_id() needs to be implemented for the #{@project.project_name} project, #{@model_name} class. It should return the patient / subject identifier."
     end
 
@@ -103,14 +103,14 @@ module Redcap
       nil
     end
 
-    def offset_days(record_id, redcap_record: nil)
+    def offset_days(record_id)
       @offset_days[record_id] ||=
         begin
           # the offset in days is computed from hmac of the record_id
           signature = OpenSSL::HMAC.hexdigest(
             'SHA256',
             @salt,
-            offset_id(record_id, redcap_record: redcap_record)
+            offset_id(record_id)
           )
 
           # we convert the hexadecimal string to a number in base 16.

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -89,9 +89,7 @@ module Redcap
     end
 
     def identifier_fields
-      (@config[:identifier_fields] || []).map do |id_field|
-        id_field.to_sym
-      end
+      @config[:identifier_fields] || []
     end
 
     def load

--- a/polyphemus/lib/etls/redcap/lib/project.rb
+++ b/polyphemus/lib/etls/redcap/lib/project.rb
@@ -48,8 +48,6 @@ module Redcap
     private
 
     def valid_fields
-      require 'pry'
-      binding.pry
       return @valid_fields if @valid_fields
 
       all_fields = models.map do |model_name, model|

--- a/polyphemus/lib/etls/redcap/lib/project.rb
+++ b/polyphemus/lib/etls/redcap/lib/project.rb
@@ -48,10 +48,12 @@ module Redcap
     private
 
     def valid_fields
+      require 'pry'
+      binding.pry
       return @valid_fields if @valid_fields
 
       all_fields = models.map do |model_name, model|
-        model.scripts.map(&:fields)
+        model.scripts.map(&:fields).concat(model.identifier_fields)
       end.flatten.compact.uniq
 
       @valid_fields = all_fields & template.field_names

--- a/polyphemus/lib/etls/redcap/lib/script.rb
+++ b/polyphemus/lib/etls/redcap/lib/script.rb
@@ -122,7 +122,7 @@ module Redcap
       update = {}
 
       redcap_records.each do |record_id, redcap_record|
-        magma_record_name = @model.identifier(*record_id, redcap_record: flat_record(record_id))
+        magma_record_name = @model.identifier(*record_id, identifier_fields: identifier_fields_data(record_id))
 
         next unless magma_record_name
 
@@ -162,6 +162,12 @@ module Redcap
       update.select do |id,record|
         !record.empty?
       end.to_h
+    end
+
+    def identifier_fields_data(record_id)
+      flat_record(record_id)&.slice(*(@model.identifier_fields.map do |field|
+        field.to_sym
+      end))
     end
   end
 end

--- a/polyphemus/lib/etls/redcap/lib/script.rb
+++ b/polyphemus/lib/etls/redcap/lib/script.rb
@@ -122,7 +122,7 @@ module Redcap
       update = {}
 
       redcap_records.each do |record_id, redcap_record|
-        magma_record_name = @model.identifier(*record_id)
+        magma_record_name = @model.identifier(*record_id, redcap_record: flat_record(record_id))
 
         next unless magma_record_name
 

--- a/polyphemus/lib/etls/redcap/lib/script.rb
+++ b/polyphemus/lib/etls/redcap/lib/script.rb
@@ -122,8 +122,6 @@ module Redcap
       update = {}
 
       redcap_records.each do |record_id, redcap_record|
-        require 'pry'
-        binding.pry
         magma_record_name = @model.identifier(*record_id, redcap_record: flat_record(record_id))
 
         next unless magma_record_name

--- a/polyphemus/lib/etls/redcap/lib/script.rb
+++ b/polyphemus/lib/etls/redcap/lib/script.rb
@@ -122,6 +122,8 @@ module Redcap
       update = {}
 
       redcap_records.each do |record_id, redcap_record|
+        require 'pry'
+        binding.pry
         magma_record_name = @model.identifier(*record_id, redcap_record: flat_record(record_id))
 
         next unless magma_record_name

--- a/polyphemus/spec/etls/redcap/loader_spec.rb
+++ b/polyphemus/spec/etls/redcap/loader_spec.rb
@@ -21,7 +21,7 @@ describe Redcap::Loader do
 
     it 'uses flat record values to replace regular values' do
       Redcap::Model.define("Model").class_eval do
-        def identifier(record_name, event_name, redcap_record: nil)
+        def identifier(record_name, event_name, identifier_fields: nil)
           event_name
         end
       end
@@ -96,7 +96,7 @@ describe Redcap::Loader do
 
     it 'iterates across records' do
       Redcap::Model.define("Make").class_eval do
-        def identifier(record_name, redcap_record: nil)
+        def identifier(record_name, identifier_fields: nil)
           record_name
         end
 
@@ -137,7 +137,7 @@ describe Redcap::Loader do
 
     it 'iterates across events' do
       Redcap::Model.define("Model").class_eval do
-        def identifier(record_name, event_name, redcap_record: nil)
+        def identifier(record_name, event_name, identifier_fields: nil)
           event_name
         end
       end
@@ -174,7 +174,7 @@ describe Redcap::Loader do
 
     it 'iterates across repeating instruments' do
       Redcap::Model.define("Year").class_eval do
-        def identifier(record_name, event_name, (repeat_instrument, repeat_id), redcap_record: nil )
+        def identifier(record_name, event_name, (repeat_instrument, repeat_id), identifier_fields: nil )
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end
@@ -275,7 +275,7 @@ describe Redcap::Loader do
 
     it 'combines across values' do
       Redcap::Model.define("Year").class_eval do
-        def identifier(record_name, event_name, (repeat_instrument, repeat_id), redcap_record: nil )
+        def identifier(record_name, event_name, (repeat_instrument, repeat_id), identifier_fields: nil )
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end

--- a/polyphemus/spec/etls/redcap/loader_spec.rb
+++ b/polyphemus/spec/etls/redcap/loader_spec.rb
@@ -21,7 +21,7 @@ describe Redcap::Loader do
 
     it 'uses flat record values to replace regular values' do
       Redcap::Model.define("Model").class_eval do
-        def identifier(record_name, event_name)
+        def identifier(record_name, event_name, redcap_record: nil)
           event_name
         end
       end
@@ -96,7 +96,7 @@ describe Redcap::Loader do
 
     it 'iterates across records' do
       Redcap::Model.define("Make").class_eval do
-        def identifier(record_name)
+        def identifier(record_name, redcap_record: nil)
           record_name
         end
 
@@ -137,7 +137,7 @@ describe Redcap::Loader do
 
     it 'iterates across events' do
       Redcap::Model.define("Model").class_eval do
-        def identifier(record_name, event_name)
+        def identifier(record_name, event_name, redcap_record: nil)
           event_name
         end
       end
@@ -174,7 +174,7 @@ describe Redcap::Loader do
 
     it 'iterates across repeating instruments' do
       Redcap::Model.define("Year").class_eval do
-        def identifier(record_name, event_name, (repeat_instrument, repeat_id) )
+        def identifier(record_name, event_name, (repeat_instrument, repeat_id), redcap_record: nil )
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end
@@ -275,7 +275,7 @@ describe Redcap::Loader do
 
     it 'combines across values' do
       Redcap::Model.define("Year").class_eval do
-        def identifier(record_name, event_name, (repeat_instrument, repeat_id) )
+        def identifier(record_name, event_name, (repeat_instrument, repeat_id), redcap_record: nil )
           [ record_name, event_name, repeat_id ].join(' ')
         end
       end

--- a/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
+++ b/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
@@ -85,8 +85,7 @@ describe Polyphemus::RedcapEtlScriptRunner do
       scripts: [
         {
           attributes: {
-            name: "name",
-            alternate_id: "date_of_birth"
+            name: "date_of_birth",
           }
         }
       ]
@@ -318,16 +317,17 @@ describe Polyphemus::RedcapEtlScriptRunner do
       expect(records.keys.include?(:model_with_alternate_id)).to eq(true)
 
       # Only finds records with all the fields in the CONFIG, which
-      #   should be :name and :date_of_birth
+      #   should be :date_of_birth
       expect(records[:model_with_alternate_id].keys.length).to eq(2)
 
-      data_789 = data_for_id('789')
-      data_987 = data_for_id('987')
+      data_456 = data_for_id('456')
+      data_654 = data_for_id('654')
 
-      expected_id_789 = temp_id(records, data_789[:date_of_birth])
-      expected_id_987 = temp_id(records, data_987[:date_of_birth])
-      expect(records[:model_with_alternate_id].key?(expected_id_789)).to eq(true)
-      expect(records[:model_with_alternate_id].key?(expected_id_987)).to eq(true)
+      expected_id_456 = temp_id(records, data_456[:date_of_birth])
+      expected_id_654 = temp_id(records, data_654[:date_of_birth])
+
+      expect(records[:model_with_alternate_id].key?(expected_id_456)).to eq(true)
+      expect(records[:model_with_alternate_id].key?(expected_id_654)).to eq(true)
     end
 
     context("mode == nil") do

--- a/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
+++ b/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
@@ -79,6 +79,20 @@ describe Polyphemus::RedcapEtlScriptRunner do
     }
   }
 
+  ALTERNATE_ID_REDCAP_CONFIG = {
+    model_with_alternate_id: {
+      each: [ "record" ],
+      scripts: [
+        {
+          attributes: {
+            name: "name",
+            alternate_id: "date_of_birth"
+          }
+        }
+      ]
+    }
+  }
+
   context 'dateshifts' do
     before do
       stub_magma_models
@@ -283,6 +297,37 @@ describe Polyphemus::RedcapEtlScriptRunner do
       expect(records.keys.include?(:model_two)).to eq(false)
 
       expect(records[:model_one].keys.length).to eq(6)
+    end
+
+    it 'when using alternate REDCap fields for ids' do
+      stub_redcap_data(:essential_data)
+      redcap_etl = Polyphemus::RedcapEtlScriptRunner.new(
+        project_name: 'test',
+        model_names: "model_with_alternate_id",
+        redcap_tokens: REDCAP_TOKEN,
+        dateshift_salt: '123',
+        redcap_host: REDCAP_HOST,
+        magma_host: MAGMA_HOST,
+        config: ALTERNATE_ID_REDCAP_CONFIG
+      )
+
+      magma_client = Etna::Clients::Magma.new(host: MAGMA_HOST, token: TEST_TOKEN)
+
+      records = redcap_etl.run(magma_client: magma_client)
+
+      expect(records.keys.include?(:model_with_alternate_id)).to eq(true)
+
+      # Only finds records with all the fields in the CONFIG, which
+      #   should be :name and :date_of_birth
+      expect(records[:model_with_alternate_id].keys.length).to eq(2)
+
+      data_789 = data_for_id('789')
+      data_987 = data_for_id('987')
+
+      expected_id_789 = temp_id(records, data_789[:date_of_birth])
+      expected_id_987 = temp_id(records, data_987[:date_of_birth])
+      expect(records[:model_with_alternate_id].key?(expected_id_789)).to eq(true)
+      expect(records[:model_with_alternate_id].key?(expected_id_987)).to eq(true)
     end
 
     context("mode == nil") do

--- a/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
+++ b/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
@@ -82,10 +82,11 @@ describe Polyphemus::RedcapEtlScriptRunner do
   ALTERNATE_ID_REDCAP_CONFIG = {
     model_with_alternate_id: {
       each: [ "record" ],
+      identifier_fields: [ "date_of_birth" ],
       scripts: [
         {
           attributes: {
-            name: "date_of_birth",
+            name: "name",
           }
         }
       ]
@@ -320,14 +321,14 @@ describe Polyphemus::RedcapEtlScriptRunner do
       #   should be :date_of_birth
       expect(records[:model_with_alternate_id].keys.length).to eq(2)
 
-      data_456 = data_for_id('456')
-      data_654 = data_for_id('654')
+      data_789 = data_for_id('789')
+      data_987 = data_for_id('987')
 
-      expected_id_456 = temp_id(records, data_456[:date_of_birth])
-      expected_id_654 = temp_id(records, data_654[:date_of_birth])
+      expected_id_789 = temp_id(records, data_789[:date_of_birth])
+      expected_id_987 = temp_id(records, data_987[:date_of_birth])
 
-      expect(records[:model_with_alternate_id].key?(expected_id_456)).to eq(true)
-      expect(records[:model_with_alternate_id].key?(expected_id_654)).to eq(true)
+      expect(records[:model_with_alternate_id].key?(expected_id_789)).to eq(true)
+      expect(records[:model_with_alternate_id].key?(expected_id_987)).to eq(true)
     end
 
     context("mode == nil") do

--- a/polyphemus/spec/fixtures/etls/redcap/test.rb
+++ b/polyphemus/spec/fixtures/etls/redcap/test.rb
@@ -48,3 +48,13 @@ define_model("BadModel").class_eval do
     "::temp-#{record_name}-abc"
   end
 end
+
+define_model("ModelWithAlternateId").class_eval do
+  def identifier(record_name, redcap_record: nil)
+    # Hardcode a temp id so that the offset is consistent. Makes
+    #   testing less random.
+    raise ArgumentError, "Missing :date_of_birth in form" if redcap_record.nil? || redcap_record[:date_of_birth].nil?
+  
+    "::temp-#{redcap_record[:date_of_birth]}-abc"
+  end
+end

--- a/polyphemus/spec/fixtures/etls/redcap/test.rb
+++ b/polyphemus/spec/fixtures/etls/redcap/test.rb
@@ -1,6 +1,6 @@
 # Define the new classes dynamically
 define_model("ModelOne").class_eval do
-  def identifier(record_name)
+  def identifier(record_name, redcap_record: nil)
     # Hardcode a temp id so that the offset is consistent. Makes
     #   testing less random.
     "::temp-#{record_name}-xyz"
@@ -12,7 +12,7 @@ define_model("ModelOne").class_eval do
 end
 
 define_model("ModelTwo").class_eval do
-  def identifier(record_name)
+  def identifier(record_name, redcap_record: nil)
     record_name
   end
 
@@ -42,7 +42,7 @@ define_model("Citation").class_eval do
 end
 
 define_model("BadModel").class_eval do
-  def identifier(record_name)
+  def identifier(record_name, redcap_record: nil)
     # Hardcode a temp id so that the offset is consistent. Makes
     #   testing less random.
     "::temp-#{record_name}-abc"

--- a/polyphemus/spec/fixtures/etls/redcap/test.rb
+++ b/polyphemus/spec/fixtures/etls/redcap/test.rb
@@ -1,6 +1,6 @@
 # Define the new classes dynamically
 define_model("ModelOne").class_eval do
-  def identifier(record_name, redcap_record: nil)
+  def identifier(record_name, identifier_fields: nil)
     # Hardcode a temp id so that the offset is consistent. Makes
     #   testing less random.
     "::temp-#{record_name}-xyz"
@@ -12,7 +12,7 @@ define_model("ModelOne").class_eval do
 end
 
 define_model("ModelTwo").class_eval do
-  def identifier(record_name, redcap_record: nil)
+  def identifier(record_name, identifier_fields: nil)
     record_name
   end
 
@@ -42,7 +42,7 @@ define_model("Citation").class_eval do
 end
 
 define_model("BadModel").class_eval do
-  def identifier(record_name, redcap_record: nil)
+  def identifier(record_name, identifier_fields: nil)
     # Hardcode a temp id so that the offset is consistent. Makes
     #   testing less random.
     "::temp-#{record_name}-abc"
@@ -50,11 +50,11 @@ define_model("BadModel").class_eval do
 end
 
 define_model("ModelWithAlternateId").class_eval do
-  def identifier(record_name, redcap_record: nil)
+  def identifier(record_name, identifier_fields: nil)
     # Hardcode a temp id so that the offset is consistent. Makes
     #   testing less random.
-    raise ArgumentError, "Missing :date_of_birth in form" if redcap_record.nil? || redcap_record[:date_of_birth].nil?
+    raise ArgumentError, "Missing :date_of_birth in form" if identifier_fields.nil? || identifier_fields[:date_of_birth].nil?
   
-    "::temp-#{redcap_record[:date_of_birth]}-abc"
+    "::temp-#{identifier_fields[:date_of_birth]}-abc"
   end
 end

--- a/polyphemus/spec/fixtures/magma_test_models.json
+++ b/polyphemus/spec/fixtures/magma_test_models.json
@@ -297,6 +297,37 @@
           }
         }
       }
+    },
+    "model_with_alternate_id": {
+      "template": {
+        "parent": "model_one",
+        "name": "model_with_alternate_id",
+        "identifier": "name",
+        "attributes": {
+          "name": {
+            "name": "name",
+            "attribute_name": "name",
+            "display_name": "Name",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "identifier"
+          },
+          "model_one": {
+            "name": "model_one",
+            "attribute_name": "model_one",
+            "model_name": "model_one",
+            "link_model_name": "model_one",
+            "display_name": "ModelOne",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "parent"
+          }
+        }
+      }
     }
   }
 }

--- a/polyphemus/spec/fixtures/redcap_mock_data_all.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_all.json
@@ -33,8 +33,7 @@
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme",
-    "date_of_birth": "1901-01-01"
+    "value": "Acme"
   },
   {
     "record": "000",
@@ -56,8 +55,7 @@
     "record_id": "987",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme",
-    "date_of_birth": "1950-01-01"
+    "value": "Acme"
   },
   {
     "record": "111",

--- a/polyphemus/spec/fixtures/redcap_mock_data_all.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_all.json
@@ -25,14 +25,16 @@
     "record_id": "456",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "1900-01-01"
+    "value": "1900-01-01",
+    "date_of_birth": "1900-01-01"
   },
   {
     "record": "789",
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "1901-01-01"
   },
   {
     "record": "000",
@@ -46,14 +48,16 @@
     "record_id": "654",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "900-01-01"
+    "value": "900-01-01",
+    "date_of_birth": "900-01-01"
   },
   {
     "record": "987",
     "record_id": "987",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "1950-01-01"
   },
   {
     "record": "111",

--- a/polyphemus/spec/fixtures/redcap_mock_data_all.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_all.json
@@ -25,15 +25,16 @@
     "record_id": "456",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "1900-01-01",
-    "date_of_birth": "1900-01-01"
+    "value": "1900-01-01"
   },
   {
     "record": "789",
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "1950-01-01",
+    "name": "Acme"
   },
   {
     "record": "000",
@@ -47,15 +48,16 @@
     "record_id": "654",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "900-01-01",
-    "date_of_birth": "900-01-01"
+    "value": "900-01-01"
   },
   {
     "record": "987",
     "record_id": "987",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "2900-01-01",
+    "name": "Acme"
   },
   {
     "record": "111",

--- a/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
@@ -18,7 +18,16 @@
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "1901-01-01"
+  },
+  {
+    "record": "987",
+    "record_id": "987",
+    "redcap_event_name": "Name",
+    "field_name": "name",
+    "value": "Acme",
+    "date_of_birth": "1950-01-01"
   },
   {
     "record": "000",

--- a/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
@@ -11,30 +11,32 @@
     "record_id": "456",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "1900-01-01",
-    "date_of_birth": "1900-01-01"
+    "value": "1900-01-01"
   },
   {
     "record": "654",
     "record_id": "654",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "900-01-01",
-    "date_of_birth": "900-01-01"
+    "value": "900-01-01"
   },
   {
     "record": "789",
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "1950-01-01",
+    "name": "Acme"
   },
   {
     "record": "987",
     "record_id": "987",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme"
+    "value": "Acme",
+    "date_of_birth": "2900-01-01",
+    "name": "Acme"
   },
   {
     "record": "000",

--- a/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
+++ b/polyphemus/spec/fixtures/redcap_mock_data_essential_data.json
@@ -11,23 +11,30 @@
     "record_id": "456",
     "redcap_event_name": "Birthday Party!",
     "field_name": "date_of_birth",
-    "value": "1900-01-01"
+    "value": "1900-01-01",
+    "date_of_birth": "1900-01-01"
+  },
+  {
+    "record": "654",
+    "record_id": "654",
+    "redcap_event_name": "Birthday Party!",
+    "field_name": "date_of_birth",
+    "value": "900-01-01",
+    "date_of_birth": "900-01-01"
   },
   {
     "record": "789",
     "record_id": "789",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme",
-    "date_of_birth": "1901-01-01"
+    "value": "Acme"
   },
   {
     "record": "987",
     "record_id": "987",
     "redcap_event_name": "Name",
     "field_name": "name",
-    "value": "Acme",
-    "date_of_birth": "1950-01-01"
+    "value": "Acme"
   },
   {
     "record": "000",


### PR DESCRIPTION
This change goes along with mountetna/redcap_projects#36, which I think can be merged and deployed first.

This PR implements a change to allow REDCap project loaders to generate identifiers from a REDCap field other than the `record` value given in REDCap. An example project is AutoIPI.

One change when creating the configs: it does require the person doing the configuration to include the alternate field name in every model config, so that it is available in the record. For example, populating a demographic table attached to subject, would require that every script includes `"subject": "my_project_identifier_field"`. This could get cumbersome with a ton of scripts, but perhaps alleviated by the "copy script" functionality in the new UI form (#600).

If we would like to constrain it more, I think we could also just add some sort of configuration parameter to the model config, like:

```
"subject": {
  "each": [],
  "scripts": [],
  "identifier_field_name": "my_project_identifier_field"
}
```

However, if we think that projects might need code to manipulate one or more REDCap fields into a single Magma record name, perhaps it's best to leave that in the Ruby model definition and not put too many constraints or assumptions into it. The current way this is implemented, the Ruby models can use whatever someone puts into the scripts. Unfortunately, it kind of leaves things in the hands of 1) whoever writes the Ruby model definitions, and 2) whoever writes the config. Kind of brittle since it's a human-communication process at that point, so open to suggestions on how to make this more robust.

As a note, I don't think we need to send the full record to `offset_id()`, as long as the identifier itself includes the alternate REDCap field's value.