### PR TITLE
Timur query better handle workflows fail

### DIFF
--- a/timur/lib/client/jsx/components/query/query_plot_menu.tsx
+++ b/timur/lib/client/jsx/components/query/query_plot_menu.tsx
@@ -111,7 +111,7 @@ const usePlotActions = ({
         .then(() => {
           setPlotLoading(original);
         })
-        .catch((e) => invoke(showMessages([e])));
+        .catch((e) => invoke(showMessages(Array.isArray(e) ? e : [e])));
     },
     [plotLoading, setPlotLoading, columns, expandMatrices, queryString, invoke]
   );

--- a/timur/lib/client/jsx/components/query/query_plot_menu.tsx
+++ b/timur/lib/client/jsx/components/query/query_plot_menu.tsx
@@ -235,7 +235,7 @@ const QueryPlotMenu = () => {
       .then(({workflows}) => {
         setPlottingWorkflows(workflows);
       })
-      .catch((e) => invoke(showMessages([e])));
+      .catch((e) => invoke(showMessages(Array.isArray(e) ? e : [e])));
   }, []);
 
   const buttonDisabled = !plottingWorkflows || plottingWorkflows.length === 0;


### PR DESCRIPTION
This PR is a small fix to how Timur Query  handles exceptions from fetching Vulcan workflows. Surfaced when Vulcan hadn't been updated yet in the last deploy.