### PR TITLE
hotfix to fix "options" route; all automated tasks were breaking...

### DIFF
--- a/etna/lib/etna/auth.rb
+++ b/etna/lib/etna/auth.rb
@@ -116,6 +116,9 @@ module Etna
       route = server.find_route(request)
 
       payload = payload.map{|k,v| [k.to_sym, v]}.to_h
+
+      return payload unless route
+
       begin      
         permissions = Etna::Permissions.from_encoded_permissions(payload[:perm])
 
@@ -142,7 +145,8 @@ module Etna
         return request.env['etna.user'] = Etna::User.new(
           update_payload(payload, token, request),
           token)
-      rescue
+      rescue => e
+        Magma.instance.logger.log_error(e)
         # bail out if anything goes wrong
         return false
       end

--- a/etna/lib/etna/auth.rb
+++ b/etna/lib/etna/auth.rb
@@ -146,7 +146,7 @@ module Etna
           update_payload(payload, token, request),
           token)
       rescue => e
-        Magma.instance.logger.log_error(e)
+        application.logger.log_error(e)
         # bail out if anything goes wrong
         return false
       end


### PR DESCRIPTION
This PR fixes a bug I introduced with the resource projects, where basically `OPTIONS` route (used to describe routes for the etna clients) never recognized a user token. This is because it is not an actual "route" and so `route` is `nil`, causing a breakage in the `route.ignore_janus?` and `route.has_auth_constraint` checks.

This bug is probably causing all the ETLs / scripts to break, since the etna client classes can't communicate with any of the apps...