### PR TITLE
Polyphemus hotfix etl file download

### DIFF
--- a/metis/Gemfile.lock
+++ b/metis/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.41)
+    etna (0.1.42)
       concurrent-ruby
       curb
       jwt
@@ -60,7 +60,7 @@ GEM
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
     json (2.5.1)
-    jwt (2.2.3)
+    jwt (2.3.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -162,4 +162,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.2.25
+   2.2.27

--- a/polyphemus/Gemfile.lock
+++ b/polyphemus/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /etna
   specs:
-    etna (0.1.41)
+    etna (0.1.42)
       concurrent-ruby
       curb
       jwt
@@ -185,4 +185,4 @@ DEPENDENCIES
   yabeda-puma-plugin
 
 BUNDLED WITH
-   2.2.25
+   2.2.27

--- a/polyphemus/lib/metis_file_in_watch_folder_etl.rb
+++ b/polyphemus/lib/metis_file_in_watch_folder_etl.rb
@@ -26,7 +26,7 @@ class Polyphemus
           matching_watches = watch_folders.select { |wf| wf.metis_id == file.folder_id }
           matching_watches.each do |watch|
             matched_files = (result[watch.watch_type] ||= [])
-            matched_files << file.with_containing_folder(watch.folder_path)
+            matched_files << file
           end
         end
       end
@@ -53,7 +53,6 @@ class Polyphemus
         predicate: "in",
         value: watch_folders(cursor).map(&:metis_id),
       ))
-      find_request.hide_paths = true
     end
 
     def matching_bucket_config(cursor)

--- a/polyphemus/spec/etls/ipi/ipi_etls_spec.rb
+++ b/polyphemus/spec/etls/ipi/ipi_etls_spec.rb
@@ -206,9 +206,9 @@ describe Polyphemus::Ipi::IpiWatchFilesEtl do
     describe 'updates magma records' do
       it "when scanner finds new files" do
         etl.process(cursor, [
-          create_metis_file("PATIENT001.T1.comp.blahblah1.fastq.gz", "", project_name: project_name, bucket_name: bucket_name),
-          create_metis_file("PATIENT001.T1.comp.blahblah2.fastq.gz", "", project_name: project_name, bucket_name: bucket_name),
-          create_metis_file("PATIENT001.T1.comp.blahblah3.fastq.gz", "", project_name: project_name, bucket_name: bucket_name),
+          create_metis_file("PATIENT001.T1.comp.blahblah1.fastq.gz", "BulkRNASeq/PATIENT001.T1.comp/PATIENT001.T1.comp.blahblah1.fastq.gz", project_name: project_name, bucket_name: bucket_name),
+          create_metis_file("PATIENT001.T1.comp.blahblah2.fastq.gz", "BulkRNASeq/PATIENT001.T1.comp/PATIENT001.T1.comp.blahblah2.fastq.gz", project_name: project_name, bucket_name: bucket_name),
+          create_metis_file("PATIENT001.T1.comp.blahblah3.fastq.gz", "BulkRNASeq/PATIENT001.T1.comp/PATIENT001.T1.comp.blahblah3.fastq.gz", project_name: project_name, bucket_name: bucket_name),
         ])
 
         # Make sure rna_seq records are updated
@@ -244,7 +244,7 @@ describe Polyphemus::Ipi::IpiWatchFilesEtl do
     describe 'updates magma records' do
       it "when scanner finds new files for file attribute" do
         etl.process(cursor, [
-          create_metis_file("PATIENT001.T1.comp.deduplicated.cram", "--path-would-be-omitted--", project_name: project_name, bucket_name: bucket_name),
+          create_metis_file("PATIENT001.T1.comp.deduplicated.cram", "bulkRNASeq/plate1_blahblah/output/PATIENT001.T1.comp/PATIENT001.T1.comp.deduplicated.cram", project_name: project_name, bucket_name: bucket_name),
         ])
 
         # Make sure rna_seq records are updated


### PR DESCRIPTION
This PR updates the Metis query for ETLs to use signed download paths instead of trying to construct them from watch folders. Addresses the errors we're seeing in Slack.