### PR TITLE
small change to behavior

### DIFF
--- a/polyphemus/lib/db_triage_file_etl.rb
+++ b/polyphemus/lib/db_triage_file_etl.rb
@@ -10,7 +10,9 @@ class Polyphemus
         should_ingest: true,
         @column_name => nil,
         removed_from_source: false,
-      )
+      ).where {
+        updated_at >= (cursor.updated_at || Time.at(0)) + 1
+      }
     end
   end
 end


### PR DESCRIPTION
This PR makes the ingest_files ETL time-scan based. It shouldn't affect the current CAT -> Metis / C4 ETLs, and seems like the better thing to do...basically the ETL will only ingest files that were updated after the last time the cursor ran. Which is probably how it actually behaves currently, anyways, assuming each ETL run ingests all available files..