### PR TITLE
Better tracking of changesets in CI

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -43,4 +43,6 @@ jobs:
           CI_SECRET: ${{ secrets.CI_SECRET }}
           IMAGES_POSTFIX: :master
           TARGET_ROOT_BRANCH: master
-        run: make -C ${{ matrix.test-app }} release
+        run: |
+          git fetch origin master
+          make -C ${{ matrix.test-app }} release

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -42,7 +42,7 @@ jobs:
           IS_CI: 1
           CI_SECRET: ${{ secrets.CI_SECRET }}
           IMAGES_POSTFIX: :master
-          TARGET_ROOT_BRANCH: master
+          TARGET_ROOT_BRANCH: origin/master
         run: |
           git fetch origin master
           make -C ${{ matrix.test-app }} release

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -42,4 +42,5 @@ jobs:
           IS_CI: 1
           CI_SECRET: ${{ secrets.CI_SECRET }}
           IMAGES_POSTFIX: :master
+          TARGET_ROOT_BRANCH: master
         run: make -C ${{ matrix.test-app }} release

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -6,11 +6,11 @@ on:
       - '*/*'
       - '*/*/*'
       - '!master'
-      # The swarm stacks branch is for keeping up to date with swarm stack configuration,
-      # thus running CI on it would be a major waste.
       - '!swarm/stacks'
       - '!production'
       - '!staging'
+      - '!production-build'
+      - '!staging-build'
 
 jobs:
   test:
@@ -37,9 +37,9 @@ jobs:
       - name: Run ${{ matrix.test-app }} test suite
         id: app_first_test_run
         env:
+          # Runs tests and builds images, but does not push (PUSH_IMAGES not set to 1)
           IMAGES_PREFIX: etnaagent/
           IS_CI: 1
           CI_SECRET: ${{ secrets.CI_SECRET }}
           IMAGES_POSTFIX: :master
-        run: |
-          make -C ${{ matrix.test-app }} release
+        run: make -C ${{ matrix.test-app }} release

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,7 @@ jobs:
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :master
           NO_TEST: 1
-          TARGET_ROOT_BRANCH: staging
+          TARGET_ROOT_BRANCH: origin/staging
         run: |
           git fetch origin staging
           make -j 4 release

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,14 @@ on:
     branches:
       - master
 
+# Ensure only one of these builds at a given time.
+concurrency:
+  group: master-build
+  # do not cancel mid subtree syncing, allow it to complete before
+  # we even proceed.
+  # cancel-in-progress: false
+
+
 jobs:
   sync-subtrees:
     runs-on: ubuntu-latest
@@ -15,14 +23,14 @@ jobs:
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
-      - name: Test + Push Release
+      - name: Build & Push master tag images to dockerhub
         env:
           IS_CI: 1
           PUSH_IMAGES: 1
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :master
           NO_TEST: 1
-        run: make release
+        run: make -j 4 release
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.SYNC_ACCESS_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,6 +30,7 @@ jobs:
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :master
           NO_TEST: 1
+          TARGET_ROOT_BRANCH: staging
         run: make -j 4 release
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,9 @@ jobs:
           IMAGES_POSTFIX: :master
           NO_TEST: 1
           TARGET_ROOT_BRANCH: staging
-        run: make -j 4 release
+        run: |
+          git fetch origin staging
+          make -j 4 release
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.SYNC_ACCESS_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,24 +4,32 @@ on:
     branches:
       - production
 
+# Ensure only one of these builds at a given time.
+concurrency:
+  group: production-build
+  cancel-in-progress: true
+
 jobs:
   build-production:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          # Arbitrarily deep in order for find-parent-pr-merge.sh to work.
-          fetch-depth: 10
+          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
-      - name: Test + Push Release
+      - name: Build & Push production tag images to dockerhub
         env:
           IS_CI: 1
           PUSH_IMAGES: 1
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :production
           NO_TEST: 1
-        run: make -j 4 release
+          TARGET_ROOT_BRANCH: production-build
+        run: |
+          git fetch origin production-build
+          make -j 4 release
+          git push origin HEAD:production-build --force
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :production
           NO_TEST: 1
-          TARGET_ROOT_BRANCH: production-build
+          TARGET_ROOT_BRANCH: origin/production-build
         run: |
           git fetch origin production-build
           make -j 4 release

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,8 @@ on:
       - '!swarm/stacks'
       - '!production'
       - '!staging'
+      - '!production-build'
+      - '!staging-build'
 
 jobs:
   test:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,24 +4,33 @@ on:
     branches:
       - staging
 
+# Ensure only one of these builds at a given time.
+concurrency:
+  group: staging-build
+  cancel-in-progress: true
+
+
 jobs:
   build-staging:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          # Arbitrarily deep in order for find-parent-pr-merge.sh to work.
-          fetch-depth: 10
+          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
-      - name: Test + Push Release
+      - name: Build & Push staging tag images to dockerhub
         env:
           IS_CI: 1
           PUSH_IMAGES: 1
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :staging
           NO_TEST: 1
-        run: make -j 4 release
+          TARGET_ROOT_BRANCH: staging-build
+        run: |
+          git fetch origin production
+          make -j 4 release
+          git push origin HEAD:staging-build --force
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,7 +28,7 @@ jobs:
           IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :staging
           NO_TEST: 1
-          TARGET_ROOT_BRANCH: staging-build
+          TARGET_ROOT_BRANCH: origin/staging-build
         run: |
           git fetch origin production
           make -j 4 release

--- a/docker/build_support/find-oldest-branch-root.sh
+++ b/docker/build_support/find-oldest-branch-root.sh
@@ -2,5 +2,20 @@
 
 set -e
 
-git log --pretty='format:%h %an' | grep GithubAction | head -n 1 | cut -d' ' -f1
+if [[ -z "$IS_CI" ]]; then
+  echo "found branch root at HEAD~1" >&2
+  echo HEAD~1
+  exit 0
+fi
+
+if ! [[ -z "$TARGET_ROOT_BRANCH "]]; then
+  echo "found branch root at $TARGET_ROOT_BRANCH" >&2
+  echo $TARGET_ROOT_BRANCH
+  exit 0
+fi
+
+result=$(git log --pretty='format:%h %an' | grep GithubAction | head -n 2 | cut -d' ' -f1)
+echo "found branch root at $result" >&2
+echo "$result"
+
 

--- a/docker/build_support/find-oldest-branch-root.sh
+++ b/docker/build_support/find-oldest-branch-root.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if ! [[ -z "$TARGET_ROOT_BRANCH "]]; then
+if ! test -z "$TARGET_ROOT_BRANCH"; then
   echo "found branch root at $TARGET_ROOT_BRANCH" >&2
   echo $TARGET_ROOT_BRANCH
   exit 0

--- a/docker/build_support/find-oldest-branch-root.sh
+++ b/docker/build_support/find-oldest-branch-root.sh
@@ -2,20 +2,11 @@
 
 set -e
 
-if [[ -z "$IS_CI" ]]; then
-  echo "found branch root at HEAD~1" >&2
-  echo HEAD~1
-  exit 0
-fi
-
 if ! [[ -z "$TARGET_ROOT_BRANCH "]]; then
   echo "found branch root at $TARGET_ROOT_BRANCH" >&2
   echo $TARGET_ROOT_BRANCH
   exit 0
 fi
 
-result=$(git log --pretty='format:%h %an' | grep GithubAction | head -n 2 | cut -d' ' -f1)
-echo "found branch root at $result" >&2
-echo "$result"
-
-
+echo "found branch root at HEAD~1" >&2
+echo HEAD~1


### PR DESCRIPTION
I made a change to ensure that in CI, only projects that "have a recent change" actually get built and tested to continue to improve branch and CI performance.

this works.  It works so well, it demonstrated that the concept of "have a recent change" was previously ill defined.

Previously, I relied on search git history for commits that belong to GithubAction, which are commits created on master while syncing subtrees.

The problem is that the way sync subtrees writes commits is, not nearly as neat as I thought it would be.  It interweaves subtree merge commits across repos in an inconsistent way which made this definition of 'have a recent change" unreliable, and sometimes CI wasn't building and releasing images of things that actually changed.

To fix this, I've introduced two new branches `staging-build` and `production-build` which help track "build state" in a more sane way.  (I could have used tags, but it resulted in more complex git fetch commands than branches).

1.  Branches build by comparing themselves against master.  Ideally, this would check by comparing against the pull request target instead of master, but I haven't worked this out quite yet.  This still works in 99.999% of cases.
2.  Master builds by comparing itself against staging.  It then pushes itself to staging, which triggers automatically
3.  Staging builds by comparing itself against staging-build.  It then pushes itself to staging-build.  The push to production is still a PR.
4.  Production builds by comparing itself against production-build.  It then pushes itself to production-build.  production-build is a terminal point that merely tracks state of what has been successfully built and pushed.