### PR TITLE
Metis thumbnail report non images locally

### DIFF
--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -179,7 +179,6 @@ class Metis
         update(has_thumbnail: true)
       rescue Vips::Error => e
         update(has_thumbnail: false)
-        puts e.message
         Metis.instance.logger.error(e.message)
       ensure
         refresh

--- a/metis/lib/models/data_block.rb
+++ b/metis/lib/models/data_block.rb
@@ -179,7 +179,8 @@ class Metis
         update(has_thumbnail: true)
       rescue Vips::Error => e
         update(has_thumbnail: false)
-        Metis.instance.logger.log_error(e)
+        puts e.message
+        Metis.instance.logger.error(e.message)
       ensure
         refresh
       end


### PR DESCRIPTION
Simple change to reduce spurious Rollbar notifications. Non-image blocks will get still logged in the container logs.