### PR TITLE
Fix for stepUI vulcan steps not being recognized as bufferedSteps

### DIFF
--- a/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
+++ b/etna/packages/etna-js/components/inputs/dropdown_autocomplete.jsx
@@ -23,7 +23,7 @@ export default function DropdownAutocomplete({
 
   const [filteredList, setFilteredList] = useState(null);
   const [showList, setShowList] = useState(false);
-  const [selectedValue, setSelectedValue] = useState(null);
+  const [selectedValue, setSelectedValue] = useState("");
 
   function filterTheList(value) {
     let re = new RegExp(value);
@@ -85,7 +85,7 @@ export default function DropdownAutocomplete({
         <input
           type='text'
           onChange={handleChange}
-          value={selectedValue || undefined}
+          value={selectedValue}
         />
         <div className='icon-wrapper' onClick={toggleList}>
           <Icon icon={`${showList ? 'caret-up' : 'caret-down'}`}></Icon>

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/nested_select_autocomplete.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/nested_select_autocomplete.tsx
@@ -64,15 +64,16 @@ function LeafOptions({
 
 type OptionSet = {[k: string]: null | OptionSet};
 
-export default function NestedSelectAutocompleteInput({ label, data, onChange, value }: WithInputParams<{label?: string}, string, OptionSet>) {
+export default function NestedSelectAutocompleteInput({ label, data, onChange, ...props }: WithInputParams<{label?: string}, string, OptionSet>) {
+  const value = useSetsDefault("", props.value, onChange)
   const allOptions = useMemoized(joinNesting, data);
   const [path, setPath] = useState([] as string[]);
-
+  
   useEffect(() => {
-    mapSome(value, value => {
+    if (value && value != "") {
       const updatedPath = getPath(allOptions, value);
       setPath(updatedPath);
-    })
+    }
   }, [allOptions, value])
 
   const handleSelect = useCallback(

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/select_autocomplete.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/select_autocomplete.tsx
@@ -4,10 +4,11 @@ import {WithInputParams} from './input_types';
 import {maybeOfNullable, some, withDefault} from "../../../../selectors/maybe";
 import {flattenStringOptions, StringOptions} from "./monoids";
 import {useMemoized} from "../../../../selectors/workflow_selectors";
+import { useSetsDefault } from './useSetsDefault';
 
-export default function SelectAutocompleteInput({data, onChange, ...props}: WithInputParams<{}, string, StringOptions>) {
+export default function SelectAutocompleteInput({data, onChange, ...props}: WithInputParams<{}, string | null, StringOptions>) {
   const options = useMemoized(flattenStringOptions, data);
-  const value = withDefault(props.value, null);
+  const value = useSetsDefault(null, props.value, onChange);
 
   return (
     <DropdownAutocomplete

--- a/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/select_autocomplete.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/user_interactions/inputs/select_autocomplete.tsx
@@ -8,7 +8,7 @@ import { useSetsDefault } from './useSetsDefault';
 
 export default function SelectAutocompleteInput({data, onChange, ...props}: WithInputParams<{}, string | null, StringOptions>) {
   const options = useMemoized(flattenStringOptions, data);
-  const value = useSetsDefault(null, props.value, onChange);
+  const value = useSetsDefault("", props.value, onChange);
 
   return (
     <DropdownAutocomplete

--- a/vulcan/stories/StepUserInput.stories.tsx
+++ b/vulcan/stories/StepUserInput.stories.tsx
@@ -128,3 +128,11 @@ ColorSelection.args = {
     'color_options': require('./color_options.json')
   }
 };
+
+export const BatchSelection = Template.bind({});
+BatchSelection.args = {
+  type: TYPE.SELECT_AUTOCOMPLETE,
+  cwlParams:  {
+    'batch_options': ['1', '2', '3']
+  }
+}


### PR DESCRIPTION
Addresses #615.

Updates both select-autocomplte and nested-select-autocomplete to utilize the `useSetsDefault` method for setting their initial value.  That function sets a default value, and also calls `onChange(<the-default>)` which will then trigger the actions for the input to be considered as a bufferedStep.

For nested-select-autocomplete, rather than do a major refactor, I had to change the initial value to be '', the empty string.  The associated validation (NotEmptyValidator) is configured to reject this all the same, and visually, there is no difference to the user.