### PR TITLE
Improve linking performance with more strict regex.

### DIFF
--- a/polyphemus/lib/etls/ipi/ipi_etls.rb
+++ b/polyphemus/lib/etls/ipi/ipi_etls.rb
@@ -17,7 +17,7 @@ class Polyphemus
           process_watch_type_with(
             bucket('data')
               .watcher('single_cell_pool_processed')
-              .watch(/^single_cell_[^\/]*\/processed\/.*\/[^\/]+POOL[^\/]+\/.*$/),
+              .watch(/^single_cell_[^\/]*\/processed\/.*\/IPIPOOL[^\/]+(\/[^\/]*)?$/),
             Polyphemus::LinkerProcessor.new(
               linker: single_cell_pooled_linker,
               model_name: 'sc_rna_seq_pool'
@@ -33,7 +33,7 @@ class Polyphemus
           process_watch_type_with(
             bucket('data')
               .watcher('single_cell_processed')
-              .watch(/^single_cell_[^\/]*\/processed\/((?!POOL).)*$/),
+              .watch(/^single_cell_[^\/]*\/processed\/.*\/IPI((?!POOL)[^\/])+(\/[^\/]*)?$/),
             Polyphemus::LinkerProcessor.new(
               linker: single_cell_non_pooled_linker,
               model_name: 'sc_rna_seq',
@@ -47,9 +47,7 @@ class Polyphemus
       end
 
       def single_cell_non_pooled_linker
-        SingleCellLinker.new(
-          record_name_regex: /.*\/(?<record_name>IPI[^\/]*)\/.*$/
-        )
+        SingleCellLinker.new
       end
 
       def single_cell_pooled_linker
@@ -115,10 +113,13 @@ class Polyphemus
 
           matched_folders = folders.map do |folder|
             record_name = @linker.record_name_by_path(
-              folder.folder_path + '/',
-              @linker.record_name_regex
+              folder
             )
-            [folder, record_name] if record_names.include?(record_name)
+            if record_names.include?(record_name)
+              [folder, record_name]
+            else
+              nil
+            end
           end.select { |f| f }
 
           matched_folders.each do |folder, record_name|
@@ -147,6 +148,7 @@ class Polyphemus
           super(
             project_name: 'ipi',
             bucket_name: 'data',
+            record_name_regex: /.*\/(?<record_name>IPI[^\/]*)\//,
             **kwds
           )
         end

--- a/polyphemus/lib/etls/ipi/linkers/ipi_rna_seq_files_linker_base.rb
+++ b/polyphemus/lib/etls/ipi/linkers/ipi_rna_seq_files_linker_base.rb
@@ -3,9 +3,8 @@ require_relative "../../../ipi/ipi_helper"
 
 class Polyphemus::IpiRnaSeqFilesLinkerBase < Polyphemus::MetisFilesLinkerBase
   def initialize(project_name: "ipi", bucket_name:, attribute_regex:, record_name_regex:)
-    super(project_name: project_name, bucket_name: bucket_name)
+    super(project_name: project_name, bucket_name: bucket_name, record_name_regex: record_name_regex)
     @attribute_regex = attribute_regex
-    @record_name_regex = record_name_regex
     @helper = IpiHelper.new
   end
 
@@ -15,7 +14,6 @@ class Polyphemus::IpiRnaSeqFilesLinkerBase < Polyphemus::MetisFilesLinkerBase
       files_by_record_name: organize_metis_files_by_magma_record(
         metis_files: files,
         magma_record_names: current_magma_record_names(project_name, model_name),
-        path_regex: @record_name_regex,
       ),
       attribute_regex: @attribute_regex,
       cursor: cursor,

--- a/polyphemus/lib/etls/metis_files_linker_base.rb
+++ b/polyphemus/lib/etls/metis_files_linker_base.rb
@@ -6,10 +6,11 @@ class Polyphemus::MetisFilesLinkerBase
 
   attr_reader :bucket_name, :project_name
 
-  def initialize(project_name:, bucket_name:)
+  def initialize(project_name:, bucket_name:, record_name_regex:)
     @project_name = project_name
     @bucket_name = bucket_name
     @magma_models = {}
+    @record_name_regex = record_name_regex
   end
 
   def cursor_model_group_state(cursor, model_name, group_name, default)
@@ -161,8 +162,15 @@ class Polyphemus::MetisFilesLinkerBase
     false
   end
 
-  def record_name_by_path(path, regex)
-    match = path.match(regex)
+  def record_name_by_path(file_or_folder)
+    if file_or_folder.is_a?(Etna::Clients::Metis::File)
+      match = file_or_folder.file_path.match(@record_name_regex)
+    elsif file_or_folder.is_a?(Etna::Clients::Metis::Folder)
+      match = (file_or_folder.folder_path + '/').match(@record_name_regex)
+    else
+      raise "file_or_folder must be either a File or Folder object"
+    end
+
     if match
       corrected_record_name(match[:record_name])
     else
@@ -172,12 +180,11 @@ class Polyphemus::MetisFilesLinkerBase
 
   def organize_metis_files_by_magma_record(
     metis_files:,
-    magma_record_names:,
-    path_regex:
+    magma_record_names:
   )
     metis_files_by_record_name = metis_files.group_by do |file|
       next if file.file_path.nil?
-      record_name_by_path(file.file_path, path_regex)
+      record_name_by_path(file)
     end
 
     metis_files_by_record_name.keys.map do |matched_record_name|

--- a/polyphemus/lib/etls/project_watch_files_etl.rb
+++ b/polyphemus/lib/etls/project_watch_files_etl.rb
@@ -6,7 +6,7 @@ class Polyphemus::ProjectWatchFilesEtl < Polyphemus::MetisFileInWatchFolderEtl
 
   def initialize(config)
     @config = config
-    super(bucket_watch_configs: config.bucket_configs)
+    super(bucket_watch_configs: config.bucket_configs, limit: 100)
   end
 
   def process_files(cursor, files, watch_type)

--- a/polyphemus/lib/etls/project_watch_folders_etl.rb
+++ b/polyphemus/lib/etls/project_watch_folders_etl.rb
@@ -7,7 +7,7 @@ class Polyphemus::ProjectWatchFoldersEtl < Polyphemus::AddWatchFolderBaseEtl
 
   def initialize(config)
     @config = config
-    super(bucket_watch_configs: config.bucket_configs)
+    super(bucket_watch_configs: config.bucket_configs, limit: 100)
   end
 
   def process_folder_contents(cursor, folders, watch_type)

--- a/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
+++ b/polyphemus/lib/etls/shared/single_cell/single_cell_linkers.rb
@@ -3,18 +3,13 @@ class Polyphemus
   end
 
   class SingleCellProcessedLinker < Polyphemus::MetisFilesLinkerBase
-    # Record name is two directories above a file
-    RECORD_NAME_REGEX = /.*\/(?<record_name>.*)\/[^\/]*\/[^\/]*$/
-
-    attr_reader :record_name_regex
-
     def initialize(
       project_name:,
       bucket_name:,
-      attribute_regex_overrides: {},
-      record_name_regex: RECORD_NAME_REGEX
+      record_name_regex:,
+      attribute_regex_overrides: {}
     )
-      super(project_name: project_name, bucket_name: bucket_name)
+      super(project_name: project_name, bucket_name: bucket_name, record_name_regex: record_name_regex)
       @attribute_regex_overrides = attribute_regex_overrides
       @record_name_regex = record_name_regex
     end
@@ -25,7 +20,6 @@ class Polyphemus
         files_by_record_name: organize_metis_files_by_magma_record(
           metis_files: files,
           magma_record_names: current_magma_record_names(project_name, model_name),
-          path_regex: @record_name_regex,
         ),
         attribute_regex: attribute_regex,
         cursor: cursor,

--- a/polyphemus/spec/etls/ipi/ipi_etls_spec.rb
+++ b/polyphemus/spec/etls/ipi/ipi_etls_spec.rb
@@ -286,7 +286,7 @@ describe Polyphemus::Ipi::SingleCellLinkers do
         test_folders
       )
 
-      expect(update_requests_raw[5]).to eql({
+      expect(update_requests_raw).to include({
         dry_run: false,
         :project_name => "ipi",
         :revisions => {

--- a/polyphemus/spec/metis_files_linker_base_spec.rb
+++ b/polyphemus/spec/metis_files_linker_base_spec.rb
@@ -74,12 +74,11 @@ describe Polyphemus::MetisFilesLinkerBase do
     linker.organize_metis_files_by_magma_record(
       metis_files: files,
       magma_record_names: existing_records.keys,
-      path_regex: record_name_regex,
     )
   end
 
   let(:linker) do
-    Polyphemus::MetisFilesLinkerBase.new(project_name: project_name, bucket_name: bucket_name)
+    Polyphemus::MetisFilesLinkerBase.new(project_name: project_name, bucket_name: bucket_name, record_name_regex: record_name_regex)
   end
 
   before(:each) do


### PR DESCRIPTION
Better performance for linking by having a stricter regex.
Current issue is that the folder regex looks for pretty much ANY folder underneath a processed record folder, but that is apparently a lot of extraneous stuff.

This restricts the watch folder regex to at most, one folder deep (which matches all known cases in the pipeline).