### PR TITLE
Task tokens preserve privileged for supereditors

### DIFF
--- a/janus/lib/models/token.rb
+++ b/janus/lib/models/token.rb
@@ -72,10 +72,8 @@ module Token
       # degrade admin permissions
       if payload[:perm] =~ /^[Aa]/
         payload[:perm] = payload[:perm].sub(/^[Aa]/) { |c| c == 'A' ? 'E' : 'e' }
-      end
-
-      # permit supereditor
-      if @janus_user.supereditor?
+        # permit supereditor
+      elsif @janus_user.supereditor?
         payload[:perm] = "e:#{project_name}"
       end
 


### PR DESCRIPTION
The source of the task token bug issue we've been seeing.