### PR TITLE
use update_json to make sure dry_run flag is boolean

### DIFF
--- a/polyphemus/lib/ipi/flow_fcs_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_fcs_file_linker.rb
@@ -60,7 +60,7 @@ class IpiFlowFcsLinker < Etna::Clients::Magma::FileLinkingWorkflow
       update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: 'ipi')
       update_request.update_revision(model_name, id, revision)
       puts "Updating #{model_name}, record #{id}."
-      magma_crud.magma_client.update(update_request)
+      magma_crud.magma_client.update_json(update_request)
     end
   end
 end

--- a/polyphemus/lib/ipi/flow_wsp_file_linker.rb
+++ b/polyphemus/lib/ipi/flow_wsp_file_linker.rb
@@ -51,7 +51,7 @@ class IpiFlowWspLinker < Etna::Clients::Magma::FileLinkingWorkflow
       update_request = Etna::Clients::Magma::UpdateRequest.new(project_name: 'ipi')
       update_request.update_revision(model_name, id, revision)
       puts "Updating #{model_name}, record #{id}."
-      magma_crud.magma_client.update(update_request)
+      magma_crud.magma_client.update_json(update_request)
     end
   end
 end


### PR DESCRIPTION
This PR fixes a bug with the Polyphemus IPI Flow linker commands that was introduced with the `dry_run` flag (created for REDCap loading). Using the form `update` method causes `dry_run` to always be a string, which means `dry_run=false` is evaluated as true and updates would never execute with these two commands. Ideally we migrate these to ETLs at some point, or IPI flow will finally end...