### PR TITLE
fix chunking

### DIFF
--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -106,6 +106,10 @@ class Polyphemus
 
         add_to_page( page, flat_record )
 
+        flat_record[:extras].each do |extra|
+          add_to_page(page, extra)
+        end
+
         if page_count > @page_size
           update_page(results, yield(page))
 


### PR DESCRIPTION
In a boneheaded move, I forgot to actually attach table data to updates when chunking redcap loading. The result is a bunch of blank records are inserted into the table. Pushing out a fix so we can fill the clinical labs table...