### PR TITLE
Production deploy

### DIFF
--- a/vulcan/lib/server/workflows/scripts/determine_batch_by_options.py
+++ b/vulcan/lib/server/workflows/scripts/determine_batch_by_options.py
@@ -1,5 +1,9 @@
-from archimedes.functions.dataflow import output_json, input_json, output_var
+from archimedes.functions.dataflow import output_json, input_json, output_path
 from archimedes.functions.environment import project_name
+
+def output_var(data, name):
+    with open(output_path(name), 'w') as output_file:
+        output_file.write(data)
 
 pdat = input_json("project_data")[project_name]
 

--- a/vulcan/lib/server/workflows/scripts/regress_pca_and_harmony.py
+++ b/vulcan/lib/server/workflows/scripts/regress_pca_and_harmony.py
@@ -1,5 +1,9 @@
-from archimedes.functions.dataflow import output_path, input_path, input_bool, input_var, output_var
+from archimedes.functions.dataflow import output_path, input_path, input_bool, input_var
 from archimedes.functions.scanpy import scanpy as sc
+
+def output_var(data, name):
+    with open(output_path(name), 'w') as output_file:
+        output_file.write(data)
 
 scdata = sc.read(input_path('normed_anndata.h5ad'))
 regress_nCounts = input_bool('regress_counts')


### PR DESCRIPTION
Works in a quick-fix where functions that had been added to archimedes are defined within vulcan scripts so as to temporarily circumvent need for updating the archimedes image.