### PR TITLE
Redcap loading in chunks

### DIFF
--- a/etna/lib/etna/clients/magma/models.rb
+++ b/etna/lib/etna/clients/magma/models.rb
@@ -215,8 +215,8 @@ module Etna
         end
 
         def model(model_key)
-          return nil unless raw.include?(model_key)
-          Model.new(raw[model_key])
+          return nil unless raw.include?(model_key.to_s)
+          Model.new(raw[model_key.to_s])
         end
 
         def all
@@ -434,8 +434,8 @@ module Etna
         end
 
         def attribute(attribute_key)
-          return nil unless raw.include?(attribute_key)
-          Attribute.new(raw[attribute_key])
+          return nil unless raw.include?(attribute_key.to_s)
+          Attribute.new(raw[attribute_key.to_s])
         end
 
         def build_attribute(key)

--- a/magma/config.yml.template
+++ b/magma/config.yml.template
@@ -6,6 +6,8 @@
     :adapter: postgres
     :user: developer
     :password: password
+  :janus:
+    :host: https://janus.development.local
   :host: https://magma.development.local
   :log_file: /dev/stdout
   :log_level: info

--- a/polyphemus/lib/client/jsx/etl/logs-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/logs-pane.tsx
@@ -27,6 +27,7 @@ const LogsPane = ({selected, name, project_name}:{selected:string|null,name:stri
     )
   }, []);
 
+
   return <EtlPane mode='logs' selected={selected}>
     <EtlPaneHeader title='Logs'/>
     <div className={classes.editor}>
@@ -44,6 +45,7 @@ const LogsPane = ({selected, name, project_name}:{selected:string|null,name:stri
         onBeforeChange={(editor, data, value) => { }}
       />
     </div>
+    { output && <a href={URL.createObjectURL(new Blob([output], { type: 'text/plain' }))} download={ `log-${project_name}-${name}.txt` }>Download log</a> }
   </EtlPane>
 }
 

--- a/polyphemus/lib/etls/redcap/lib/loader.rb
+++ b/polyphemus/lib/etls/redcap/lib/loader.rb
@@ -55,6 +55,12 @@ module Redcap
       end
     end
 
+    def patch_attribute(records, model_name, record_name, att_name, value)
+      records[ model_name.to_sym ] ||= {}
+      records[ model_name.to_sym ][ record_name ] ||= {}
+      records[ model_name.to_sym ][ record_name ][ att_name ] = value
+    end
+
     def patch_tables
       # find any table attributes
       magma_models_wrapper.models.model_keys.each do |model_name|
@@ -69,9 +75,7 @@ module Redcap
                   record[ model_name.to_sym ]
                 end.each do |model_record_name, revisions|
                   temp_id_names = revisions.map(&:first)
-                  records[ model_name.to_sym ] ||= {}
-                  records[ model_name.to_sym ][ model_record_name ] ||= {}
-                  records[ model_name.to_sym ][ model_record_name ][ att_name ] = temp_id_names
+                  patch_attribute(records, model_name, model_record_name, att_name, temp_id_names)
                 end
 
                 # Blank out records that have no data if user specifies a
@@ -84,9 +88,8 @@ module Redcap
                     found_record_names.include?(r)
                   end
                   @records_to_blank[ model_name.to_sym ].each do |model_record_name|
-                    records[ model_name.to_sym ] ||= {}
-                    records[ model_name.to_sym ][ model_record_name ] ||= {}
-                    records[ model_name.to_sym ][ model_record_name ][ att_name ] = [] # empty array in Magma removes existing table records for an attribute
+                    # empty array in Magma removes existing table records for an attribute
+                    patch_attribute(records, model_name, model_record_name, att_name, [])
                   end
                 end
               end

--- a/polyphemus/lib/etls/redcap/lib/magma_models.rb
+++ b/polyphemus/lib/etls/redcap/lib/magma_models.rb
@@ -48,9 +48,13 @@ module Redcap
 
       return false unless parent_name
 
-      models.model(
-        parent_name
-      ).template.attributes.attribute(
+      parent = models.model(
+        parent_model_name(model_name.to_s)
+      )
+
+      return false unless parent
+
+      parent.template.attributes.attribute(
         model_name.to_s
       ).attribute_type == Etna::Clients::Magma::AttributeType::TABLE
     end

--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -49,6 +49,19 @@ class Polyphemus
       page[ entry[:model_name] ] [ entry[:record_name ] ] = entry[:record]
     end
 
+    def update_page(page, update)
+      update.each do |model_name, records|
+        records.each do |record_name, record|
+          add_to_page(
+            page,
+            model_name: model_name,
+            record_name: record_name,
+            record: record
+          )
+        end
+      end
+    end
+
     # the page size is approximate
     def paginate(loader, all_records, &block)
       flat_records = all_records.map do |model_name, records|
@@ -94,7 +107,7 @@ class Polyphemus
         add_to_page( page, flat_record )
 
         if page_count > @page_size
-          results.update(yield page)
+          update_page(results, yield(page))
 
           page = {}
           page_count = 0
@@ -102,7 +115,7 @@ class Polyphemus
       end
 
       unless page.empty?
-        results.update(yield page)
+        update_page(results, yield(page))
       end
 
       results

--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -130,9 +130,6 @@ class Polyphemus
             dry_run: !commit)
           select_documents(magma_client.update_json(update_request))
         end
-      rescue Etna::Error => e
-        require 'pry'
-        binding.pry
       end
 
       logger.write(JSON.pretty_generate(magma_documents))

--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -20,7 +20,7 @@ class Polyphemus
     attr_reader :magma_client, :update_request, :model_names, :redcap_tokens, :redcap_host, :magma_host, :dateshift_salt, :mode
 
     # Override initialize, user won't be passing in a filename directly as with other ETLs.
-    def initialize(project_name:, model_names: "all", redcap_tokens:, redcap_host:, magma_host:, dateshift_salt:, mode: 'default', config:)
+    def initialize(project_name:, model_names: "all", redcap_tokens:, redcap_host:, magma_host:, dateshift_salt:, mode: 'default', config:, page_size: 20000)
       raise "No dateshift_salt provided, please provide one." unless dateshift_salt
       raise "Mode must be \"default\", \"existing\", or \"strict\"." unless ['default', 'existing', 'strict'].include?(mode)
       raise "Must provide at least one REDCap token." unless redcap_tokens && redcap_tokens.length > 0
@@ -41,6 +41,71 @@ class Polyphemus
       @magma_host = magma_host
       @dateshift_salt = dateshift_salt
       @mode = mode # operating mode: nil, "strict", "existing"
+      @page_size = page_size
+    end
+
+    def add_to_page(page, entry)
+      page[ entry[:model_name] ] ||= {}
+      page[ entry[:model_name] ] [ entry[:record_name ] ] = entry[:record]
+    end
+
+    # the page size is approximate
+    def paginate(loader, all_records, &block)
+      flat_records = all_records.map do |model_name, records|
+        next if loader.magma_models_wrapper.is_table?(model_name)
+
+        records.map do |record_name, record|
+          flat = {
+            model_name: model_name,
+            record_name: record_name,
+            record: record
+          }
+
+          extras = []
+          record.each do |attribute_name, value|
+            att = loader.magma_models_wrapper.models.model(model_name).template.attributes.attribute(attribute_name)
+
+            if att.attribute_type == 'table'
+              value.each do |table_entry_name|
+                table_record = all_records[ att.link_model_name.to_sym ][table_entry_name]
+                extras.push(
+                  {
+                    model_name: att.link_model_name.to_sym,
+                    record_name: table_entry_name,
+                    record: table_record
+                  }
+                )
+              end
+            end
+          end
+
+          flat[:extras] = extras
+
+          flat
+        end
+      end.compact.flatten(1).shuffle
+
+      page_count = 0
+      page = {}
+      results = {}
+      flat_records.each do |flat_record|
+        page_count += 1 + flat_record[:extras].size
+
+        add_to_page( page, flat_record )
+
+        if page_count > @page_size
+          results.update(yield page)
+
+          page = {}
+          page_count = 0
+        end
+      end
+
+      unless page.empty?
+        results.update(yield page)
+      end
+
+      results
     end
 
     def run(magma_client:, commit: false, logger: STDOUT)
@@ -57,11 +122,18 @@ class Polyphemus
       logger.write("\n==== DRY RUN! ====\n") if !commit
       logger.write("Posting revisions.\n")
 
-      update_request = Etna::Clients::Magma::UpdateRequest.new(
-        project_name: @project_name,
-        revisions: all_records,
-        dry_run: !commit)
-      magma_documents = select_documents(magma_client.update_json(update_request))
+      begin
+        magma_documents = paginate(loader, all_records) do |records|
+          update_request = Etna::Clients::Magma::UpdateRequest.new(
+            project_name: @project_name,
+            revisions: records,
+            dry_run: !commit)
+          select_documents(magma_client.update_json(update_request))
+        end
+      rescue Etna::Error => e
+        require 'pry'
+        binding.pry
+      end
 
       logger.write(JSON.pretty_generate(magma_documents))
       logger.write("\n")

--- a/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
+++ b/polyphemus/spec/etls/redcap/redcap_etl_script_runner_spec.rb
@@ -237,7 +237,7 @@ describe Polyphemus::RedcapEtlScriptRunner do
 
       # ensure containing records works for model_two
       injected_parent_id = "#{id_123}-one"
-      expect(records[:model_one][injected_parent_id][:parent]).to eq("#{injected_parent_id}-parent")
+      expect(records[:model_one][injected_parent_id][:parent_model]).to eq("#{injected_parent_id}-parent")
     end
 
     it 'specific models' do

--- a/polyphemus/spec/fixtures/etls/redcap/test.rb
+++ b/polyphemus/spec/fixtures/etls/redcap/test.rb
@@ -35,7 +35,7 @@ define_model("ModelTwo").class_eval do
     
     model_one_names.map do |model_one_name|
       result[model_one_name] ||= {}
-      result[model_one_name][:parent] = "#{model_one_name}-parent"
+      result[model_one_name][:parent_model] = "#{model_one_name}-parent"
     end
 
     {

--- a/polyphemus/spec/fixtures/magma_test_models.json
+++ b/polyphemus/spec/fixtures/magma_test_models.json
@@ -34,6 +34,18 @@
             "hidden": false,
             "validation": null,
             "attribute_type": "identifier"
+          },
+          "model_one": {
+            "name": "model_one",
+            "attribute_name": "model_one",
+            "model_name": "model_one",
+            "link_model_name": "model_one",
+            "display_name": "Model One",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "collection"
           }
         }
       }
@@ -44,6 +56,18 @@
         "name": "model_one",
         "identifier": "name",
         "attributes": {
+          "parent_model": {
+            "name": "parent_model",
+            "attribute_name": "parent_model",
+            "model_name": "parent_model",
+            "link_model_name": "parent_model",
+            "display_name": "Parent Model",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "parent"
+          },
           "birthday": {
             "name": "birthday",
             "attribute_name": "birthday",

--- a/polyphemus/spec/fixtures/magma_test_models.json
+++ b/polyphemus/spec/fixtures/magma_test_models.json
@@ -85,6 +85,18 @@
             "hidden": false,
             "validation": null,
             "attribute_type": "collection"
+          },
+          "model_with_alternate_id": {
+            "name": "model_with_alternate_id",
+            "attribute_name": "model_with_alternate_id",
+            "model_name": "model_with_alternate_id",
+            "link_model_name": "model_with_alternate_id",
+            "display_name": "Model With Alternate Id",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "collection"
           }
         }
       }
@@ -165,6 +177,17 @@
             "hidden": false,
             "validation": null,
             "attribute_type": "table"
+          },
+          "citation": {
+            "name": "citation",
+            "attribute_name": "citation",
+            "display_name": "Citations",
+            "link_model_name": "citation",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "collection"
           }
         },
         "parent": "model_one"


### PR DESCRIPTION
This tries to paginate redcap loading into pages of roughly around 20K records, to hopefully allow the redcap client to remain within the bounds of timeouts for magma updates.

Due to the chunking it is possible that there may be validation errors in multiple segments of the upload; however, this will raise out of the first one it encounters, which might lead to some obscuring of a comprehensive error report on the entire loading operation. However, I'm not sure how best to accumulate validation errors to avoid this.

A partial update is also likely in this circumstance if --dry-run is not used. This is just a fact of life to be accepted with this chunking I think.

Somewhat a WIP - needs hand-testing first.