### PR TITLE
add in missing query-input map

### DIFF
--- a/vulcan/lib/server/workflows/visualization.metadata.json
+++ b/vulcan/lib/server/workflows/visualization.metadata.json
@@ -1,10 +1,15 @@
 {
-  "projects": ["example"],
+  "projects": ["example", "ipi"],
   "authors": ["Dan Bunis"],
   "lastModified": "Feb 18, 2022",
   "vignette": "# The Standard Visualization Workflow\n\nThis workflow allows users to create a plot type of their choice from data library data of their choice.\n\n## Step 1) Selecting Data via Timur-Query:\n\nThis Data Loading method utilizes the 'Data Source magma query' Primary Inputs group. Users can fill in these inputs manually, but the recommended method is to build your query in the Timur-Query page ([documentation](https://mountetna.github.io/query.html)), then click the `Plot` button to have the relevant inputs filled in automatically.\n\n## (Under construction) Optional Step 1.5) Make Data Adjustments\n\n Tooling is in the works and will be available soon!\n\n## Step 2) Configuring the plot\n\nAfter data is obtained, the Plot Configuration Interface will appear. First choose your plot type from the similarly named dropdown, then additional inputs will show up which allow you to set what data to use for axes, colors, etc. and as other advanced options.\n\nFor additional details regarding individual inputs of the Plot Configuration Interface, see https://mountetna.github.io/vulcan.html#the-plot-configuration-interface.\n\n## We are currently working on:\n\n- An Excel-like data adjustment interface where users will be able to add columns and make manual edits to their queried data.\n- User interface improvements.\n- Additional Visualization Features",
   "tags": ["general", "plotting"],
   "image": "scatter.png",
   "displayName": "Visualization",
-  "description": "Standard Visualization Workflow: Pick data, then create a plot of your choice"
+  "description": "Standard Visualization Workflow: Pick data, then create a plot of your choice",
+  "inputQueryMap": {
+    "1_Data_Source_magma_query__queryTerms": "query",
+    "1_Data_Source_magma_query__user_columns": "user_columns",
+    "1_Data_Source_magma_query__expand_matrices": "expand_matrices"
+  }
 }


### PR DESCRIPTION
Ran into the issue that @dtm2451  mentioned at standup, that query values weren't getting mapped to Vulcan inputs. Realized that we were missing the config values in the workflow metadata, oops...

Side-question @dtm2451 , do we have to release the visualization workflow to IPI, too, before the presentation?