### PR TITLE
Zc/load application secrets from file

### DIFF
--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -50,6 +50,21 @@ module Etna::Application
     Etna::Application.register(self)
   end
 
+  # a <- b
+  def deep_merge(a, b)
+    if a.is_a?(Hash)
+      if b.is_a?(Hash)
+        b.keys.each do |b_key|
+          a[b_key] = deep_merge(a[b_key], b[b_key])
+        end
+
+        return a
+      end
+    end
+
+    a.nil? ? b : a
+  end
+
   def configure(opts)
     @config = opts
 
@@ -66,7 +81,9 @@ module Etna::Application
         target = (target[n.downcase.to_sym] ||= {})
       end
 
-      target[path.last.downcase.to_sym] ||= YAML.load(File.read(ENV[key]))
+      v = YAML.load(File.read(ENV[key]))
+      target[path.last.downcase.to_sym] =
+        deep_merge(target[path.last.downcase.to_sym], v)
     end
 
     if (rollbar_config = config(:rollbar)) && rollbar_config[:access_token]

--- a/etna/lib/etna/application.rb
+++ b/etna/lib/etna/application.rb
@@ -53,10 +53,11 @@ module Etna::Application
   def configure(opts)
     @config = opts
 
-    # Apply environmental variables of the form "APP__x__y__z"
-    prefix = "#{self.class.name.upcase}__"
-    ENV.keys.select { |k| k.start_with?(prefix) }.each do |key|
-      path = key.split("__", -1)
+    # Apply environmental variables of the form "ETNA__x__y__z_FILE"
+    # by reading the given file.
+    prefix = "ETNA__"
+    ENV.keys.select { |k| k.start_with?(prefix) && k.end_with?("_FILE") }.each do |key|
+      path = key.sub(/_FILE/, '').split("__", -1)
       path.shift # drop the first, just app name
 
       target = @config
@@ -65,7 +66,7 @@ module Etna::Application
         target = (target[n.downcase.to_sym] ||= {})
       end
 
-      target[path.last.downcase.to_sym] ||= ENV[key]
+      target[path.last.downcase.to_sym] ||= YAML.load(File.read(ENV[key]))
     end
 
     if (rollbar_config = config(:rollbar)) && rollbar_config[:access_token]

--- a/etna/spec/application_spec.rb
+++ b/etna/spec/application_spec.rb
@@ -17,18 +17,25 @@ describe Etna::Application do
       ENV.clear.update(@orig_ENV)
     end
 
+    def in_temp_file(string)
+      Tempfile.open do |file|
+        file.write(string)
+        file.path
+      end
+    end
+
     it 'loads all kinds of keys successfully, merging them with existing items' do
-      ENV['TESTAPP__PRODUCTION__DB__PASSWORD'] = 'password'
-      ENV['TESTAPP__PRODUCTION__DB__NO_OVERRIDE'] = 'blah'
-      ENV['TESTAPP__PRODUCTION__KEY'] = 'value'
+      ENV['ETNA__PRODUCTION__DB__PASSWORD_FILE'] = in_temp_file('- password')
+      ENV['ETNA__PRODUCTION__DB__NO_OVERRIDE_FILE'] = in_temp_file('blah')
+      ENV['ETNA__PRODUCTION__KEY_FILE'] = in_temp_file('123')
       app = TestApp.instance
       app.configure({:production => { :db => {:host => 'm', :no_override => 'thing'}} })
 
-      expect(app.config(:key, :production)).to eql('value')
+      expect(app.config(:key, :production)).to eql(123)
       expect(app.config(:db, :production)).to eql({
         :no_override => 'thing',
         :host => 'm',
-        :password => 'password'
+        :password => ['password']
       })
     end
   end

--- a/etna/spec/application_spec.rb
+++ b/etna/spec/application_spec.rb
@@ -28,6 +28,7 @@ describe Etna::Application do
       ENV['ETNA__PRODUCTION__DB__PASSWORD_FILE'] = in_temp_file('- password')
       ENV['ETNA__PRODUCTION__DB__NO_OVERRIDE_FILE'] = in_temp_file('blah')
       ENV['ETNA__PRODUCTION__KEY_FILE'] = in_temp_file('123')
+      ENV['ETNA__PRODUCTION_FILE'] = in_temp_file({ :db => { merge_me: 123 } }.to_yaml)
       app = TestApp.instance
       app.configure({:production => { :db => {:host => 'm', :no_override => 'thing'}} })
 
@@ -35,7 +36,8 @@ describe Etna::Application do
       expect(app.config(:db, :production)).to eql({
         :no_override => 'thing',
         :host => 'm',
-        :password => ['password']
+        :password => ['password'],
+        :merge_me => 123,
       })
     end
   end


### PR DESCRIPTION
This is a minor adjustment ahead of polyphemus migration to swarm infra.

Goal: make it easy to compose configuration without chef (for instance, base staging config gets merged with metis specific config), and inject <systems> secrets into config at process time (these being different from airflow secrets known to users, this is more like database passwords and rollbar tokens, etc).

Considered these options
1.  Allowing multiple yml files to be merged -- more or less what this solution is, but I found environment variables pointing to files to consistently be the easiest option.
2.  Script the put together configs similar to chef -- more moving parts that gets tricky to maintain.  From vulcan and metis staging migrations, this path seemed least resistant but supporting all kinds of config.yml value injections we'll need.