### PR TITLE
use multiline input for user key, to avoid issue with escape chars

### DIFF
--- a/janus/lib/client/jsx/__tests__/__snapshots__/janus-settings.test.jsx.snap
+++ b/janus/lib/client/jsx/__tests__/__snapshots__/janus-settings.test.jsx.snap
@@ -25,16 +25,16 @@ exports[`JanusSettings renders 1`] = `
       className="item"
     >
       <div
-        className="MuiFormControl-root MuiTextField-root makeStyles-text-1"
+        className="MuiFormControl-root MuiTextField-root makeStyles-keyText-2"
       >
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
           onClick={[Function]}
         >
-          <input
+          <textarea
             aria-invalid={false}
             autoFocus={false}
-            className="MuiInputBase-input MuiInput-input"
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
             disabled={false}
             onAnimationStart={[Function]}
             onBlur={[Function]}
@@ -42,7 +42,30 @@ exports[`JanusSettings renders 1`] = `
             onFocus={[Function]}
             placeholder="Paste 2048+ bit RSA key in PEM format"
             required={false}
-            type="text"
+            rows={1}
+            style={
+              Object {
+                "height": -4,
+                "overflow": "hidden",
+              }
+            }
+          />
+          <textarea
+            aria-hidden={true}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            readOnly={true}
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+                "transform": "translateZ(0)",
+                "visibility": "hidden",
+              }
+            }
+            tabIndex={-1}
           />
         </div>
       </div>

--- a/janus/lib/client/jsx/__tests__/janus-settings.test.jsx
+++ b/janus/lib/client/jsx/__tests__/janus-settings.test.jsx
@@ -11,18 +11,26 @@ describe('JanusSettings', () => {
   beforeEach(() => {
     store = mockStore({
       user: {
-	email: "janus@two-faces.org",
-	name: "Janus Bifrons",
-	permissions: { }
+        email: "janus@two-faces.org",
+        name: "Janus Bifrons",
+        permissions: { }
       }
     });
   });
+
+  const createNodeMock = element => {
+    if (element.type === "textarea") {
+      return document.createElement("textarea");
+    } else {
+      return null;
+    }
+  };
 
   it('renders', async () => {
     const initialStubs = [
       stubUrl({
         verb: 'get',
-	path: '/api/user/info',
+	      path: '/api/user/info',
         status: 200,
         response: {
           user: {
@@ -37,7 +45,8 @@ describe('JanusSettings', () => {
     let component = create(
       <Provider store={store}>
         <JanusSettings/>
-      </Provider>
+      </Provider>,
+      { createNodeMock }
     );
 
     await act( async () => {

--- a/janus/lib/client/jsx/janus-settings.jsx
+++ b/janus/lib/client/jsx/janus-settings.jsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const KeysSettings = ({user}) => {
+const KeysSettings = ({user, setUser}) => {
   let [ error, setError ] = useState(null);
 
   const classes = useStyles();
@@ -34,7 +34,7 @@ const KeysSettings = ({user}) => {
 
   let uploadKey = useCallback(
     () => json_post('/api/user/update_key', { pem }).then(
-        ({user}) => { setUser(user); setError(null); }
+        ({user}) => { setUser(user); setError('Saved!'); setPemText(null); }
     ).catch(
       e => e.then( ({error}) => setError(error) )
     ), [pem]
@@ -114,7 +114,7 @@ const JanusSettings = () => {
   );
 
   return <div id='janus-settings'>
-    <KeysSettings user={ janusUser }/>
+    <KeysSettings user={ janusUser } setUser={setUser} />
     <TaskTokenSettings user={ user }/>
     { isSuperuser(user) && <TokenBuilder user={ user }/> }
   </div>;

--- a/janus/lib/client/jsx/janus-settings.jsx
+++ b/janus/lib/client/jsx/janus-settings.jsx
@@ -36,11 +36,13 @@ const KeysSettings = ({user, setUser}) => {
   let uploadKey = useCallback(
     () => {
       setDisabled(true);
-      return json_post('/api/user/update_key', { pem }).then(
-        ({user}) => { setUser(user); setError('Saved!'); }
-    ).catch(
-      e => e.then( ({error}) => setError(error) )
-    ).finally(() => setDisabled(false))}, [pem]
+      return json_post('/api/user/update_key', { pem })
+      .then(
+          ({user}) => { setUser(user); setError('Saved!'); }
+      ).catch(
+        e => e.then( ({error}) => setError(error) )
+      ).finally(() => setDisabled(false))
+    }, [pem]
   );
 
   return <div id='keys-group'>

--- a/janus/lib/client/jsx/janus-settings.jsx
+++ b/janus/lib/client/jsx/janus-settings.jsx
@@ -17,6 +17,9 @@ import { isSuperuser } from 'etna-js/utils/janus';
 const useStyles = makeStyles((theme) => ({
   text: {
     width: '300px'
+  },
+  keyText: {
+    width: '650px'
   }
 }));
 
@@ -31,7 +34,7 @@ const KeysSettings = ({user}) => {
 
   let uploadKey = useCallback(
     () => json_post('/api/user/update_key', { pem }).then(
-      ({user}) => { setUser(user); setError(null); }
+        ({user}) => { setUser(user); setError(null); }
     ).catch(
       e => e.then( ({error}) => setError(error) )
     ), [pem]
@@ -52,7 +55,8 @@ const KeysSettings = ({user}) => {
     }
     <div className='item'>
       <TextField 
-        className={classes.text}
+        multiline
+        className={classes.keyText}
         onChange={ e => setPemText(e.target.value) }
         placeholder='Paste 2048+ bit RSA key in PEM format'/>
       <Button onClick={uploadKey}>Upload Key</Button>

--- a/janus/lib/client/jsx/janus-settings.jsx
+++ b/janus/lib/client/jsx/janus-settings.jsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
 
 const KeysSettings = ({user, setUser}) => {
   let [ error, setError ] = useState(null);
+  const [disabled, setDisabled] = useState(false);
 
   const classes = useStyles();
 
@@ -33,11 +34,13 @@ const KeysSettings = ({user, setUser}) => {
   let [ pem, setPemText ] = useState(null);
 
   let uploadKey = useCallback(
-    () => json_post('/api/user/update_key', { pem }).then(
-        ({user}) => { setUser(user); setError('Saved!'); setPemText(null); }
+    () => {
+      setDisabled(true);
+      return json_post('/api/user/update_key', { pem }).then(
+        ({user}) => { setUser(user); setError('Saved!'); }
     ).catch(
       e => e.then( ({error}) => setError(error) )
-    ), [pem]
+    ).finally(() => setDisabled(false))}, [pem]
   );
 
   return <div id='keys-group'>
@@ -59,7 +62,7 @@ const KeysSettings = ({user, setUser}) => {
         className={classes.keyText}
         onChange={ e => setPemText(e.target.value) }
         placeholder='Paste 2048+ bit RSA key in PEM format'/>
-      <Button onClick={uploadKey}>Upload Key</Button>
+      <Button onClick={uploadKey} disabled={disabled}>Upload Key</Button>
       { error && <span className='error'>{error}</span> }
     </div>
   </div>


### PR DESCRIPTION
This PR is a hotfix for Janus -- it seems impossible to upload a user's RSA key via the UI, since the input is an `input` instead of `textarea`. So if you try to upload your key in raw format, the newlines are pasted as spaces (and you get `Invalid key format` error). If you try to escape yourself and add `\n` for newlines, those get escaped as `\\n` and you get the same `Invalid key format` error. This PR switches to use a `textarea` input, which accepts the newlines from pasting the raw key and does not escape them.

I'm going to push this directly to production to help solve a DS's immediate problem, but opening this PR for review.