### PR TITLE
reduce database calls

### DIFF
--- a/magma/lib/magma/loader.rb
+++ b/magma/lib/magma/loader.rb
@@ -322,9 +322,14 @@ class Magma
     # This is implemented in the loader because it 
     #   requires access to both the set of @records as well as the database.
     def path_to_date_shift_root(model, record_name)
+      @path_to_root ||= {}
+      @path_to_root[model.model_name] ||= {}
+
+      return @path_to_root[model.model_name][record_name] unless @path_to_root[model.model_name][record_name].nil?
+
       # Check if there is some path to the date-shift-root model, across @records and
       #   the database.
-      queue = model.path_to_date_shift_root
+      queue = model_path_to_date_shift_root(model).clone
       has_path = !queue.empty?
 
       # First model off the queue matches the record_name.
@@ -338,14 +343,14 @@ class Magma
 
         # If the model is the date-shift-root and we have a record-name for it,
         #   then a path must exist or will be created.
-        next if model_to_check.is_date_shift_root? && !current_record_name.nil?
+        next if is_date_shift_root?(model_to_check) && !current_record_name.nil?
 
         # If the user disconnects the record before we've found the date-shift-root
         #   model, then they've broken the path.
         begin
           has_path = false
           next
-        end if record_entry_explicitly_disconnected?(model_to_check, current_record_name) && !model_to_check.is_date_shift_root?
+        end if record_entry_explicitly_disconnected?(model_to_check, current_record_name) && !is_date_shift_root?(model_to_check)
 
         # If parent exists in the @records, and will be created
         parent_record_name = parent_record_name_from_records(model_to_check, current_record_name)
@@ -364,7 +369,11 @@ class Magma
         has_path = false
       end
 
-      has_path ? path_to_root : []
+      path = has_path ? path_to_root : []
+      
+      @path_to_root[model.model_name][record_name] = path
+
+      path
     end
     
     def is_connected_to_date_shift_root?(model, record_name)
@@ -373,13 +382,39 @@ class Magma
 
     private
 
+    def is_date_shift_root?(model)
+      @is_date_shift_root ||= {}
+
+      return @is_date_shift_root[model.model_name] if @is_date_shift_root.key?(model.model_name)
+
+      @is_date_shift_root[model.model_name] = model.is_date_shift_root?
+
+      @is_date_shift_root[model.model_name]
+    end
+
+    def model_path_to_date_shift_root(model)
+      @paths_to_date_shift_root ||= {}
+
+      @paths_to_date_shift_root[model.model_name] ||= model.path_to_date_shift_root
+    end
+
     def record_entry_explicitly_disconnected?(model, record_name)
+      @record_entry_disconnected_cache ||= {}
+      @record_entry_disconnected_cache[model.model_name] ||= {}
+
+      return @record_entry_disconnected_cache[model.model_name][record_name] unless @record_entry_disconnected_cache[model.model_name][record_name].nil?
+
       entry = record_entry_from_records(model, record_name)
 
-      return false if entry.nil?
+      explicitly_disconnected = false
+      
+      explicitly_disconnected = (entry.explicitly_disconnected_from_parent?) ||
+        (!entry.explicitly_disconnected_from_parent? &&
+          record_entry_explicitly_disconnected_by_parent(entry, model, record_name)) unless entry.nil?
 
-      (entry.explicitly_disconnected_from_parent?) ||
-      (record_entry_explicitly_disconnected_by_parent(entry, model, record_name))
+      @record_entry_disconnected_cache[model.model_name][record_name] = explicitly_disconnected
+
+      explicitly_disconnected
     end
 
     def record_entry_from_records(model, record_name)
@@ -391,24 +426,60 @@ class Magma
     def record_entry_explicitly_disconnected_by_parent(record_entry, model, record_name)
       return false unless !record_entry.includes_parent_record?
 
+      @record_entry_disconnected_by_parent_cache ||= {}
+      @record_entry_disconnected_by_parent_cache[model.model_name] ||= {}
+
+      return @record_entry_disconnected_by_parent_cache[model.model_name][record_name] unless @record_entry_disconnected_by_parent_cache[model.model_name][record_name].nil?
+
+      explicitly_disconnected = false
+
       parent_record_name = parent_record_name_from_db(model, record_name)
       parent_entry = record_entry_from_records(model.parent_model, parent_record_name)
 
-      return false unless parent_entry
+      explicitly_disconnected = !parent_entry[model.model_name]&.include?(record_name) if parent_entry
 
-      !parent_entry[model.model_name]&.include?(record_name)
+      @record_entry_disconnected_by_parent_cache[model.model_name][record_name] = explicitly_disconnected
+
+      explicitly_disconnected
     end
 
     def parent_record_name_from_records(model, record_name)
       record_entry_from_records(model, record_name)&.parent_record_name
     end
 
-    def parent_record_name_from_db(model, record_name)
-      db_record = model.where(
-        model.identity.column_name.to_sym => record_name
-      ).first
+    def db_records_for_model_by_identifier(model)
+      @all_model_records ||= {}
+      @all_model_records[model.model_name] ||= model.all.map do |record|
+        [record.identifier.to_s, record]
+      end.to_h
+    end
 
-      db_record&.send(model.parent_model_name)&.identifier
+    def db_record_identifiers_for_model_by_row_id(model)
+      @all_parent_identifiers ||= {}
+      @all_parent_identifiers[model.model_name] ||= model.all.map do |record|
+        [record.id, record.identifier]
+      end.to_h
+    end
+
+    def parent_record_in_db(parent_model, parent_record_id)
+      parent_record_id && db_record_identifiers_for_model_by_row_id(parent_model).key?(parent_record_id)
+    end
+
+    def parent_record_name_from_db(model, record_name)
+      @parent_record_name_cache ||= {}
+      @parent_record_name_cache[model.model_name] ||= {}
+
+      return @parent_record_name_cache[model.model_name][record_name] unless @parent_record_name_cache[model.model_name][record_name].nil?
+
+      db_record = db_records_for_model_by_identifier(model)[record_name]
+
+      parent_record_id = db_record&.send("#{model.attributes.values.select { |a|
+        a.is_a?(Magma::ParentAttribute)
+      }.first.column_name}".to_sym)
+      
+      @parent_record_name_cache[model.model_name][record_name] = db_record_identifiers_for_model_by_row_id(model.parent_model)[parent_record_id] if parent_record_in_db(model.parent_model, parent_record_id)
+
+      @parent_record_name_cache[model.model_name][record_name]
     end
 
     def validate!

--- a/magma/lib/magma/loader/date_shift_cache.rb
+++ b/magma/lib/magma/loader/date_shift_cache.rb
@@ -1,0 +1,23 @@
+class Magma
+  class DateShiftCache
+    # Cache model state and paths to date_shift_root
+    def initialize
+      @is_date_shift_root = {}
+      @paths_to_date_shift_root = {}
+    end
+
+    def is_date_shift_root?(model)
+      return @is_date_shift_root[model.model_name] if @is_date_shift_root.key?(model.model_name)
+
+      # Do not use ||= because model.is_date_shift_root? is a boolean, and
+      #   falsy values re-trigger assignment with ||=
+      @is_date_shift_root[model.model_name] = model.is_date_shift_root?
+
+      @is_date_shift_root[model.model_name]
+    end
+
+    def model_path_to_date_shift_root(model)
+      @paths_to_date_shift_root[model.model_name] ||= model.path_to_date_shift_root
+    end
+  end
+end

--- a/magma/lib/magma/loader/date_shift_cache.rb
+++ b/magma/lib/magma/loader/date_shift_cache.rb
@@ -7,17 +7,15 @@ class Magma
     end
 
     def is_date_shift_root?(model)
-      return @is_date_shift_root[model.model_name] if @is_date_shift_root.key?(model.model_name)
-
       # Do not use ||= because model.is_date_shift_root? is a boolean, and
       #   falsy values re-trigger assignment with ||=
-      @is_date_shift_root[model.model_name] = model.is_date_shift_root?
+      return @is_date_shift_root[model] if @is_date_shift_root.key?(model)
 
-      @is_date_shift_root[model.model_name]
+      @is_date_shift_root[model] = model.is_date_shift_root?
     end
 
     def model_path_to_date_shift_root(model)
-      @paths_to_date_shift_root[model.model_name] ||= model.path_to_date_shift_root
+      @paths_to_date_shift_root[model] ||= model.path_to_date_shift_root
     end
   end
 end

--- a/magma/lib/magma/loader/record_hierarchy_cache.rb
+++ b/magma/lib/magma/loader/record_hierarchy_cache.rb
@@ -1,0 +1,157 @@
+require_relative './date_shift_cache'
+
+class Magma
+  class RecordHierarchyCache
+    def initialize(records)
+      @parent_record_name_cache = {}
+      @all_model_records = {}
+      @all_parent_identifiers = {}
+      @path_to_root = {}
+      @record_entry_disconnected_cache = {}
+      @record_entry_disconnected_by_parent_cache = {}
+
+      @records = records
+
+      @date_shift_cache = Magma::DateShiftCache.new
+    end
+    
+    # This requires access to both the set of @records from the loader as well as the database.
+    def path_to_date_shift_root(model, record_name)
+      @path_to_root[model] ||= {}
+
+      return @path_to_root[model][record_name] unless @path_to_root[model][record_name].nil?
+
+      # Check if there is some path to the date-shift-root model, across @records and
+      #   the database.
+      queue = @date_shift_cache.model_path_to_date_shift_root(model).clone
+      has_path = !queue.empty?
+
+      # First model off the queue matches the record_name.
+      current_record_name = record_name
+      path_to_root = []
+
+      until queue.empty? || !has_path
+        model_to_check = queue.shift
+
+        path_to_root << current_record_name
+
+        # If the model is the date-shift-root and we have a record-name for it,
+        #   then a path must exist or will be created.
+        next if @date_shift_cache.is_date_shift_root?(model_to_check) && !current_record_name.nil?
+
+        # If the user disconnects the record before we've found the date-shift-root
+        #   model, then they've broken the path.
+        begin
+          has_path = false
+          next
+        end if user_disconnected_record(model_to_check, current_record_name)
+
+        # If parent exists in the @records, and will be created
+        parent_record_name = parent_record_name_from_records(model_to_check, current_record_name)
+
+        # If parent not found in @records AND there is not an explicit "disconnect" action, 
+        #   check the database for the EXISTING record and find its parent.
+        # If no existing record (current_record_name is a new record_entry), this should return nil and there is no path
+        parent_record_name = parent_record_name_from_db(model_to_check, current_record_name) if parent_record_name.nil?
+        
+        begin
+          current_record_name = parent_record_name
+          next
+        end unless parent_record_name.nil?
+
+        # If no parents have been found, the path doesn't exist or is broken
+        has_path = false
+      end
+
+      path = has_path ? path_to_root : []
+      
+      @path_to_root[model][record_name] = path
+
+      path
+    end
+
+    def parent_record_name_from_db(model, record_name)
+      @parent_record_name_cache[model] ||= {}
+
+      return @parent_record_name_cache[model][record_name] unless @parent_record_name_cache[model][record_name].nil?
+
+      parent_record_id = db_records_for_model_by_identifier(model)[record_name]
+      
+      @parent_record_name_cache[model][record_name] = db_record_identifiers_for_model_by_row_id(model.parent_model)[parent_record_id] if parent_record_in_db(model.parent_model, parent_record_id)
+
+      @parent_record_name_cache[model][record_name]
+    end
+
+    private
+
+    def user_disconnected_record(model, record_name)
+      record_entry_explicitly_disconnected?(model, record_name) && !@date_shift_cache.is_date_shift_root?(model)
+    end
+
+    def record_entry_explicitly_disconnected?(model, record_name)
+      @record_entry_disconnected_cache[model] ||= {}
+
+      return @record_entry_disconnected_cache[model][record_name] unless @record_entry_disconnected_cache[model][record_name].nil?
+
+      entry = record_entry_from_records(model, record_name)
+
+      explicitly_disconnected = false
+      
+      explicitly_disconnected = (entry.explicitly_disconnected_from_parent?) ||
+        (!entry.explicitly_disconnected_from_parent? &&
+          record_entry_explicitly_disconnected_by_parent(entry, model, record_name)) unless entry.nil?
+
+      @record_entry_disconnected_cache[model][record_name] = explicitly_disconnected
+
+      explicitly_disconnected
+    end
+
+    def record_entry_from_records(model, record_name)
+      return @records[model][record_name] if @records[model][record_name]
+      
+      nil
+    end
+
+    def record_entry_explicitly_disconnected_by_parent(record_entry, model, record_name)
+      return false unless !record_entry.includes_parent_record?
+
+      @record_entry_disconnected_by_parent_cache[model] ||= {}
+
+      return @record_entry_disconnected_by_parent_cache[model][record_name] unless @record_entry_disconnected_by_parent_cache[model][record_name].nil?
+
+      explicitly_disconnected = false
+
+      parent_record_name = parent_record_name_from_db(model, record_name)
+      parent_entry = record_entry_from_records(model.parent_model, parent_record_name)
+
+      explicitly_disconnected = !parent_entry[model]&.include?(record_name) if parent_entry
+
+      @record_entry_disconnected_by_parent_cache[model][record_name] = explicitly_disconnected
+
+      explicitly_disconnected
+    end
+
+    def parent_record_name_from_records(model, record_name)
+      record_entry_from_records(model, record_name)&.parent_record_name
+    end
+
+    def db_records_for_model_by_identifier(model)
+      @all_model_records[model] ||= model.select_map(
+        [model.column_name(attribute_type: Magma::IdentifierAttribute),
+         model.column_name(attribute_type: Magma::ParentAttribute)]).map do |identifier, parent_id|
+          [identifier.to_s, parent_id]
+        end.to_h
+    end
+
+    def db_record_identifiers_for_model_by_row_id(model) 
+      @all_parent_identifiers[model] ||= model.select_map(
+        [:id,
+         model.column_name(attribute_type: Magma::IdentifierAttribute)]
+      ).to_h
+    end
+
+    def parent_record_in_db(parent_model, parent_record_id)
+      parent_record_id && db_record_identifiers_for_model_by_row_id(parent_model).key?(parent_record_id)
+    end
+  end
+end

--- a/magma/lib/magma/loader/record_hierarchy_cache.rb
+++ b/magma/lib/magma/loader/record_hierarchy_cache.rb
@@ -66,8 +66,6 @@ class Magma
       path = has_path ? path_to_root : []
 
       @path_to_root[model][record_name] = path
-
-      path
     end
 
     private
@@ -90,8 +88,6 @@ class Magma
                                  record_entry_explicitly_disconnected_by_parent(entry, model, record_name)) unless entry.nil?
 
       @record_entry_disconnected_cache[model][record_name] = explicitly_disconnected
-
-      explicitly_disconnected
     end
 
     def record_entry_from_records(model, record_name)
@@ -115,8 +111,6 @@ class Magma
       explicitly_disconnected = !parent_entry[model]&.include?(record_name) if parent_entry
 
       @record_entry_disconnected_by_parent_cache[model][record_name] = explicitly_disconnected
-
-      explicitly_disconnected
     end
 
     def parent_record_name_from_records(model, record_name)
@@ -150,9 +144,7 @@ class Magma
 
       parent_record_id = db_records_for_model_by_identifier(model)[record_name]
 
-      @parent_record_name_cache[model][record_name] = db_record_identifiers_for_model_by_row_id(model.parent_model)[parent_record_id] if parent_record_in_db(model.parent_model, parent_record_id)
-
-      @parent_record_name_cache[model][record_name]
+      @parent_record_name_cache[model][record_name] = db_record_identifiers_for_model_by_row_id(model.parent_model)[parent_record_id]
     end
   end
 end

--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -220,6 +220,18 @@ class Magma
           attr.is_a?(Magma::ShiftedDateTimeAttribute)
         end
       end
+
+      def column_name(attribute_type: nil, attribute_name: nil)
+        return nil if attribute_type.nil? && attribute_name.nil?
+
+        match = attribute_name && attributes.key?(attribute_name) ?
+          attributes[attribute_name] :
+          attributes.values.select do |attribute|
+            attribute.is_a?(attribute_type)
+          end.first
+
+        match&.column_name.to_sym
+      end
     end
 
     # record methods

--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -216,7 +216,7 @@ class Magma
       end
 
       def date_shift_attributes
-        attributes.values.select do |attr|
+        @date_shift_attributes ||= attributes.values.select do |attr|
           attr.is_a?(Magma::ShiftedDateTimeAttribute)
         end
       end

--- a/magma/lib/magma/model.rb
+++ b/magma/lib/magma/model.rb
@@ -224,13 +224,14 @@ class Magma
       def column_name(attribute_type: nil, attribute_name: nil)
         return nil if attribute_type.nil? && attribute_name.nil?
 
-        match = attribute_name && attributes.key?(attribute_name) ?
-          attributes[attribute_name] :
+        match = attribute_name ?
+          attributes.key?(attribute_name) ?
+            attributes[attribute_name] : nil :
           attributes.values.select do |attribute|
             attribute.is_a?(attribute_type)
           end.first
 
-        match&.column_name.to_sym
+        match&.column_name&.to_sym
       end
     end
 

--- a/magma/spec/magma_model_spec.rb
+++ b/magma/spec/magma_model_spec.rb
@@ -56,4 +56,9 @@ describe Magma::Model do
       expect(Labors::Victim.path_to_date_shift_root).to eq([])
     end
   end
+
+  it 'can get column names' do
+    expect(Labors::Monster.column_name(attribute_type: Magma::IdentifierAttribute)).to eq(:name)
+    expect(Labors::Monster.column_name(attribute_name: :reference_monster)).to eq(:reference_monster_id)
+  end
 end

--- a/magma/spec/magma_model_spec.rb
+++ b/magma/spec/magma_model_spec.rb
@@ -60,5 +60,9 @@ describe Magma::Model do
   it 'can get column names' do
     expect(Labors::Monster.column_name(attribute_type: Magma::IdentifierAttribute)).to eq(:name)
     expect(Labors::Monster.column_name(attribute_name: :reference_monster)).to eq(:reference_monster_id)
+
+    expect(Labors::Monster.column_name()).to eq(nil)
+    expect(Labors::Monster.column_name(attribute_name: :non_attribute)).to eq(nil)
+    expect(Labors::Monster.column_name(attribute_type: Magma::MatrixAttribute)).to eq(nil)
   end
 end

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -2492,7 +2492,7 @@ describe UpdateController do
         update({
           victim: {
             @john_doe.name => {
-              wound: ["::temp-1", "::temp-2"]
+              wound: ["::temp-1", "::temp-2", "::temp-3"]
             }
           },
           wound: {
@@ -2502,7 +2502,10 @@ describe UpdateController do
             "::temp-2" => {
               severity: 9,
               location: "finger"
-            }
+            },
+            "::temp-3" => {
+              received_date: '2000-02-01'
+            },
           }},
           :privileged_editor
         )
@@ -2510,15 +2513,20 @@ describe UpdateController do
         expect(last_response.status).to eq(200)
         new_wound_ids = json_body[:models][:victim][:documents][@john_doe.name.to_sym][:wound]
 
-        expect(Labors::Wound.count).to eq(8)
+        expect(Labors::Wound.count).to eq(9)
         wounds = Labors::Wound.where(id: new_wound_ids).all
         wound_1 = wounds.first
+        wound_3 = wounds[1]
         wound_2 = wounds.last
 
         expect(wound_1[:received_date]).not_to eq(nil)
+        expect(wound_3[:received_date]).not_to eq(nil)
         expect(
           wound_1[:received_date].iso8601
         ).not_to eq(iso_date_str('2000-01-01'))
+        expect(
+          wound_3[:received_date].iso8601
+        ).not_to eq(iso_date_str('2000-02-01'))
         expect(wound_2[:severity]).to eq(9)
       end
 


### PR DESCRIPTION
Basically this PR aggressively caches the database results for model paths (to the date-shift-root model) and parent model / record_entry model record identifiers. When testing locally, it reduced update calls to ~15s or less -- so a little bit longer than the 1 minute for all of clinical_labs that @graft  saw without date-shifting, but much better than minutes / chunk.

Thoughts?

![Screenshot from 2022-02-01 11-53-29](https://user-images.githubusercontent.com/4930129/152013799-cab8c8de-c947-4c37-99be-59e5b80c2647.png)
