### PR TITLE
scRNAseq - all batch correct by record ID

### DIFF
--- a/vulcan/lib/server/workflows/scripts/determine_batch_by_options.py
+++ b/vulcan/lib/server/workflows/scripts/determine_batch_by_options.py
@@ -3,7 +3,7 @@ from archimedes.functions.dataflow import output_json, input_json, output_var
 pdat = input_json("project_data")
 
 no_batch='NO BATCH CORRECTION'
-opts = [no_batch] + list(pdat['color_options'].keys())
+opts = [no_batch, 'Record_ID'] + list(pdat['color_options'].keys())
 
 output_json(opts, 'batch_options')
 output_var(no_batch, 'no_batch_string')


### PR DESCRIPTION
I've realized that even though we have the batch correction algorithm worked in the scRNAseq workflow, there's not actually a valid option that makes sense for running batch correction within IPI.

I want to add an option that's "Record_or_Pool" which should reflect sequencing batches, but that would require an update to the project definitions with a slot for the pool_model name.  I've started an implementation of this (not pushed), but it gets a bit more complicated than I'd like for something I want to squeeze in before Tuesday.

An option in the interim, because all of the ready-to-use ipi single-cell data is non-pools, is to just use the Record_IDs themselves.  That's what this PR does.