### PR TITLE
Magma query attribute distinct

### DIFF
--- a/magma/lib/magma/query/distinct.rb
+++ b/magma/lib/magma/query/distinct.rb
@@ -1,13 +1,11 @@
 class Magma
   class Distinct
-    attr_reader :table_alias
-
-    def initialize(table_alias)
-      @table_alias = table_alias
+    def initialize(column_name)
+      @column_name = column_name
     end
 
     def apply(query)
-      query.distinct.unordered
+      query.distinct.order(@column_name)
     end
   end
 end

--- a/magma/lib/magma/query/distinct.rb
+++ b/magma/lib/magma/query/distinct.rb
@@ -1,0 +1,13 @@
+class Magma
+  class Distinct
+    attr_reader :table_alias
+
+    def initialize(table_alias)
+      @table_alias = table_alias
+    end
+
+    def apply(query)
+      query.distinct.unordered
+    end
+  end
+end

--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -359,8 +359,8 @@ EOT
       )
     end
 
-    def distinct_constraint
-      Magma::Distinct.new(alias_name)
+    def distinct_constraint column_name
+      Magma::Distinct.new(Sequel.qualify(alias_name, column_name))
     end
 
     def invalid_argument! argument

--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -359,6 +359,10 @@ EOT
       )
     end
 
+    def distinct_constraint
+      Magma::Distinct.new(alias_name)
+    end
+
     def invalid_argument! argument
       raise QuestionError, "Expected an argument to #{self.class.name}" if argument.nil?
       raise QuestionError, "#{argument} is not a valid argument to #{self.class.name}"

--- a/magma/lib/magma/query/predicate/column.rb
+++ b/magma/lib/magma/query/predicate/column.rb
@@ -31,6 +31,10 @@ class Magma
       @arguments.empty? ? [ Sequel[alias_name][@column_name].as(column_name) ] : []
     end
 
+    def attribute_column_name
+      @column_name
+    end
+
     protected
 
     def column_name

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -140,7 +140,7 @@ class Magma
       child :record_child
 
       constraint do
-        distinct_constraint
+        distinct_constraint(record_child.child_predicate.attribute_column_name)
       end
 
       select_columns do
@@ -148,7 +148,7 @@ class Magma
       end
 
       extract do |table|
-        table.map do |row| row.values end.flatten.uniq.sort
+        table.map do |row| row.values end.flatten.uniq.compact
       end
       format { [ child_format ] }
     end

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -140,6 +140,8 @@ class Magma
       child :record_child
 
       constraint do
+        validate_distinct
+
         distinct_constraint(record_child.child_predicate.attribute_column_name)
       end
 
@@ -269,6 +271,12 @@ class Magma
       end
 
       alias_for_column(attr.column_name)
+    end
+
+    private
+
+    def validate_distinct
+      raise ArgumentError.new("Can only use ::distinct on string attributes.") unless record_child.child_predicate.is_a?(Magma::StringPredicate)
     end
   end
 end

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -24,7 +24,7 @@ class Magma
     #      ::all - returns every item in the list, represented by a Model
     #      ::count - returns the number of items in the list
     #      ::every - a Boolean that returns true if every item in the list is non-zero
-    #      ::distinct - returns distinct values of items in the list
+    #      ::distinct - returns distinct values of items in the list. Only works with model -> attribute
 
     attr_reader :model
 

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -1,6 +1,7 @@
 require_relative 'predicate'
 require_relative 'join'
 require_relative 'constraint'
+require_relative 'distinct'
 require_relative 'query_executor'
 
 # A query for a piece of data. Each question is a path through the data

--- a/magma/lib/magma/query/verb.rb
+++ b/magma/lib/magma/query/verb.rb
@@ -117,5 +117,20 @@ class Magma
     def get_subquery_config(*args)
       @subquery_config
     end
+
+    def select_columns(*args, &block)
+      @select_columns = block_given? ? block : args
+    end
+
+    def get_select_columns
+      case @select_columns
+      when Symbol
+        @predicate.send @select_columns
+      when Proc
+        @predicate.instance_exec(&@select_columns)
+      else
+        raise "Cannot determine select_columns for #{@predicate}"
+      end
+    end
   end
 end

--- a/magma/spec/fixtures/labors_model_attributes.yml
+++ b/magma/spec/fixtures/labors_model_attributes.yml
@@ -100,6 +100,7 @@ characteristic:
     type: string
   value:
     type: string
+    column_name: old_value
 project:
   name:
     type: identifier

--- a/magma/spec/labors/migrations/26_change_characteristic_value_name.rb
+++ b/magma/spec/labors/migrations/26_change_characteristic_value_name.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(Sequel[:labors][:characteristics]) do
+      rename_column :value, :old_value
+    end
+  end
+end

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -1320,9 +1320,6 @@ describe QueryController do
       lion_stance = create(:characteristic, labor: lion, name: "stance", value: "wrestling2.0" )
       hydra_stance = create(:characteristic, labor: hydra, name: "stance", value: "hacking1.5" )
       stables_stance = create(:characteristic, labor: stables, name: "stance", value: "shoveling:00123" )
-
-      create(:characteristic, labor: lion, name: "weather", value: "sunny" )
-      create(:characteristic, labor: hydra, name: "weather", value: "overcast" )
     end
 
     it 'supports ::matches' do


### PR DESCRIPTION
This PR adds a `::distinct` verb to the model predicates, to allow you to grab all distinct values of an attribute. i.e. `["demographic", "::distinct", "name"]` returns the existing table `name` entries.

This is in preparation of simplifying the Query UI to pre-populate some clause fields as dropdowns instead of blank text fields.

Note, this doesn't work for foreign key relationships or JSON entries (i.e. files)....not sure if that's okay? We could get the files working by converting the columns to JSONB instead of JSON, but in reality all the file attributes are unique and distinct anyways, so I don't think that's really in our use case.