### PR TITLE
Janus display add user error messages

### DIFF
--- a/janus/lib/client/jsx/janus-ui.jsx
+++ b/janus/lib/client/jsx/janus-ui.jsx
@@ -10,6 +10,8 @@ import FlagsView from './flags/flags-view';
 
 import { findRoute, setRoutes } from 'etna-js/dispatchers/router';
 
+import {Notifications} from 'etna-js/components/Notifications';
+import Messages from 'etna-js/components/messages';
 import { createEtnaTheme } from 'etna-js/style/theme';
 
 const theme = createEtnaTheme("#3684fd","#77c");
@@ -53,7 +55,9 @@ const JanusUI = () => {
   return (
     <ThemeProvider theme={theme}>
       <div id='janus-group'>
+        <Notifications />
         <JanusNav/>
+        <Messages />
         <Component {...params}/>
       </div>
     </ThemeProvider>

--- a/janus/lib/client/jsx/project-view.jsx
+++ b/janus/lib/client/jsx/project-view.jsx
@@ -3,6 +3,8 @@ import { json_post, json_get } from 'etna-js/utils/fetch';
 import {selectUser} from 'etna-js/selectors/user-selector';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 import { isAdmin, isSuperuser } from 'etna-js/utils/janus';
+import { useActionInvoker } from 'etna-js/hooks/useActionInvoker';
+import {showMessages} from 'etna-js/actions/message_actions';
 
 import {makeStyles} from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -136,7 +138,7 @@ const displayPermissions = (permissions, filter) => (
 );
 
 const ProjectView = ({project_name}) => {
-  const [error, setError] = useState();
+  const invoke = useActionInvoker();
 
   let user = useReduxState( state => selectUser(state) );
   let [ project, setProject ] = useState({});
@@ -177,7 +179,7 @@ const ProjectView = ({project_name}) => {
           ).filter(_=>_).join(', ')
         }
       </div>
-      {error && <div className='error'>Error: {error}</div>}
+
       <TableContainer className={classes.table} component={Paper}>
         <Table aria-label='project users'>
           <TableHead>
@@ -205,10 +207,7 @@ const ProjectView = ({project_name}) => {
                 permission={p}
                 editable={editable}
                 roles={roles}
-                onSave={({revision, user_email}) => {
-                  setError();
-                  postUpdatePermission(project_name, user_email, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => setError(error)))
-                }}
+                onSave={({revision, user_email}) => postUpdatePermission(project_name, user_email, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => invoke(showMessages([error]))))}
               />
             )
           }
@@ -217,10 +216,7 @@ const ProjectView = ({project_name}) => {
               create={true}
               editable={true}
               roles={['viewer', 'editor']} 
-              onSave={({revision}) => {
-                setError();
-                postAddUser(project_name, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => setError(error)))
-              }} />
+              onSave={({revision}) => postAddUser(project_name, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => invoke(showMessages([error]))))} />
           }
           </TableBody>
         </Table>

--- a/janus/lib/client/jsx/project-view.jsx
+++ b/janus/lib/client/jsx/project-view.jsx
@@ -136,6 +136,8 @@ const displayPermissions = (permissions, filter) => (
 );
 
 const ProjectView = ({project_name}) => {
+  const [error, setError] = useState();
+
   let user = useReduxState( state => selectUser(state) );
   let [ project, setProject ] = useState({});
   let [ filter, setFilter ] = useState(null);
@@ -175,7 +177,7 @@ const ProjectView = ({project_name}) => {
           ).filter(_=>_).join(', ')
         }
       </div>
-
+      {error && <div className='error'>Error: {error}</div>}
       <TableContainer className={classes.table} component={Paper}>
         <Table aria-label='project users'>
           <TableHead>
@@ -203,7 +205,10 @@ const ProjectView = ({project_name}) => {
                 permission={p}
                 editable={editable}
                 roles={roles}
-                onSave={({revision, user_email}) => postUpdatePermission(project_name, user_email, revision).then(() => retrieveProject())}
+                onSave={({revision, user_email}) => {
+                  setError();
+                  postUpdatePermission(project_name, user_email, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => setError(error)))
+                }}
               />
             )
           }
@@ -212,7 +217,10 @@ const ProjectView = ({project_name}) => {
               create={true}
               editable={true}
               roles={['viewer', 'editor']} 
-              onSave={({revision}) => postAddUser(project_name, revision).then(() => retrieveProject()).catch()} />
+              onSave={({revision}) => {
+                setError();
+                postAddUser(project_name, revision).then(() => retrieveProject()).catch((e) => e.then(({error}) => setError(error)))
+              }} />
           }
           </TableBody>
         </Table>

--- a/janus/lib/client/jsx/store.jsx
+++ b/janus/lib/client/jsx/store.jsx
@@ -2,9 +2,10 @@ import * as Redux from 'redux';
 import thunk from 'redux-thunk';
 import * as ReduxLogger from 'redux-logger';
 import user from 'etna-js/reducers/user-reducer';
+import messages from 'etna-js/reducers/message_reducer';
 
 const createStore = () => {
-  let reducers = { user };
+  let reducers = { user, messages };
 
   let middleWares = [thunk];
 

--- a/janus/lib/client/scss/janus.scss
+++ b/janus/lib/client/scss/janus.scss
@@ -7,6 +7,7 @@
 @import 'reset';
 @import 'project';
 @import 'login';
+@import 'messages';
 
 body {
   padding: 0px;

--- a/janus/lib/client/scss/messages.scss
+++ b/janus/lib/client/scss/messages.scss
@@ -1,0 +1,98 @@
+#messages {
+  font-size: 16px;
+  color: darkgreen;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 2px solid forestgreen;
+  border-top: 1px solid forestgreen;
+
+  #quote {
+    color: rgba(forestgreen, 0.3);
+    display: inline;
+    font-size: 100px;
+    margin: 0;
+    position: absolute;
+    left: 0px;
+    top: -9.7px;
+    z-index: 10;
+    svg {
+      opacity: 1;
+      position: absolute;
+      top: -30px;
+      left: 3px;
+      path {
+        fill: #ffffff;
+        stroke: forestgreen;
+        stroke-width: 1px;
+        stroke-linecap: butt;
+        stroke-linejoin: miter;
+        stroke-opacity: 1;
+      }
+    }
+  }
+  #dismiss {
+    font-size: 30px;
+    cursor: pointer;
+    &:hover {
+      color: limegreen;
+      background-color: rgba(limegreen, 0.1);
+    }
+    flex-basis: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  #message_viewer {
+    flex-grow: 1;
+    padding-left: 10px;
+    #nav {
+      font-size: 15px;
+      display: inline-block;
+      .pager {
+        &:first-child {
+          padding-right: 2px;
+        }
+        padding-left: 2px;
+      }
+      .arrow {
+        color: goldenrod;
+        cursor: pointer;
+      }
+    }
+    #message {
+      overflow: auto;
+      padding: 0px;
+      padding-right: 10px;
+      h1,
+      h2,
+      h3 {
+        font-weight: normal;
+      }
+    }
+  }
+  blockquote {
+    font-size: 20px;
+    background-color: rgba(cornsilk, 0.5);
+    font-style: italic;
+    margin: 0 10px;
+    padding: 5px;
+    p {
+      margin: 0;
+      padding: 0;
+    }
+  }
+  pre {
+    padding: 5px;
+    margin: 0px;
+    background-color: rgba(forestgreen, 0.2);
+    white-space: normal;
+  }
+  em {
+    color: red;
+    font-weight: bold;
+  }
+  ul {
+    list-style-type: lower-roman;
+  }
+}

--- a/janus/lib/client/scss/project.scss
+++ b/janus/lib/client/scss/project.scss
@@ -31,4 +31,13 @@
       @include janus-header;
     }
   }
+
+  .error {
+    display: inline-block;
+    background: rgba(255,0,0,0.1);
+    color: darkred;
+    font-size: 0.7em;
+    padding: 3px;
+    margin: 2px;
+  }
 }

--- a/janus/lib/server/controllers/admin_controller.rb
+++ b/janus/lib/server/controllers/admin_controller.rb
@@ -64,7 +64,7 @@ class AdminController < Janus::Controller
     require_params(:email, :name, :role)
     @project = Project[project_name: @params[:project_name]]
 
-    @email = @params[:email].downcase
+    @email = @params[:email].downcase.strip
 
     raise Etna::Forbidden, 'Cannot set admin role!' if @params[:role] == 'administrator'
 

--- a/janus/lib/server/views/client.html.erb
+++ b/janus/lib/server/views/client.html.erb
@@ -3,6 +3,7 @@
 <html>
   <head>
     <title><%= Janus.instance.environment == :development ? 'Dev Janus' : 'Janus' %></title>
+    <link rel="shortcut icon" href="/images/janus.svg" type="image/x-icon" />
     <link rel='stylesheet' media='screen' href='/css/janus.bundle.css'/>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
   </head>

--- a/janus/spec/admin_spec.rb
+++ b/janus/spec/admin_spec.rb
@@ -374,6 +374,33 @@ describe AdminController do
       expect(user2.email).to eq('portunus@two-faces.org')
     end
 
+    it 'strips leading and trailing whitespace from an e-mail' do
+      user = create(:user, name: 'Janus Bifrons', email: 'janus@two-faces.org')
+
+      door = create(:project, project_name: 'door', project_name_full: 'Door')
+      perm = create(:permission, project: door, user: user, role: 'administrator', privileged: true)
+
+      auth_header(:janus)
+      json_post('add_user/door', email: ' portunus@two-faces.org ', name: 'Portunus', role: 'editor', affiliation: "ILWU")
+
+      expect(last_response.status).to eq(302)
+      expect(last_response.headers['Location']).to eq('/door')
+
+      expect(Permission.count).to eq(2)
+      expect(User.count).to eq(2)
+
+      perm2 = Permission.last
+      user2 = User.last
+      expect(perm2).not_to be_privileged
+      expect(perm2.user).to eq(user2)
+      expect(perm2.project).to eq(door)
+      expect(perm2.role).to eq('editor')
+      expect(perm2.affiliation).to eq('ILWU')
+
+      expect(user2.name).to eq('Portunus')
+      expect(user2.email).to eq('portunus@two-faces.org')
+    end
+
     it 'allows an admin to add an existing user to a project' do
       user = create(:user, name: 'Janus Bifrons', email: 'janus@two-faces.org')
       user2 = create(:user, name: 'Portunus', email: 'portunus@two-faces.org')

--- a/metis/lib/server/views/index.html.erb
+++ b/metis/lib/server/views/index.html.erb
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>
-      Metis File Browser
-    </title>
+    <title><%= Metis.instance.environment == :development ? 'Dev ' : '' %>Metis File Browser</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link type='text/css' rel='stylesheet' href='/css/metis.bundle.css' />
-    <link rel="icon"  type="image/png"  href="/img/favicon.png">
+    <link rel="shortcut icon" href="/images/metis.svg" type="image/x-icon" />
   </head>
   <body>
     <div id='ui-group'></div>

--- a/polyphemus/lib/polyphemus/views/client.html.erb
+++ b/polyphemus/lib/polyphemus/views/client.html.erb
@@ -2,7 +2,8 @@
 <meta charset='utf-8'/>
 <html>
   <head>
-    <title><%= Polyphemus.instance.environment == :development ? 'Dev Polyphemus' : 'Polyphemus' %></title>
+    <title><%= Polyphemus.instance.environment == :development ? 'Dev ' : '' %>Polyphemus</title>
+    <link rel="shortcut icon" href="/images/polyphemus.svg" type="image/x-icon" />
     <link rel='stylesheet' media='screen' href='/css/polyphemus.bundle.css'/>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
   </head>


### PR DESCRIPTION
Displays server error messages on the Janus project page when adding a user, so user will get some better feedback if they run into an issue, like the e-mail is malformed. I did not automatically strip spaces, because we're using a standard library regex to validate the e-mail (note that this means not all strings are valid...like `foo@site` passes the regex). So instead of trying to maintain what is a valid e-mail, I figured we could leave it to the user + Ruby standard library...

Also adds favicons for  Janus, Polyphemus, and Metis.