### PR TITLE
Vulcan input drawer

### DIFF
--- a/etna/packages/etna-js/style/theme.jsx
+++ b/etna/packages/etna-js/style/theme.jsx
@@ -80,9 +80,6 @@ export const createEtnaTheme = (p,s) => {
       MuiCheckbox: {
         disableRipple: true
       },
-      MuiGrid: {
-        disableElevation: true
-      },
       MuiChip: {
         color: "secondary",
         size: "small"

--- a/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/input_feed.spec.tsx.snap
+++ b/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/input_feed.spec.tsx.snap
@@ -6,73 +6,197 @@ exports[`InputFeed renders complete UI steps and error steps 1`] = `
 >
   <div>
     <div
-      className="primary-inputs"
-    />
+      className="MuiPaper-root MuiCard-root makeStyles-card-1 MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        className="MuiGrid-root makeStyles-header-2 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+        onClick={[Function]}
+      >
+        <div
+          className="MuiGrid-root MuiGrid-item"
+        >
+          <h6
+            className="MuiTypography-root MuiTypography-h6"
+          >
+            Primary Inputs
+          </h6>
+        </div>
+        <div
+          className="MuiGrid-root MuiGrid-item"
+        >
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+            disabled={false}
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        className="MuiCollapse-container MuiCollapse-hidden"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="MuiCollapse-wrapper"
+        >
+          <div
+            className="MuiCollapse-wrapperInner"
+          />
+        </div>
+      </div>
+    </div>
   </div>
   <div
-    className="step-user-input step "
+    className="MuiPaper-root MuiCard-root makeStyles-card-3  step-user-input MuiPaper-elevation0 MuiPaper-rounded"
   >
     <div
+      className="MuiGrid-root makeStyles-header-6 MuiGrid-container MuiGrid-justify-xs-space-between"
       onClick={[Function]}
     >
       <div
-        className="step-name"
+        className="MuiGrid-root MuiGrid-container MuiGrid-item"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
       >
-        <div
-          className="step-status-icon-wrapper"
-        >
-          <span
-            className="icon-grp icon-grp-step-status-icon light  fa-stack fa-fw"
-            title="second"
-          >
-            <i
-              className="icon step-status-icon light  clock fa fa-2x fa-clock"
-            />
-          </span>
-        </div>
-        <div
-          className="step-button"
-        >
-          second
-        </div>
         <svg
+          aria-describedby={null}
           aria-hidden={true}
-          className="MuiSvgIcon-root"
+          className="MuiSvgIcon-root makeStyles-pending-10 makeStyles-icon-7"
           focusable="false"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          title="second"
           viewBox="0 0 24 24"
         >
           <path
-            d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+            d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+          <path
+            d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
           />
         </svg>
+        <p
+          className="MuiTypography-root makeStyles-label-5 MuiTypography-body1"
+        >
+          second
+        </p>
       </div>
+      <button
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
+      </button>
     </div>
     <div
-      className="step-user-input-inputs sliding-panel vertical open"
+      className="MuiCollapse-container step-user-input-inputs MuiCollapse-entered"
+      style={
+        Object {
+          "minHeight": "0px",
+        }
+      }
     >
-      <div>
+      <div
+        className="MuiCollapse-wrapper"
+      >
         <div
-          className="view_item"
+          className="MuiCollapse-wrapperInner"
         >
-          <div
-            className="item_view"
-          >
+          <div>
             <div
-              className="input-help"
+              className="view_item"
             >
               <div
-                className="input-help-children-wrapper"
+                className="item_view"
               >
-                <input
-                  onChange={[Function]}
-                  type="text"
-                  value="default-value"
-                />
+                <div
+                  className="input-help"
+                >
+                  <div
+                    className="input-help-children-wrapper"
+                  >
+                    <input
+                      onChange={[Function]}
+                      type="text"
+                      value="default-value"
+                    />
+                  </div>
+                  <div
+                    className="help-icon-wrapper"
+                    title=""
+                  />
+                </div>
               </div>
-              <div
-                className="help-icon-wrapper"
-                title=""
-              />
             </div>
           </div>
         </div>
@@ -80,69 +204,123 @@ exports[`InputFeed renders complete UI steps and error steps 1`] = `
     </div>
   </div>
   <div
-    className="step-user-input step "
+    className="MuiPaper-root MuiCard-root makeStyles-card-3  step-user-input MuiPaper-elevation0 MuiPaper-rounded"
   >
     <div
+      className="MuiGrid-root makeStyles-header-6 MuiGrid-container MuiGrid-justify-xs-space-between"
       onClick={[Function]}
     >
       <div
-        className="step-name"
+        className="MuiGrid-root MuiGrid-container MuiGrid-item"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
       >
-        <div
-          className="step-status-icon-wrapper"
-        >
-          <span
-            className="icon-grp icon-grp-step-status-icon light  fa-stack fa-fw"
-            title="third"
-          >
-            <i
-              className="icon step-status-icon light  clock fa fa-2x fa-clock"
-            />
-          </span>
-        </div>
-        <div
-          className="step-button"
-        >
-          third
-        </div>
         <svg
+          aria-describedby={null}
           aria-hidden={true}
-          className="MuiSvgIcon-root"
+          className="MuiSvgIcon-root makeStyles-pending-10 makeStyles-icon-7"
           focusable="false"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          title="third"
           viewBox="0 0 24 24"
         >
           <path
-            d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+            d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+          <path
+            d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
           />
         </svg>
+        <p
+          className="MuiTypography-root makeStyles-label-5 MuiTypography-body1"
+        >
+          third
+        </p>
       </div>
+      <button
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
+      </button>
     </div>
     <div
-      className="step-user-input-inputs sliding-panel vertical open"
+      className="MuiCollapse-container step-user-input-inputs MuiCollapse-entered"
+      style={
+        Object {
+          "minHeight": "0px",
+        }
+      }
     >
-      <div>
+      <div
+        className="MuiCollapse-wrapper"
+      >
         <div
-          className="view_item"
+          className="MuiCollapse-wrapperInner"
         >
-          <div
-            className="item_view"
-          >
+          <div>
             <div
-              className="input-help"
+              className="view_item"
             >
               <div
-                className="input-help-children-wrapper"
+                className="item_view"
               >
-                <input
-                  onChange={[Function]}
-                  type="text"
-                  value="default-value"
-                />
+                <div
+                  className="input-help"
+                >
+                  <div
+                    className="input-help-children-wrapper"
+                  >
+                    <input
+                      onChange={[Function]}
+                      type="text"
+                      value="default-value"
+                    />
+                  </div>
+                  <div
+                    className="help-icon-wrapper"
+                    title=""
+                  />
+                </div>
               </div>
-              <div
-                className="help-icon-wrapper"
-                title=""
-              />
             </div>
           </div>
         </div>
@@ -155,18 +333,24 @@ exports[`InputFeed renders complete UI steps and error steps 1`] = `
     <div
       className="step-name"
     >
-      <div
-        className="step-status-icon-wrapper"
+      <svg
+        aria-describedby={null}
+        aria-hidden={true}
+        className="MuiSvgIcon-root makeStyles-error-11 makeStyles-icon-7"
+        focusable="false"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        title="zero"
+        viewBox="0 0 24 24"
       >
-        <span
-          className="icon-grp icon-grp-step-status-icon light red  fa-stack fa-fw"
-          title="zero"
-        >
-          <i
-            className="icon step-status-icon light red  times-circle fa fa-2x fa-times-circle"
-          />
-        </span>
-      </div>
+        <path
+          d="M14.59 8L12 10.59 9.41 8 8 9.41 10.59 12 8 14.59 9.41 16 12 13.41 14.59 16 16 14.59 13.41 12 16 9.41 14.59 8zM12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+        />
+      </svg>
       <div
         className="step-button"
       >

--- a/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/output_feed.spec.tsx.snap
+++ b/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/output_feed.spec.tsx.snap
@@ -10,18 +10,24 @@ exports[`OutputFeed renders UI output steps 1`] = `
     <div
       className="step-name"
     >
-      <div
-        className="step-status-icon-wrapper"
+      <svg
+        aria-describedby={null}
+        aria-hidden={true}
+        className="MuiSvgIcon-root makeStyles-complete-2 makeStyles-icon-1"
+        focusable="false"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        title="second"
+        viewBox="0 0 24 24"
       >
-        <span
-          className="icon-grp icon-grp-step-status-icon light green  fa-stack fa-fw"
-          title="second"
-        >
-          <i
-            className="icon step-status-icon light green  check fa fa-2x fa-check"
-          />
-        </span>
-      </div>
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
       <div
         className="step-button"
       >
@@ -38,18 +44,24 @@ exports[`OutputFeed renders UI output steps 1`] = `
     <div
       className="step-name"
     >
-      <div
-        className="step-status-icon-wrapper"
+      <svg
+        aria-describedby={null}
+        aria-hidden={true}
+        className="MuiSvgIcon-root makeStyles-complete-2 makeStyles-icon-1"
+        focusable="false"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        title="fourth"
+        viewBox="0 0 24 24"
       >
-        <span
-          className="icon-grp icon-grp-step-status-icon light green  fa-stack fa-fw"
-          title="fourth"
-        >
-          <i
-            className="icon step-status-icon light green  check fa fa-2x fa-check"
-          />
-        </span>
-      </div>
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
       <div
         className="step-button"
       >
@@ -74,18 +86,24 @@ exports[`OutputFeed renders UI output steps 1`] = `
     <div
       className="step-name"
     >
-      <div
-        className="step-status-icon-wrapper"
+      <svg
+        aria-describedby={null}
+        aria-hidden={true}
+        className="MuiSvgIcon-root makeStyles-complete-2 makeStyles-icon-1"
+        focusable="false"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        title="sixth"
+        viewBox="0 0 24 24"
       >
-        <span
-          className="icon-grp icon-grp-step-status-icon light green  fa-stack fa-fw"
-          title="sixth"
-        >
-          <i
-            className="icon step-status-icon light green  check fa fa-2x fa-check"
-          />
-        </span>
-      </div>
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
       <div
         className="step-button"
       >

--- a/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/primary_inputs.spec.tsx.snap
+++ b/vulcan/lib/client/jsx/components/workflow/session/__tests__/__snapshots__/primary_inputs.spec.tsx.snap
@@ -4,271 +4,368 @@ exports[`PrimaryInputs renders each type of input 1`] = `
 Array [
   <div>
     <div
-      className="primary-inputs"
+      className="MuiPaper-root MuiCard-root makeStyles-card-1 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        className="inputs-pane"
+        className="MuiGrid-root makeStyles-header-2 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+        onClick={[Function]}
       >
         <div
-          className="header-wrapper"
+          className="MuiGrid-root MuiGrid-item"
         >
-          <div
-            className="inputs-pane-header toggle open"
-            onClick={[Function]}
+          <h6
+            className="MuiTypography-root MuiTypography-h6"
           >
-            <div
-              className="title"
-            >
-              Inputs
-            </div>
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
-              />
-            </svg>
-          </div>
-          <div
-            className="filler"
-          />
+            Primary Inputs
+          </h6>
         </div>
         <div
-          className="primary-inputs-container items sliding-panel vertical open"
+          className="MuiGrid-root MuiGrid-item"
+        >
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+            disabled={false}
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        className="MuiCollapse-container MuiCollapse-hidden"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="MuiCollapse-wrapper"
         >
           <div
-            className="view_item"
+            className="MuiCollapse-wrapperInner"
           >
             <div
-              className="item_name"
-            >
-              aBool
-            </div>
-            <div
-              className="item_view"
+              className="MuiPaper-root MuiAccordion-root MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
             >
               <div
-                className="input-help"
+                aria-disabled={false}
+                aria-expanded={false}
+                className="MuiButtonBase-root MuiAccordionSummary-root makeStyles-header-3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                role="button"
+                tabIndex={0}
               >
                 <div
-                  className="input-help-children-wrapper"
+                  className="MuiAccordionSummary-content"
                 >
-                  <input
-                    checked={true}
-                    className="text_box"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                  <p
+                    className="MuiTypography-root MuiTypography-body1"
                   >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
+                    
+                  </p>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            className="view_item"
-          >
-            <div
-              className="item_name"
-            >
-              aBoolWithoutDefault
-            </div>
-            <div
-              className="item_view"
-            >
               <div
-                className="input-help"
+                className="MuiCollapse-container MuiCollapse-hidden"
+                style={
+                  Object {
+                    "minHeight": "0px",
+                  }
+                }
               >
                 <div
-                  className="input-help-children-wrapper"
+                  className="MuiCollapse-wrapper"
                 >
-                  <input
-                    checked={false}
-                    className="text_box"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                  <div
+                    className="MuiCollapse-wrapperInner"
                   >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="view_item"
-          >
-            <div
-              className="item_name"
-            >
-              aFloat
-            </div>
-            <div
-              className="item_view"
-            >
-              <div
-                className="input-help"
-              >
-                <div
-                  className="input-help-children-wrapper"
-                >
-                  <input
-                    onChange={[Function]}
-                    onKeyPress={[Function]}
-                    type="text"
-                    value={1.2}
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-                  >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="view_item"
-          >
-            <div
-              className="item_name"
-            >
-              aFloatWithoutDefault
-            </div>
-            <div
-              className="item_view"
-            >
-              <div
-                className="input-help"
-              >
-                <div
-                  className="input-help-children-wrapper"
-                >
-                  <input
-                    onChange={[Function]}
-                    onKeyPress={[Function]}
-                    type="text"
-                    value={0}
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-                  >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="view_item"
-          >
-            <div
-              className="item_name"
-            >
-              anInt
-            </div>
-            <div
-              className="item_view"
-            >
-              <div
-                className="input-help"
-              >
-                <div
-                  className="input-help-children-wrapper"
-                >
-                  <input
-                    onChange={[Function]}
-                    onKeyPress={[Function]}
-                    type="text"
-                    value={1}
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-                  >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="view_item"
-          >
-            <div
-              className="item_name"
-            >
-              anIntWithoutDefault
-            </div>
-            <div
-              className="item_view"
-            >
-              <div
-                className="input-help"
-              >
-                <div
-                  className="input-help-children-wrapper"
-                >
-                  <input
-                    onChange={[Function]}
-                    onKeyPress={[Function]}
-                    type="text"
-                    value={0}
-                  />
-                </div>
-                <div
-                  className="help-icon-wrapper"
-                  title="help"
-                >
-                  <span
-                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
-                  >
-                    <i
-                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
-                    />
-                  </span>
+                    <div
+                      role="region"
+                    >
+                      <div
+                        className="MuiAccordionDetails-root makeStyles-group-4"
+                      >
+                        <div
+                          className="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
+                        >
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              aBool
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    checked={true}
+                                    className="text_box"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              aBoolWithoutDefault
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    checked={false}
+                                    className="text_box"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              aFloat
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    onChange={[Function]}
+                                    onKeyPress={[Function]}
+                                    type="text"
+                                    value={1.2}
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              aFloatWithoutDefault
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    onChange={[Function]}
+                                    onKeyPress={[Function]}
+                                    type="text"
+                                    value={0}
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              anInt
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    onChange={[Function]}
+                                    onKeyPress={[Function]}
+                                    type="text"
+                                    value={1}
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="view_item"
+                          >
+                            <div
+                              className="item_name"
+                            >
+                              anIntWithoutDefault
+                            </div>
+                            <div
+                              className="item_view"
+                            >
+                              <div
+                                className="input-help"
+                              >
+                                <div
+                                  className="input-help-children-wrapper"
+                                >
+                                  <input
+                                    onChange={[Function]}
+                                    onKeyPress={[Function]}
+                                    type="text"
+                                    value={0}
+                                  />
+                                </div>
+                                <div
+                                  className="help-icon-wrapper"
+                                  title="help"
+                                >
+                                  <span
+                                    className="icon-grp icon-grp-help-icon  fa-stack fa-fw"
+                                  >
+                                    <i
+                                      className="icon help-icon  question-circle fa fa-2x fa-question-circle"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -281,14 +378,47 @@ Array [
     className="reset-or-commit-inputs"
   >
     <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-text"
       disabled={false}
+      onBlur={[Function]}
       onClick={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      Reset
+      <span
+        className="MuiButton-label"
+      >
+        Reset
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
     <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-text"
       disabled={false}
+      onBlur={[Function]}
       onClick={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
       style={
         Object {
           "background": "linear-gradient(135deg, #6e8efb, #a777e3)",
@@ -298,8 +428,17 @@ Array [
           "textAlign": "center",
         }
       }
+      tabIndex={0}
+      type="button"
     >
-      Commit
+      <span
+        className="MuiButton-label"
+      >
+        Commit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>,
 ]

--- a/vulcan/lib/client/jsx/components/workflow/session/__tests__/input_feed.spec.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/__tests__/input_feed.spec.tsx
@@ -18,6 +18,7 @@ import {
   setWorkflow,
   setWorkflows
 } from '../../../../actions/vulcan_actions';
+import Card from '@material-ui/core/Card';
 
 describe('InputFeed', () => {
   fit('renders complete UI steps and error steps', () => {
@@ -84,8 +85,11 @@ describe('InputFeed', () => {
       1
     );
 
+
     expect(
-      instance.findAllByProps({className: 'step-user-input step '}).length
+      instance.findAllByType(Card).filter(
+        t => t.props.className.endsWith('step-user-input')
+      ).length
     ).toEqual(2);
 
     expect(component.toJSON()).toMatchSnapshot();

--- a/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
@@ -12,6 +12,27 @@ import {
 import {BoundInputSpecification} from "../user_interactions/inputs/input_types";
 import {useWorkflow} from "../../../contexts/workflow_context";
 
+import IconButton from '@material-ui/core/IconButton';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Accordion from '@material-ui/core/Accordion';
+import Typography from '@material-ui/core/Typography';
+import {makeStyles} from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  header: {
+    background: '#eee',
+    cursor: 'pointer',
+    minHeight: '32px',
+    height: '32px'
+  },
+  group: {
+    padding: 0,
+    borderBottom: '1px solid #eee'
+  }
+}));
+
 interface Props {
   inputs: BoundInputSpecification[],
   groupName: string,
@@ -21,7 +42,7 @@ const collator = new Intl.Collator(undefined, {
   numeric: true, sensitivity: 'base'
 });
 
-export default function InputGroup({inputs, groupName}: Props) {
+export default function InputGroup({inputs, groupName, select, expanded}: Props) {
   const {state} = useContext(VulcanContext);
   const {workflow} = useWorkflow();
   let {session, status, data} = state;
@@ -41,23 +62,21 @@ export default function InputGroup({inputs, groupName}: Props) {
     (a, b) =>
       collator.compare(a.label, b.label)), [inputs]);
 
-  return (<div className='inputs-pane'>
-    <div className='header-wrapper'>
-      <div onClick={toggleInputs} className={`inputs-pane-header toggle ${open ? 'open' : 'closed'}`}>
-        <div className='title'>{groupName}</div>
-        {open ? <ExpandLessIcon/> : <ExpandMoreIcon/>}
-      </div>
-      <div className='filler'/>
-    </div>
-    <div
-      className={`primary-inputs-container items sliding-panel vertical ${open ? 'open' : 'closed'}`}
-    >
+  const classes = useStyles();
+
+  return (<Accordion elevation={0} expanded={ expanded } onChange={ select }>
+    <AccordionSummary className={classes.header}>
+        <Typography>{groupName}</Typography>
+    </AccordionSummary>
+    <AccordionDetails className={classes.group}>
+      <Grid container direction='column'>
       {sortedInputs.map((input, index) => {
         return (<UserInput
           input={input}
           key={index}
         />);
       })}
-    </div>
-  </div>);
+      </Grid>
+    </AccordionDetails>
+  </Accordion>);
 }

--- a/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/input_group.tsx
@@ -36,6 +36,8 @@ const useStyles = makeStyles((theme) => ({
 interface Props {
   inputs: BoundInputSpecification[],
   groupName: string,
+  expanded: boolean,
+  select: (event: any) => void
 }
 
 const collator = new Intl.Collator(undefined, {

--- a/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
@@ -22,12 +22,14 @@ import {makeStyles} from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    borderRadius: 0
+    borderRadius: 0,
+    border: '1px solid #eee',
   },
   header: {
-    padding: '5px 5px 5px 10px'
+    padding: '5px 10px'
   }
 }));
+
 export default function PrimaryInputs() {
   const {commitSessionInputChanges, dispatch} = useContext(VulcanContext);
 
@@ -89,8 +91,8 @@ function PrimaryInputsInner() {
             <Typography variant='h6'>Inputs</Typography>
           </Grid>
           <Grid item>
-            <IconButton onClick={ () => setOpen(!open) }>
-              { open ? <ExpandLessIcon/> : <ExpandMoreIcon/>}
+            <IconButton size='small' onClick={ () => setOpen(!open) }>
+              { open ? <ExpandLessIcon fontSize='small'/> : <ExpandMoreIcon fontSize='small'/>}
             </IconButton>
           </Grid>
         </Grid>

--- a/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
@@ -23,10 +23,11 @@ import {makeStyles} from '@material-ui/core/styles';
 const useStyles = makeStyles((theme) => ({
   card: {
     borderRadius: 0,
-    border: '1px solid #eee',
+    border: '1px solid #eee'
   },
   header: {
-    padding: '5px 10px'
+    padding: '5px 10px',
+    cursor: 'pointer'
   }
 }));
 
@@ -86,12 +87,12 @@ function PrimaryInputsInner() {
 
   return (
     <Card className={classes.card}>
-        <Grid className={classes.header} container alignItems='center' justify='space-between'>
+        <Grid className={classes.header} container alignItems='center' justify='space-between' onClick={ () => setOpen(!open) }>
           <Grid item>
-            <Typography variant='h6'>Inputs</Typography>
+            <Typography variant='h6'>Primary Inputs</Typography>
           </Grid>
           <Grid item>
-            <IconButton size='small' onClick={ () => setOpen(!open) }>
+            <IconButton size='small'>
               { open ? <ExpandLessIcon fontSize='small'/> : <ExpandMoreIcon fontSize='small'/>}
             </IconButton>
           </Grid>

--- a/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/session/primary_inputs.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect, useMemo} from 'react';
+import React, {useState, useCallback, useContext, useEffect, useMemo} from 'react';
 
 import {VulcanContext} from '../../../contexts/vulcan_context';
 
@@ -10,7 +10,24 @@ import {
 import {useWorkflow} from "../../../contexts/workflow_context";
 import {Maybe, maybeOfNullable} from "../../../selectors/maybe";
 import {BufferedInputsContext, WithBufferedInputs} from "../../../contexts/input_state_management";
+import Collapse from '@material-ui/core/Collapse';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+import IconButton from '@material-ui/core/IconButton';
+import {makeStyles} from '@material-ui/core/styles';
 
+const useStyles = makeStyles((theme) => ({
+  card: {
+    borderRadius: 0
+  },
+  header: {
+    padding: '5px 5px 5px 10px'
+  }
+}));
 export default function PrimaryInputs() {
   const {commitSessionInputChanges, dispatch} = useContext(VulcanContext);
 
@@ -59,19 +76,39 @@ function PrimaryInputsInner() {
     }, {} as {[k: string]: BoundInputSpecification[]});
   }, [inputSpecifications, inputs, setInputs, state.data, state.session, state.status, workflow]);
 
+  const [ expanded, setExpanded ] = useState('');
+
+  const [ open, setOpen ] = useState(false);
+
+  const classes = useStyles();
+
   return (
-    <div className='primary-inputs'>
-      {Object.keys(groupedInputs)
-        .sort()
-        .map((groupName, index) => {
-          return (
-            <InputGroup
-              groupName={groupName}
-              key={index}
-              inputs={groupedInputs[groupName]}
-            />
-          );
-        })}
-    </div>
+    <Card className={classes.card}>
+        <Grid className={classes.header} container alignItems='center' justify='space-between'>
+          <Grid item>
+            <Typography variant='h6'>Inputs</Typography>
+          </Grid>
+          <Grid item>
+            <IconButton onClick={ () => setOpen(!open) }>
+              { open ? <ExpandLessIcon/> : <ExpandMoreIcon/>}
+            </IconButton>
+          </Grid>
+        </Grid>
+        <Collapse in={ open }>
+          {Object.keys(groupedInputs)
+            .sort()
+            .map((groupName, index) => {
+              return (
+                <InputGroup
+                  expanded={ expanded == groupName }
+                  select={ () => setExpanded(expanded == groupName ? '' : groupName) }
+                  groupName={groupName.split('_').slice(1).join(' ')}
+                  key={index}
+                  inputs={groupedInputs[groupName]}
+                />
+              );
+            })}
+        </Collapse>
+    </Card>
   );
 }

--- a/vulcan/lib/client/jsx/components/workflow/steps/animated_clock.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/animated_clock.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 export default function AnimatedClock() {
   return (
-    <article className='clock'>
+    <div className='clock'>
       <div className='hours-container'>
         <div className='hours'/>
       </div>
       <div className='minutes-container'>
         <div className='minutes'/>
       </div>
-    </article>
+    </div>
   );
 }

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_icon.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_icon.tsx
@@ -1,0 +1,62 @@
+import React, {useContext} from 'react';
+
+import {VulcanContext} from '../../../contexts/vulcan_context';
+import Icon from 'etna-js/components/icon';
+import AnimatedClock from './animated_clock';
+import {WorkflowStep} from '../../../api_types';
+import {labelOfStepOrGroupedStep, statusStringOfStepOrGroupedStep} from '../../../selectors/workflow_selectors';
+import {STATUS} from '../../../api_types';
+import {WorkflowStepGroup} from "../user_interactions/inputs/input_types";
+import {makeStyles} from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
+import CheckIcon from '@material-ui/icons/Check';
+import ClockIcon from '@material-ui/icons/AccessTime';
+import ErrorIcon from '@material-ui/icons/HighlightOff';
+
+const useStyles = makeStyles((theme) => ({
+  icon: {
+    opacity: 0.5
+  },
+  [STATUS.COMPLETE]: {
+    color: 'green'
+  },
+  [STATUS.RUNNING]: {
+    color: 'gray'
+  },
+  [STATUS.PENDING]: {
+    color: 'gray'
+  },
+  [STATUS.ERROR]: {
+    color: 'red'
+  }
+}));
+
+type IconClass = typeof CheckIcon;
+
+const icons: {[k: string]: {icon: IconClass}} = {
+  [STATUS.COMPLETE]: {icon: CheckIcon},
+  [STATUS.RUNNING]: {icon: ClockIcon},
+  [STATUS.PENDING]: {icon: ClockIcon},
+  [STATUS.ERROR]: {icon: ErrorIcon}
+};
+const StepIcon = ({
+  step
+}: {
+  step: WorkflowStep | WorkflowStepGroup;
+}) => {
+  let {state} = useContext(VulcanContext);
+  const {workflow, status} = state;
+  if (!workflow) return null;
+  const statusStr = statusStringOfStepOrGroupedStep(step, workflow, status);
+  const label = labelOfStepOrGroupedStep(step);
+  let icon_config = icons[statusStr] || icons[STATUS.PENDING];
+
+  let IconComponent:IconClass = STATUS.RUNNING === statusStr ? AnimatedClock : icon_config.icon;
+
+  const classes = useStyles();
+  return <Tooltip title={label}>
+    <IconComponent className={`${classes[ statusStr ]} ${classes.icon}`}/>
+  </Tooltip>
+}
+
+export default StepIcon;

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_name.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_name.tsx
@@ -1,57 +1,25 @@
 import React, {useContext} from 'react';
 
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-
 import {VulcanContext} from '../../../contexts/vulcan_context';
-import Icon from 'etna-js/components/icon';
-import AnimatedClock from './animated_clock';
 import {WorkflowStep} from '../../../api_types';
-import {labelOfStepOrGroupedStep, statusStringOfStepOrGroupedStep} from '../../../selectors/workflow_selectors';
+import {labelOfStepOrGroupedStep} from '../../../selectors/workflow_selectors';
 import {STATUS} from '../../../api_types';
 import {WorkflowStepGroup} from "../user_interactions/inputs/input_types";
 
-const icons: {[k: string]: {icon: string; className: string}} = {
-  [STATUS.COMPLETE]: {icon: 'check', className: 'light green'},
-  [STATUS.RUNNING]: {icon: 'clock', className: 'light'},
-  [STATUS.PENDING]: {icon: 'clock', className: 'light'},
-  [STATUS.ERROR]: {icon: 'times-circle', className: 'light red'}
-};
+import StepIcon from './step_icon';
 
 const StepName = ({
-  step,
-  showToggle,
-  open
+  step
 }: {
-  step: WorkflowStep | WorkflowStepGroup;
-  showToggle?: boolean;
-  open?: boolean;
+  step: WorkflowStep | WorkflowStepGroup
 }) => {
   let {state} = useContext(VulcanContext);
-  const {workflow, status} = state;
-  if (!workflow) return null;
-  const statusStr = statusStringOfStepOrGroupedStep(step, workflow, status);
   const label = labelOfStepOrGroupedStep(step);
-  let icon = icons[statusStr] || icons[STATUS.PENDING];
-
-  let className = `step-status-icon ${icon.className}`;
-  let IconComponent = (
-    <Icon
-      title={label}
-      className={className}
-      icon={icon.icon}
-    />
-  );
-
-  if (STATUS.RUNNING === statusStr) {
-    IconComponent = <AnimatedClock />;
-  }
 
   return (
     <div className='step-name'>
-      <div className='step-status-icon-wrapper'>{IconComponent}</div>
+      <StepIcon step={step}/>
       <div className='step-button'>{label}</div>
-      {showToggle ? open ? <ExpandLessIcon /> : <ExpandMoreIcon /> : null}
     </div>
   );
 };

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
@@ -3,11 +3,38 @@ import React, {
 } from 'react';
 
 import {VulcanContext} from '../../../contexts/vulcan_context';
-import StepName from './step_name';
+import StepIcon from './step_icon';
+import {labelOfStepOrGroupedStep} from '../../../selectors/workflow_selectors';
 import { statusOfStep } from '../../../selectors/workflow_selectors';
 import StepUserInputDrawer from './step_user_input_drawer';
 import {STATUS} from '../../../api_types';
 import {WorkflowStepGroup} from "../user_interactions/inputs/input_types";
+
+import Card from '@material-ui/core/Card';
+import Typography from '@material-ui/core/Typography';
+import Collapse from '@material-ui/core/Collapse';
+import IconButton from '@material-ui/core/IconButton';
+import Grid from '@material-ui/core/Grid';
+import {makeStyles} from '@material-ui/core/styles';
+
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+
+const useStyles = makeStyles((theme) => ({
+  card: {
+    borderRadius: 0,
+    border: '1px solid #eee'
+  },
+  error: {
+    border: '1px solid red'
+  },
+  label: {
+    paddingLeft: '5px'
+  },
+  header: {
+    padding: '5px 5px 5px 10px'
+  }
+}));
 
 export default function StepUserInputWrapper({group}: { group: WorkflowStepGroup }) {
   const [open, setOpen] = useState(true);
@@ -33,16 +60,21 @@ export default function StepUserInputWrapper({group}: { group: WorkflowStepGroup
     }
   }, [shouldOpen, shouldClose]);
 
-  return (<div
-      className={`step-user-input step ${hasValidationErrors ? 'error' : ''}`}
-    >
-      <div onClick={toggleInputs}>
-        <StepName step={group} showToggle={true} open={open}/>
-      </div>
-      <div
-        className={`step-user-input-inputs sliding-panel vertical ${open ? 'open' : 'closed'}`}
-      >
-        <StepUserInputDrawer group={group}/>
-      </div>
-    </div>);
+  const classes = useStyles();
+
+  const label = labelOfStepOrGroupedStep(group);
+  return (<Card elevation={0} className={`${classes.card} ${hasValidationErrors ? classes.error : '' } step-user-input`}>
+    <Grid justify='space-between' container onClick={toggleInputs}>
+      <Grid item container style={{width:'auto'}}>
+        <StepIcon step={group}/>
+        <Typography className={classes.label}>{label}</Typography>
+      </Grid>
+      <IconButton size='small' onClick={ () => setOpen(!open) }>
+        { open ? <ExpandLessIcon fontSize='small'/> : <ExpandMoreIcon fontSize='small'/>}
+      </IconButton>
+    </Grid>
+    <Collapse className='step-user-input-inputs' in={open}>
+      <StepUserInputDrawer group={group}/>
+    </Collapse>
+  </Card>);
 }

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: '5px'
   },
   header: {
-    padding: '5px 5px 5px 10px'
+    cursor: 'pointer'
   }
 }));
 
@@ -64,7 +64,7 @@ export default function StepUserInputWrapper({group}: { group: WorkflowStepGroup
 
   const label = labelOfStepOrGroupedStep(group);
   return (<Card elevation={0} className={`${classes.card} ${hasValidationErrors ? classes.error : '' } step-user-input`}>
-    <Grid justify='space-between' container onClick={toggleInputs}>
+    <Grid className={classes.header} justify='space-between' container onClick={toggleInputs}>
       <Grid item container style={{width:'auto'}}>
         <StepIcon step={group}/>
         <Typography className={classes.label}>{label}</Typography>

--- a/vulcan/lib/client/jsx/contexts/input_state_management.tsx
+++ b/vulcan/lib/client/jsx/contexts/input_state_management.tsx
@@ -12,6 +12,8 @@ import {mapSome, Maybe, maybeOfNullable, some, withDefault} from "../selectors/m
 import {DataEnvelope} from "../components/workflow/user_interactions/inputs/input_types";
 import {VulcanContext} from "./vulcan_context";
 
+import Button from '@material-ui/core/Button';
+
 export const defaultInputStateManagement = {
   commitSessionInputChanges(stepName: string | null, inputs: DataEnvelope<Maybe<any>>) {
     return false;
@@ -80,10 +82,10 @@ export function WithBufferedInputs({
       {children}
     </div>
     { hasInputs ? <div className='reset-or-commit-inputs'>
-      <button onClick={cancelInputs} disabled={!!state.pollingState}>
+      <Button onClick={cancelInputs} disabled={!!state.pollingState}>
         Reset
-      </button>
-      <button  
+      </Button>
+      <Button  
         onClick={commitInputs}
         style={{
           background: "linear-gradient(135deg, #6e8efb, #a777e3)",
@@ -95,7 +97,7 @@ export function WithBufferedInputs({
           }}
         disabled={!!state.pollingState}>
         Commit
-      </button>
+      </Button>
     </div> : null } 
   </BufferedInputsContext.Provider>
 }

--- a/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
+++ b/vulcan/lib/client/jsx/selectors/workflow_selectors.ts
@@ -264,8 +264,6 @@ export const inputGroupName = (name: string) => {
   let groupName = name.split('__')[0];
   if (groupName === name) return null;
 
-  groupName = groupName.replace(/_/g, ' ');
-
   return groupName;
 };
 

--- a/vulcan/lib/client/jsx/vulcan_ui.jsx
+++ b/vulcan/lib/client/jsx/vulcan_ui.jsx
@@ -3,6 +3,11 @@ import {connect} from 'react-redux';
 import {findRoute, setRoutes} from './router';
 
 import {VulcanProvider} from './contexts/vulcan_context';
+import { ThemeProvider } from '@material-ui/core/styles';
+
+import { createEtnaTheme } from 'etna-js/style/theme';
+
+const theme = createEtnaTheme("#de5833","#948f8e");
 
 // Components.
 import Browser from './components/browser.tsx';
@@ -92,14 +97,16 @@ class VulcanUI extends React.Component {
       <React.Fragment>
         <ModalDialogContainer>
           <VulcanProvider params={params}>
-            <div id='ui-container'>
-              <RemountOnParamsChange params={params}>
-                <Notifications />
-                <VulcanNav environment={environment} mode={mode} />
-                <Messages />
-                <Component key={key} {...params} />
-              </RemountOnParamsChange>
-            </div>
+            <ThemeProvider theme={theme}>
+              <div id='ui-container'>
+                <RemountOnParamsChange params={params}>
+                  <Notifications />
+                  <VulcanNav environment={environment} mode={mode} />
+                  <Messages />
+                  <Component key={key} {...params} />
+                </RemountOnParamsChange>
+              </div>
+            </ThemeProvider>
           </VulcanProvider>
         </ModalDialogContainer>
       </React.Fragment>

--- a/vulcan/lib/client/scss/clock.scss
+++ b/vulcan/lib/client/scss/clock.scss
@@ -5,11 +5,12 @@
 }
 
 .clock {
-  margin-top: 5px;
+  opacity: 0.5;
   border-radius: 50%;
-  background: #808080 no-repeat center;
+  border: gray 2.5px solid;
   height: 16px;
-  width: 16px;
+  flex: 0 0 16px;
+  margin: 2px;
   display: inline-block;
   position: relative;
 
@@ -31,7 +32,7 @@
     .minutes,
     .hours {
       position: absolute;
-      background: #bfbfbf;
+      background: gray;
     }
 
     .minutes {

--- a/vulcan/lib/client/scss/workflow.scss
+++ b/vulcan/lib/client/scss/workflow.scss
@@ -98,6 +98,7 @@
 .step-name {
   display: flex;
   align-items: center;
+  padding-left: 10px;
 
   .step-status-icon-wrapper {
     flex: 0 0 40px;
@@ -201,21 +202,7 @@
         padding: 10px;
 
         .step-name {
-          @include input-tab;
-
-          .step-button {
-            text-align: right;
-          }
-        }
-
-        &.error {
-          .step-user-input-inputs {
-            border: 1px solid red;
-          }
-        }
-
-        .step-user-input-inputs {
-          border: 1px solid #ccc;
+          flex: 1 1 auto;
         }
 
         .view_item {

--- a/vulcan/package-lock.json
+++ b/vulcan/package-lock.json
@@ -18758,6 +18758,30 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.0.tgz",
+      "integrity": "sha512-4ximSqKXLTQmYLJuvrRHtpOqniR+ASoaVK+Rxdy6ZpfsLvUqtIM7oGGgopRG+O4p9NRv/AfuVD3jsvdxyXqozQ==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.6.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "color-alpha": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
@@ -18824,6 +18848,15 @@
       "requires": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
+      }
+    },
+    "color-string": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "colorette": {
@@ -40043,6 +40076,21 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
       "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
     },
     "simplicial-complex": {
       "version": "1.0.0",

--- a/vulcan/package.json
+++ b/vulcan/package.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/parser": "^4.25.0",
     "babel-core": "^6.26.0",
     "codemirror": "^5.39.0",
+    "color": "^3.2.0",
     "css-loader": "^3.6.0",
     "d3": "^5.5.0",
     "d3-ease": "^1.0.3",


### PR DESCRIPTION
A mostly-cosmetic change that hides the primary inputs from view in a drawer unless the user specifically wants to go and muck with them. Ostensibly this means a workflow ought to run with the baked-in defaults.

I also changed the step input groups to use a similar material-ui interface for consistency, which has the benefit of making the input feed more compact and gives some nice transitions. So far I haven't touched the actual inputs, just their containers.