### PR TITLE
Timur query bug 768

### DIFF
--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import Grid from '@material-ui/core/Grid';
 import {makeStyles} from '@material-ui/core/styles';
 
@@ -99,33 +99,46 @@ const QueryResults = () => {
       json(),
       EditorView.editable.of(false),
       EditorState.readOnly.of(true),
-      EditorState.transactionFilter.of((tr) => {
-        if (!tr.docChanged && tr.selection) {
-          // Keep any pure selection transactions
-          return tr;
-        } else {
-          // All other transactions, in our case, involve doc changes.
-          // In this case, undo any active selections to avoid confusion.
-          return {
-            ...tr,
-            selection: {
-              anchor: 0,
-              head: 0
-            }
-          };
-        }
-      }),
+      // EditorState.transactionFilter.of((tr) => {
+      //   console.log('tr', tr, tr.docChanged, tr.selection);
+      //   if (!tr.docChanged && tr.selection) {
+      //     console.log('1');
+      //     // Pass through as normal. Selection-only change
+      //     return {...tr};
+      //   } else {
+      //     console.log('2');
+      //     // If this is only a doc change, clear the selection.
+      //     return {
+      //       ...tr,
+      //       selection: {
+      //         anchor: 0,
+      //         head: 0
+      //       }
+      //     };
+      //   }
+      // }),
       EditorView.lineWrapping
     ],
-    [codeMirrorText]
+    []
   );
+
+  const [selection, setSelection] = useState({anchor: 0, head: 0});
+  const handleOnUpdate = useCallback((v: any) => {
+    console.log('v', v);
+  }, []);
 
   if (!rootModel) return null;
 
+  console.log('codeMirrorText', codeMirrorText);
   return (
     <Grid container className={classes.resultsPane}>
       <Grid item className={classes.result}>
-        <CodeMirror extensions={extensions} value={codeMirrorText} />
+        <CodeMirror
+          extensions={extensions}
+          value={codeMirrorText}
+          selection={selection}
+          onUpdate={handleOnUpdate}
+        />
       </Grid>
       <Grid xs={12} item container direction='column'>
         <Grid className={classes.config} item container justify='flex-end'>

--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -13,6 +13,7 @@ import AntSwitch from './ant_switch';
 import {defaultHighlightStyle} from '@codemirror/highlight';
 import {json} from '@codemirror/lang-json';
 import {EditorView} from '@codemirror/view';
+import {EditorState} from '@codemirror/state';
 import CodeMirror from 'rodemirror';
 
 const useStyles = makeStyles((theme) => ({
@@ -97,9 +98,26 @@ const QueryResults = () => {
       defaultHighlightStyle.fallback,
       json(),
       EditorView.editable.of(false),
+      EditorState.readOnly.of(true),
+      EditorState.transactionFilter.of((tr) => {
+        if (!tr.docChanged && tr.selection) {
+          // Keep any pure selection transactions
+          return tr;
+        } else {
+          // All other transactions, in our case, involve doc changes.
+          // In this case, undo any active selections to avoid confusion.
+          return {
+            ...tr,
+            selection: {
+              anchor: 0,
+              head: 0
+            }
+          };
+        }
+      }),
       EditorView.lineWrapping
     ],
-    []
+    [codeMirrorText]
   );
 
   if (!rootModel) return null;

--- a/timur/package-lock.json
+++ b/timur/package-lock.json
@@ -1664,9 +1664,9 @@
       }
     },
     "@codemirror/lang-json": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.19.1.tgz",
-      "integrity": "sha512-66K5TT9HO0ODtpjY+3Ub6t3r0OB1d27P+Kl5oygk4tDavHUBpsyHTJRFw/CdeRM2VwjbpBfctGm/cTrSthFDZg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.19.2.tgz",
+      "integrity": "sha512-fgUWR58Is59P5D/tiazX6oTczioOCDYqjFT5PEBAmLBFMSsRqcnJE0xNO1snrhg7pWEFDq5wR/oN0eZhkeR6Gg==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -1694,9 +1694,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -1707,9 +1707,9 @@
       "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
     },
     "@codemirror/view": {
-      "version": "0.19.39",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.39.tgz",
-      "integrity": "sha512-ol4smHAwhWkW8p1diPZiZkLZVmKybKhQigwyrgdF7k1UFNY+/KDH4w2xic8JQXxX+v0ppMsoNf11C+afKJze5g==",
+      "version": "0.19.47",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.47.tgz",
+      "integrity": "sha512-SfbagKvJQl5dtt+9wYpo9sa3ZkMgUxTq+/hXDf0KVwIx+zu3cJIqfEm9xSx6yXkq7it7RsPGHaPasApNffF/8g==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",

--- a/timur/package.json
+++ b/timur/package.json
@@ -9,9 +9,9 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.13.0",
     "@codemirror/highlight": "^0.19.7",
-    "@codemirror/lang-json": "^0.19.1",
-    "@codemirror/state": "^0.19.6",
-    "@codemirror/view": "^0.19.39",
+    "@codemirror/lang-json": "^0.19.2",
+    "@codemirror/state": "^0.19.9",
+    "@codemirror/view": "^0.19.47",
     "@emotion/core": "^10.0.28",
     "@material-ui/core": "^4.11.4",
     "@material-ui/data-grid": "^4.0.0-alpha.31",

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -2229,6 +2229,7 @@ exports[`QueryBuilder renders with Plot button 1`] = `
           >
             <div
               aria-multiline="true"
+              aria-readonly="true"
               autocapitalize="off"
               autocorrect="off"
               class="cm-content cm-lineWrapping"
@@ -4906,6 +4907,7 @@ exports[`QueryBuilder renders without Plot button 1`] = `
           >
             <div
               aria-multiline="true"
+              aria-readonly="true"
               autocapitalize="off"
               autocorrect="off"
               class="cm-content cm-lineWrapping"

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
           >
             <div
               aria-multiline="true"
+              aria-readonly="true"
               autocapitalize="off"
               autocorrect="off"
               class="cm-content cm-lineWrapping"
@@ -350,6 +351,7 @@ exports[`QueryResults renders 1`] = `
           >
             <div
               aria-multiline="true"
+              aria-readonly="true"
               autocapitalize="off"
               autocorrect="off"
               class="cm-content cm-lineWrapping"


### PR DESCRIPTION
This PR closes #768 .

The root cause of the issue was when you had a selection in the CodeMirror query preview text area, and then updated the query in such as way as to reduce the text length -- i.e. delete a filter or column. If the highlighted selection included the deleted text, CodeMirror would throw an exception because the text was now shorter than the specified selection, as if you had selected outside of the document. CodeMirror throwing this exception would cause the app to crash, causing a white screen.

There was also a similar issue when you added to the query, though less drastic (no white-screen of death). For example, if you had `query` + `user_columns` selected, adding a filter would lead to losing some of the `user_columns` selection. Potentially causing user confusion, since their selection would change.

This PR turns the `selected` attribute into a controlled value via `useState` hook, and resets it whenever the text in CodeMirror changes. This should prevent both app crashes and user confusion due to the selection changing relative to the text.