### PR TITLE
update python version

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -27,6 +27,7 @@ jobs:
           - etna
           - archimedes
           - deployer
+          - airflow
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -28,7 +28,6 @@ jobs:
           - archimedes
           - deployer
           - airflow
-          - swarm/swarm-keeper
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -28,6 +28,7 @@ jobs:
           - archimedes
           - deployer
           - airflow
+          - swarm/swarm-keeper
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM known_hosts
 FROM bash_mocker
 
-FROM apache/airflow:2.2.2
+FROM apache/airflow:2.2.2-python3.7
 
 # This drops an sqlite database in the base directory which is not used in production,
 # but enables much faster testing since the migrations do not need to be run.

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM known_hosts
 FROM bash_mocker
 
-FROM apache/airflow:2.2.2-python3.9
+FROM apache/airflow:2.2.2-python3.8
 
 # This drops an sqlite database in the base directory which is not used in production,
 # but enables much faster testing since the migrations do not need to be run.

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM known_hosts
 FROM bash_mocker
 
-FROM apache/airflow:2.2.2-python3.7
+FROM apache/airflow:2.2.2-python3.9
 
 # This drops an sqlite database in the base directory which is not used in production,
 # but enables much faster testing since the migrations do not need to be run.

--- a/airflow/opt/requirements.txt
+++ b/airflow/opt/requirements.txt
@@ -64,7 +64,6 @@ boto3==1.18.65
 botocore==1.21.65
 cached-property==1.5.2
 cachetools==4.2.2
-cattrs==1.5.0
 celery==5.2.0
 certifi==2020.12.5
 cffi==1.15.0


### PR DESCRIPTION
I think the pypi install issue was because the default python version in the container was python 3.6. Looks like libraries like cattrs and celery have removed support for python 3.6, so this PR pins to pythonn 3.7 (which those libraries still support). We could also pin to say, 3.9 if we want to future proof a bit.