### PR TITLE
separate output logs endpoint from etl_config

### DIFF
--- a/polyphemus/lib/client/jsx/etl/etl-config.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-config.tsx
@@ -150,7 +150,7 @@ const EtlConfig = ({project_name, etl,name,config,status,secrets,params,output,r
       <ConfigurePane error={error} name={name} project_name={project_name} selected={mode} config={config} job={job} update={postUpdate}/>
       <RunPane error={error} selected={mode} run_interval={run_interval} update={postUpdate} params={params} param_opts={ job ? job.params : null } />
       <RemovePane selected={mode} update={postUpdate}/>
-      <LogsPane selected={mode} output={output}/>
+      <LogsPane selected={mode} name={name} project_name={project_name}/>
       <SecretsPane error={error} selected={mode} update={postUpdate} keys={ job ? job.secrets : null} secrets={secrets}/>
     </CardContent>
   </Card>

--- a/polyphemus/lib/client/jsx/etl/logs-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/logs-pane.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Button from '@material-ui/core/Button';
 import EtlPane, {EtlPaneHeader} from './etl-pane';
 import {makeStyles} from '@material-ui/core/styles';
 import { Controlled } from 'react-codemirror2';
 import Typography from '@material-ui/core/Typography';
+import { json_get } from 'etna-js/utils/fetch';
 
 const useStyles = makeStyles( theme => ({
   editor: {
@@ -14,8 +15,17 @@ const useStyles = makeStyles( theme => ({
   }
 }));
 
-const LogsPane = ({selected, output}:{selected:string|null,output:string}) => {
+const LogsPane = ({selected, name, project_name}:{selected:string|null,name:string,project_name:string}) => {
   const classes = useStyles();
+  const [ output, setOutput ] = useState('');
+
+  useEffect( () => {
+    json_get(
+      `/api/etl/${project_name}/output/${name}`
+    ).then(
+      ({output}) => setOutput(output)
+    )
+  }, []);
 
   return <EtlPane mode='logs' selected={selected}>
     <EtlPaneHeader title='Logs'/>

--- a/polyphemus/lib/models/etl_config.rb
+++ b/polyphemus/lib/models/etl_config.rb
@@ -101,7 +101,7 @@ class Polyphemus
           next [ key, secrets.map do |skey, secret|
             [ skey, secret.to_s.empty? ? '' : '***' ]
           end.to_h ]
-        when :id
+        when :output, :id
           next
         else
           case value

--- a/polyphemus/lib/polyphemus/controllers/etl_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/etl_controller.rb
@@ -20,6 +20,17 @@ class EtlController < Polyphemus::Controller
     success_json(etl_configs.map(&:to_revision))
   end
 
+  def output
+    etl_config = Polyphemus::EtlConfig.exclude(archived: true).where(
+      project_name: @params[:project_name],
+      name: @params[:name]
+    ).first
+
+    raise Etna::FileNotFound, "No such etl #{@params[:name]} configured for project #{@params[:project_name]}" unless etl_config
+
+    success_json(output: etl_config.output)
+  end
+
   def update
     etl_configs = Polyphemus::EtlConfig.exclude(archived: true).where(
       project_name: @params[:project_name],

--- a/polyphemus/lib/server.rb
+++ b/polyphemus/lib/server.rb
@@ -29,6 +29,7 @@ class Polyphemus
     post '/api/etl/:project_name/update/:name', action: 'etl#update', auth: { user: { can_edit?: :project_name } }, log_redact_keys: [ :secrets ]
     post '/api/etl/:project_name/create/:name', action: 'etl#create', auth: { user: { can_edit?: :project_name } }
     get '/api/etl/:project_name/revisions/:name', action: 'etl#revisions', auth: { user: { can_edit?: :project_name } }
+    get '/api/etl/:project_name/output/:name', action: 'etl#output', auth: { user: { can_edit?: :project_name } }
 
     get '/' do erb_view(:client) end
 

--- a/polyphemus/spec/etl_controller_spec.rb
+++ b/polyphemus/spec/etl_controller_spec.rb
@@ -15,10 +15,23 @@ describe EtlController do
       expect(last_response.status).to eq(200)
       expect(json_body.length).to eq(1)
       expect(json_body.first.keys).to match_array([
-        :project_name, :etl, :name, :ran_at, :run_interval, :archived, :status, :output, :updated_at, :created_at, :config, :comment, :secrets, :params
+        :project_name, :etl, :name, :ran_at, :run_interval, :archived, :status, :updated_at, :created_at, :config, :comment, :secrets, :params
       ])
       expect(json_body.first[:project_name]).to eq('labors')
       expect(json_body.first[:secrets]).to eq(password: '***')
+    end
+  end
+
+  context '#output' do
+    it 'returns output for an etl_config' do
+      output = 'A serious error happened'
+      create_dummy_etl(run_interval: Polyphemus::EtlConfig::RUN_NEVER, output: output)
+      auth_header(:editor)
+      get(URI.encode('/api/etl/labors/output/Dummy ETL'))
+
+      expect(last_response.status).to eq(200)
+      expect(json_body.length).to eq(1)
+      expect(json_body).to eq(output: output)
     end
   end
 


### PR DESCRIPTION
A little quality-of-life one just separating out a logging (output) endpoint for the Polyphemus ETL config UI. In the absence, some processes generate large logs which results in a very large loading time for the config list. This splits to loading in the background (though all the data is still loaded at once, not when you click through to individual panes), hopefully making this easier.

Not done here is some indication that Polyphemus is loading during this process. There is no throbber for Polyphemus, and I wish there were a more generic Etna interface to track the getting of data (possibly hooking into json_get, etc.).