### PR TITLE
Polyphemus redcap config UI tweaks

### DIFF
--- a/etna/packages/etna-js/index.d.ts
+++ b/etna/packages/etna-js/index.d.ts
@@ -358,3 +358,10 @@ declare module 'etna-js/actions/location_actions' {
     link: string;
   };
 }
+
+declare module 'etna-js/hooks/useAsyncWork' {
+  export default function useAsyncWork(
+    f: Function,
+    opts: any
+  ): [loading: boolean, wrapper: Function, awaitNextRender: Function];
+}

--- a/polyphemus/lib/client/jsx/etl/__tests__/__snapshots__/redcap-form.spec.tsx.snap
+++ b/polyphemus/lib/client/jsx/etl/__tests__/__snapshots__/redcap-form.spec.tsx.snap
@@ -159,6 +159,7 @@ exports[`RedcapForm renders renders with existing config 1`] = `
         >
           <div
             class="MuiGrid-root makeStyles-model_row_name MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
+            title=""
           >
             remove
           </div>
@@ -186,6 +187,7 @@ exports[`RedcapForm renders renders with existing config 1`] = `
         >
           <div
             class="MuiGrid-root makeStyles-model_row_name MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
+            title=""
           >
             each
           </div>
@@ -268,6 +270,7 @@ exports[`RedcapForm renders renders with existing config 1`] = `
         >
           <div
             class="MuiGrid-root makeStyles-model_row_name MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
+            title="The \`invert\` option constructs the REDCap id from the Magma record name; only used for biospecimens where the ID is unknown in REDCap."
           >
             invert
           </div>
@@ -310,6 +313,7 @@ exports[`RedcapForm renders renders with existing config 1`] = `
         >
           <div
             class="MuiGrid-root makeStyles-model_row_name MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
+            title="\`identifier_fields\` must be specified when the REDCap form provides the Timur record name."
           >
             identifier_fields
           </div>
@@ -338,6 +342,7 @@ exports[`RedcapForm renders renders with existing config 1`] = `
         >
           <div
             class="MuiGrid-root makeStyles-model_row_name MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
+            title=""
           >
             scripts
           </div>

--- a/polyphemus/lib/client/jsx/etl/configure-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/configure-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import {makeStyles} from '@material-ui/core/styles';
 import CardActions from '@material-ui/core/CardActions';
 import Grid from '@material-ui/core/Grid';
@@ -14,12 +14,12 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 
 import ConfigScript from './config-script';
-import EtlPane, { EtlPaneHeader } from './etl-pane';
+import EtlPane, {EtlPaneHeader} from './etl-pane';
 import RedcapForm from './redcap-form';
 import RevisionHistory from './revision-history';
-import { formatTime } from './run-state';
+import {formatTime} from './run-state';
 
-const useStyles = makeStyles( theme => ({
+const useStyles = makeStyles((theme) => ({
   savebar: {
     justifyContent: 'space-between',
     width: 'auto'
@@ -31,90 +31,143 @@ const useStyles = makeStyles( theme => ({
   }
 }));
 
-const FORMS:{
-  [key:string]: any
+const FORMS: {
+  [key: string]: any;
 } = {
   redcap: RedcapForm
 };
 
-const ConfigurePane = ({name, project_name, selected, config, job, update, error}:{
-  name:string,
-  project_name:string,
-  selected:string|null,
-  config:any,
-  job:Job|undefined,
-  update:Function,
-  error:string
+const ConfigurePane = ({
+  name,
+  project_name,
+  selected,
+  config,
+  job,
+  update
+}: {
+  name: string;
+  project_name: string;
+  selected: string | null;
+  config: any;
+  job: Job | undefined;
+  update: Function;
 }) => {
   const classes = useStyles();
 
-  const [ origScript, setOrigScript ] = useState('');
-  const [ editedScript, setEditedScript ] = useState('');
-  const [ editedConfig, setEditedConfig ] = useState({});
-  const [ comment, setComment ] = useState('');
-  const [ showRevisions, setShowRevisions ] = useState(false);
-  const [ showJson, setShowJson ] = useState(false);
+  const [origScript, setOrigScript] = useState('');
+  const [editedScript, setEditedScript] = useState('');
+  const [editedConfig, setEditedConfig] = useState({});
+  const [comment, setComment] = useState('');
+  const [showRevisions, setShowRevisions] = useState(false);
+  const [showJson, setShowJson] = useState(false);
 
   const JobForm = job ? FORMS[job.name] : null;
 
-  useEffect( () => {
-    const script = JSON.stringify(config,null,2);
+  useEffect(() => {
+    const script = JSON.stringify(config, null, 2);
     setOrigScript(script);
     setEditedScript(script);
     setEditedConfig(config);
   }, [config]);
 
-  const showSave = showJson ? (origScript != editedScript) : (editedConfig != config);
+  const showSave = showJson
+    ? origScript != editedScript
+    : editedConfig != config;
 
-  return <EtlPane mode='configure' selected={selected}>
-    <EtlPaneHeader title='Configuration' error={error}>
-      {
-        showSave && 
+  return (
+    <EtlPane mode='configure' selected={selected}>
+      <EtlPaneHeader title='Configuration'>
+        {showSave && (
           <Grid spacing={1} container className={classes.savebar}>
-            <Grid item><TextField style={{width:300}} value={comment} onChange={ e => setComment(e.target.value) } placeholder='Revision comment'/></Grid>
-            <Grid item><Button disabled={ comment == '' } onClick={ () => {
-              update({ comment, config: showJson ? JSON.parse(editedScript) : editedConfig });
-              setComment('');
-            } } >Save</Button></Grid >
-            <Grid item><Button onClick={() => showJson ? setEditedScript(origScript) : setEditedConfig(config)} color='secondary'>Reset</Button></Grid>
+            <Grid item>
+              <TextField
+                style={{width: 300}}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder='Revision comment'
+              />
+            </Grid>
+            <Grid item>
+              <Button
+                disabled={comment == ''}
+                onClick={() => {
+                  update({
+                    comment,
+                    config: showJson ? JSON.parse(editedScript) : editedConfig
+                  });
+                  setComment('');
+                }}
+              >
+                Save
+              </Button>
+            </Grid>
+            <Grid item>
+              <Button
+                onClick={() =>
+                  showJson
+                    ? setEditedScript(origScript)
+                    : setEditedConfig(config)
+                }
+                color='secondary'
+              >
+                Reset
+              </Button>
+            </Grid>
           </Grid>
-      }
-      <Grid container spacing={1} item className={classes.buttons}>
-        {
-          JobForm && <Tooltip title={ showJson ? 'show form' : 'show json' }>
-            <IconButton disabled={showSave} onClick={() => setShowJson(!showJson) } size='small' aria-label='revision history'
-              color={ showJson ? 'primary' : 'default' }>
-              <CodeIcon/>
+        )}
+        <Grid container spacing={1} item className={classes.buttons}>
+          {JobForm && (
+            <Tooltip title={showJson ? 'show form' : 'show json'}>
+              <IconButton
+                disabled={showSave}
+                onClick={() => setShowJson(!showJson)}
+                size='small'
+                aria-label='revision history'
+                color={showJson ? 'primary' : 'default'}
+              >
+                <CodeIcon />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title='revision history'>
+            <IconButton
+              onClick={() => setShowRevisions(true)}
+              size='small'
+              aria-label='revision history'
+            >
+              <HistoryIcon />
             </IconButton>
           </Tooltip>
-        }
-        <Tooltip title='revision history'>
-          <IconButton onClick={() => setShowRevisions(true) } size='small' aria-label='revision history'>
-            <HistoryIcon/>
-          </IconButton>
-        </Tooltip>
-        <RevisionHistory
-          name={name}
-          project_name={project_name}
-          open={showRevisions}
-          config={config}
-          update={
-            newConfig => {
+          <RevisionHistory
+            name={name}
+            project_name={project_name}
+            open={showRevisions}
+            config={config}
+            update={(newConfig) => {
               setEditedConfig(newConfig);
-              setEditedScript(JSON.stringify(newConfig,null,2));
+              setEditedScript(JSON.stringify(newConfig, null, 2));
               setShowRevisions(false);
-            }
-          }
-          onClose={() => setShowRevisions(false)}
+            }}
+            onClose={() => setShowRevisions(false)}
+          />
+        </Grid>
+      </EtlPaneHeader>
+      {!JobForm || showJson ? (
+        <ConfigScript
+          script={editedScript}
+          schema={job ? job.schema : null}
+          onChange={setEditedScript}
         />
-      </Grid>
-    </EtlPaneHeader>
-    {
-      (!JobForm || showJson)
-        ? <ConfigScript script={editedScript} schema={job ? job.schema : null} onChange={setEditedScript} />
-        : <JobForm project_name={project_name} config={editedConfig} job={job} update={ setEditedConfig }/>
-    }
-  </EtlPane>
-}
+      ) : (
+        <JobForm
+          project_name={project_name}
+          config={editedConfig}
+          job={job}
+          update={setEditedConfig}
+        />
+      )}
+    </EtlPane>
+  );
+};
 
 export default ConfigurePane;

--- a/polyphemus/lib/client/jsx/etl/etl-config.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-config.tsx
@@ -108,9 +108,11 @@ const EtlConfig = ({
 
   const postUpdate = useCallback(
     (update: any) => {
-      setMode(null);
       return json_post(`/api/etl/${project_name}/update/${name}`, update)
-        .then((etl) => onUpdate(etl))
+        .then((etl) => {
+          setMode(null);
+          onUpdate(etl);
+        })
         .catch((r) => r.then(({error}: {error: string}) => setError(error)));
     },
     [project_name, name]
@@ -187,8 +189,12 @@ const EtlConfig = ({
             </Grid>
           </Grid>
         </CardActions>
+        {error && (
+          <Grid item className={classes.error}>
+            <Typography>{error}</Typography>
+          </Grid>
+        )}
         <ConfigurePane
-          error={error}
           name={name}
           project_name={project_name}
           selected={mode}
@@ -197,7 +203,6 @@ const EtlConfig = ({
           update={postUpdate}
         />
         <RunPane
-          error={error}
           selected={mode}
           run_interval={run_interval}
           update={postUpdate}
@@ -208,7 +213,6 @@ const EtlConfig = ({
         <RemovePane selected={mode} update={postUpdate} />
         <LogsPane selected={mode} name={name} project_name={project_name} />
         <SecretsPane
-          error={error}
           selected={mode}
           update={postUpdate}
           keys={job ? job.secrets : null}

--- a/polyphemus/lib/client/jsx/etl/etl-config.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-config.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useEffect} from 'react';
 import {json_post} from 'etna-js/utils/fetch';
 
 import Typography from '@material-ui/core/Typography';
@@ -36,7 +36,7 @@ import {formatTime, runTime} from './run-state';
 const StatusIcon = ({status}: {status: string}) => {
   let IconComponent: any;
   if (status == 'completed') IconComponent = CheckIcon;
-  else if (status == 'error') IconComponent = ErrorIcon;
+  else if (status == 'message') IconComponent = ErrorIcon;
   else if (status == 'pending') IconComponent = ScheduleIcon;
   else return null;
 
@@ -75,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
   completed: {
     color: 'green'
   },
-  error: {
+  message: {
     paddingLeft: '0.5rem',
     color: 'red'
   },
@@ -102,20 +102,25 @@ const EtlConfig = ({
   onUpdate
 }: Etl & {job: Job | undefined; onUpdate: Function}) => {
   const [mode, setMode] = useState<string | null>(null);
-  const [error, setError] = useState('');
-  const toggleMode = (m: string) => (mode == m ? setMode(null) : setMode(m));
+  const [message, setMessage] = useState('');
+  const toggleMode = (m: string) => {
+    mode == m ? setMode(null) : setMode(m);
+    setMessage('');
+  };
 
   const classes: any = useStyles();
 
   const postUpdate = useCallback(
     (update: any) => {
+      setMessage('');
       return json_post(`/api/etl/${project_name}/update/${name}`, update)
         .then((etl) => {
-          setMode(null);
           onUpdate(etl);
-          setError('');
+          setMessage('Saved!');
         })
-        .catch((r) => r.then(({error}: {error: string}) => setError(error)));
+        .catch((r) =>
+          r.then(({message}: {message: string}) => setMessage(message))
+        );
     },
     [project_name, name]
   );
@@ -191,9 +196,9 @@ const EtlConfig = ({
             </Grid>
           </Grid>
         </CardActions>
-        {error && (
-          <Grid item className={classes.error}>
-            <Typography>{error}</Typography>
+        {message && (
+          <Grid item className={classes.message}>
+            <Typography>{message}</Typography>
           </Grid>
         )}
         <ConfigurePane

--- a/polyphemus/lib/client/jsx/etl/etl-config.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-config.tsx
@@ -112,6 +112,7 @@ const EtlConfig = ({
         .then((etl) => {
           setMode(null);
           onUpdate(etl);
+          setError('');
         })
         .catch((r) => r.then(({error}: {error: string}) => setError(error)));
     },

--- a/polyphemus/lib/client/jsx/etl/etl-config.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-config.tsx
@@ -76,6 +76,7 @@ const useStyles = makeStyles((theme) => ({
     color: 'green'
   },
   error: {
+    paddingLeft: '0.5rem',
     color: 'red'
   },
   pending: {

--- a/polyphemus/lib/client/jsx/etl/etl-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/etl-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, {useState, useCallback} from 'react';
 import Collapse from '@material-ui/core/Collapse';
 import CardContent from '@material-ui/core/CardContent';
 import CardActions from '@material-ui/core/CardActions';
@@ -6,9 +6,9 @@ import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import {makeStyles} from '@material-ui/core/styles';
 
-const useStyles = makeStyles( theme => ({
+const useStyles = makeStyles((theme) => ({
   pane: {
-    padding: '8px',
+    padding: '8px'
   },
   paneheader: {
     height: '20px',
@@ -27,30 +27,41 @@ const useStyles = makeStyles( theme => ({
   }
 }));
 
-export const EtlPaneHeader = ({title,error,children}:{title:string,error?:string,children?:React.ReactNode}) => {
+export const EtlPaneHeader = ({
+  title,
+  children
+}: {
+  title: string;
+  children?: React.ReactNode;
+}) => {
   const classes = useStyles();
 
-  return <Grid className={classes.header} container alignItems='center'>
-    <Grid item className={classes.title}>
-      <Typography>{title}</Typography>
-    </Grid>
-    {
-      error && <Grid item className={classes.error}>
-        <Typography>{error}</Typography>
+  return (
+    <Grid className={classes.header} container alignItems='center'>
+      <Grid item className={classes.title}>
+        <Typography>{title}</Typography>
       </Grid>
-    }
-    { children }
-  </Grid>
-}
+      {children}
+    </Grid>
+  );
+};
 
-const EtlPane = ({mode, selected, children }:{mode:string, selected:string|null,children:React.ReactNode}) => {
+const EtlPane = ({
+  mode,
+  selected,
+  children
+}: {
+  mode: string;
+  selected: string | null;
+  children: React.ReactNode;
+}) => {
   const classes = useStyles();
 
-  return <Collapse in={mode == selected} timeout='auto' unmountOnExit>
-    <CardContent className={classes.pane}>
-      { children }
-    </CardContent>
-  </Collapse>
+  return (
+    <Collapse in={mode == selected} timeout='auto' unmountOnExit>
+      <CardContent className={classes.pane}>{children}</CardContent>
+    </Collapse>
+  );
 };
 
 export default EtlPane;

--- a/polyphemus/lib/client/jsx/etl/redcap-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/redcap-form.tsx
@@ -249,7 +249,7 @@ const ValueRow = ({
   else if (opts.enum)
     valueComponent = (
       <Select value={value} onChange={(e) => update(e.target.value)}>
-        {opts.enum.map((v: string) => (
+        {opts.enum.sort().map((v: string) => (
           <MenuItem key={v} value={v}>
             {v}
           </MenuItem>
@@ -990,7 +990,7 @@ const AddModel = ({
           <MenuItem value=''>
             <em>None</em>
           </MenuItem>
-          {model_names.map((att_name) => (
+          {model_names.sort().map((att_name) => (
             <MenuItem key={att_name} value={att_name}>
               {att_name}
             </MenuItem>
@@ -1068,7 +1068,7 @@ const RedcapForm = ({
             value={tab}
             onChange={(e, tab) => setTab(tab)}
           >
-            {modelNames.map((modelName) => (
+            {modelNames.sort().map((modelName) => (
               <Tab label={modelName} key={modelName} />
             ))}
           </Tabs>

--- a/polyphemus/lib/client/jsx/etl/redcap-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/redcap-form.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useCallback, useContext, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useContext,
+  useMemo
+} from 'react';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import Tabs from '@material-ui/core/Tabs';
@@ -29,15 +35,15 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
-import { ModalProps } from '@material-ui/core/Modal';
+import {ModalProps} from '@material-ui/core/Modal';
 
-import { MagmaContext } from 'etna-js/contexts/magma-context';
-import { RedcapContext, RedcapProvider } from './redcap-context';
+import {MagmaContext} from 'etna-js/contexts/magma-context';
+import {RedcapContext, RedcapProvider} from './redcap-context';
 import {Debouncer} from 'etna-js/utils/debouncer';
 
 import {makeStyles, Theme} from '@material-ui/core/styles';
 
-const useStyles = makeStyles( (theme:Theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   form: {
     height: '500px',
     flexWrap: 'nowrap'
@@ -60,7 +66,7 @@ const useStyles = makeStyles( (theme:Theme) => ({
     padding: '5px',
     borderRadius: '0px 2px 2px 0px',
     border: '1px solid #eee',
-    marginRight: '5px',
+    marginRight: '5px'
   },
   remove_entity: {
     height: '30px',
@@ -77,7 +83,7 @@ const useStyles = makeStyles( (theme:Theme) => ({
   tab_scroll: {
     flexGrow: 0,
     maxWidth: 'calc(100% - 50px)',
-    flexBasis: 'calc(100% - 50px)',
+    flexBasis: 'calc(100% - 50px)'
   },
   tab_buttons: {
     flex: '1 1 auto',
@@ -95,7 +101,7 @@ const useStyles = makeStyles( (theme:Theme) => ({
   },
   model_row: {
     minHeight: '47px',
-    "&:not(:last-of-type)": {
+    '&:not(:last-of-type)': {
       borderBottom: '1px solid #eee',
       marginBottom: '5px'
     }
@@ -141,7 +147,7 @@ const useStyles = makeStyles( (theme:Theme) => ({
     color: theme.palette.secondary.main,
     flex: '1 1 auto',
     marginRight: '5px',
-    padding: '0px 10px',
+    padding: '0px 10px'
   },
   value: {
     flex: '1 1 auto',
@@ -159,35 +165,45 @@ const useStyles = makeStyles( (theme:Theme) => ({
   }
 }));
 
-const diff = (list1:string[], list2:string[]) => {
+const diff = (list1: string[], list2: string[]) => {
   const l2 = new Set(list2);
-  return list1.filter( x => !l2.has(x) );
-}
+  return list1.filter((x) => !l2.has(x));
+};
 
-const SmallCheckbox = (props:any) => <Checkbox
-  icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-  checkedIcon={<CheckBoxIcon fontSize="small" />}
-  {...props}/>;
+const SmallCheckbox = (props: any) => (
+  <Checkbox
+    icon={<CheckBoxOutlineBlankIcon fontSize='small' />}
+    checkedIcon={<CheckBoxIcon fontSize='small' />}
+    {...props}
+  />
+);
 
-const debounce = (callback:Function, delay:number) => {
-  let timer:ReturnType<typeof setTimeout>;
-  return (...args:any[]) => {
+const debounce = (callback: Function, delay: number) => {
+  let timer: ReturnType<typeof setTimeout>;
+  return (...args: any[]) => {
     clearTimeout(timer);
     timer = setTimeout(() => callback(...args), delay);
-  }
-}
+  };
+};
 
-const ValueRow = ({field_name, value, update, opts}:{
-  field_name: string,
-  value: any,
-  update: (newValue:any) => void,
-  opts:any
+const ValueRow = ({
+  field_name,
+  value,
+  update,
+  opts
+}: {
+  field_name: string;
+  value: any;
+  update: (newValue: any) => void;
+  opts: any;
 }) => {
   const classes = useStyles();
 
   const [localValue, setLocalValue] = useState<typeof value>('');
 
-  useEffect(() => { setLocalValue(value) }, [value]);
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
 
   let valueComponent;
 
@@ -198,549 +214,897 @@ const ValueRow = ({field_name, value, update, opts}:{
       setLocalValue(newValue);
       debouncer.ready(() => update(newValue));
     },
-    [ value, debouncer, update ]
+    [value, debouncer, update]
   );
 
-  if (opts === undefined)
-    valueComponent = <Typography>{ value }</Typography>;
+  if (opts === undefined) valueComponent = <Typography>{value}</Typography>;
   else if (opts.type === 'string')
-    valueComponent = <TextField fullWidth value={localValue} onChange={(e) => debouncedUpdate(e.target.value)}/>;
+    valueComponent = (
+      <TextField
+        fullWidth
+        value={localValue}
+        onChange={(e) => debouncedUpdate(e.target.value)}
+      />
+    );
   else if (opts.type == 'array')
-    valueComponent = <TextField placeholder='Comma-separated list' fullWidth value={localValue.join(', ')} onChange={(e:React.ChangeEvent<HTMLInputElement>) => debouncedUpdate(e.target.value.split(/,\s*/))}/>;
+    valueComponent = (
+      <TextField
+        placeholder='Comma-separated list'
+        fullWidth
+        value={localValue.join(', ')}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          debouncedUpdate(e.target.value.split(/,\s*/))
+        }
+      />
+    );
   else if (opts.type == 'boolean')
-    valueComponent = <SmallCheckbox checked={value} onChange={(e:React.ChangeEvent<HTMLInputElement>) => update(e.target.checked)}/>;
+    valueComponent = (
+      <SmallCheckbox
+        checked={value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          update(e.target.checked)
+        }
+      />
+    );
   else if (opts.enum)
-    valueComponent = <Select value={value} onChange={e => update(e.target.value) } >
-      {
-        opts.enum.map(
-           (v:string) => <MenuItem key={v} value={v}>{v}</MenuItem>
-        )
-      }
-    </Select>;
+    valueComponent = (
+      <Select value={value} onChange={(e) => update(e.target.value)}>
+        {opts.enum.map((v: string) => (
+          <MenuItem key={v} value={v}>
+            {v}
+          </MenuItem>
+        ))}
+      </Select>
+    );
 
-  return <Card className={classes.value_row} variant='outlined' elevation={0}>
-    <Grid item container alignItems='center'>
-      <Grid item className={classes.field_name}><Typography>{field_name}</Typography></Grid>
-      <Grid item className={classes.value}>{ valueComponent }</Grid>
-      <Grid item className={classes.remove_value} container justify='flex-end'>
-        <Tooltip title='Remove property'>
-          <IconButton onClick={ () => update(undefined) }><ClearIcon fontSize='small'/></IconButton>
-        </Tooltip>
+  return (
+    <Card className={classes.value_row} variant='outlined' elevation={0}>
+      <Grid item container alignItems='center'>
+        <Grid item className={classes.field_name}>
+          <Typography>{field_name}</Typography>
+        </Grid>
+        <Grid item className={classes.value}>
+          {valueComponent}
+        </Grid>
+        <Grid
+          item
+          className={classes.remove_value}
+          container
+          justify='flex-end'
+        >
+          <Tooltip title='Remove property'>
+            <IconButton onClick={() => update(undefined)}>
+              <ClearIcon fontSize='small' />
+            </IconButton>
+          </Tooltip>
+        </Grid>
       </Grid>
-    </Grid>
-  </Card>
-}
+    </Card>
+  );
+};
 
-const AddProp = ({open,close,update,attribute_value,attribute_props}:{
-  open: boolean,
-  close: () => void,
-  update: (newValue:any) => void,
-  attribute_value: { [key: string]: any }|string,
-  attribute_props: { [key: string]: any }
+const AddProp = ({
+  open,
+  close,
+  update,
+  attribute_value,
+  attribute_props
+}: {
+  open: boolean;
+  close: () => void;
+  update: (newValue: any) => void;
+  attribute_value: {[key: string]: any} | string;
+  attribute_props: {[key: string]: any};
 }) => {
   const props = diff(
     attribute_props ? Object.keys(attribute_props) : [],
-    typeof attribute_value === 'string' ? [ 'redcap_field', 'value' ] : Object.keys(attribute_value)
+    typeof attribute_value === 'string'
+      ? ['redcap_field', 'value']
+      : Object.keys(attribute_value)
   );
 
-  const [ newProp, setNewProp ] = useState('');
+  const [newProp, setNewProp] = useState('');
 
-  return <Dialog open={open} onClose={close}>
-    <DialogTitle>Add property</DialogTitle>
-    <DialogContent>
-      <Select displayEmpty value={newProp} onChange={ (e:React.ChangeEvent<{ value: unknown }>) => setNewProp(e.target.value as string)} >
-        <MenuItem value=''><em>None</em></MenuItem>
-        {
-          props.map(
-            prop => <MenuItem key={prop} value={prop}>{prop}</MenuItem>
-          )
-        }
-      </Select>
-    </DialogContent>
-    <DialogActions>
-      <Button disabled={ !newProp } onClick={ () => {
-        const opts = attribute_props?.[newProp];
-        const newValue = !opts ? undefined :
-          opts.type == 'string' ? '' :
-          opts.enum ? opts.enum[0] :
-          opts.type == 'array' ? [] :
-          opts.type == 'boolean' ? true : undefined;
+  return (
+    <Dialog open={open} onClose={close}>
+      <DialogTitle>Add property</DialogTitle>
+      <DialogContent>
+        <Select
+          displayEmpty
+          value={newProp}
+          onChange={(e: React.ChangeEvent<{value: unknown}>) =>
+            setNewProp(e.target.value as string)
+          }
+        >
+          <MenuItem value=''>
+            <em>None</em>
+          </MenuItem>
+          {props.map((prop) => (
+            <MenuItem key={prop} value={prop}>
+              {prop}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!newProp}
+          onClick={() => {
+            const opts = attribute_props?.[newProp];
+            const newValue = !opts
+              ? undefined
+              : opts.type == 'string'
+              ? ''
+              : opts.enum
+              ? opts.enum[0]
+              : opts.type == 'array'
+              ? []
+              : opts.type == 'boolean'
+              ? true
+              : undefined;
 
-        const oldValue = (typeof attribute_value === 'string') ? { redcap_field: attribute_value, value: 'value' } : attribute_value;
+            const oldValue =
+              typeof attribute_value === 'string'
+                ? {redcap_field: attribute_value, value: 'value'}
+                : attribute_value;
 
-        if (newValue != undefined) update({
-          ...oldValue, [newProp]: newValue
-        });
+            if (newValue != undefined)
+              update({
+                ...oldValue,
+                [newProp]: newValue
+              });
 
-        close();
-      } } color="secondary">Add</Button>
-    </DialogActions>
-  </Dialog>
-}
+            close();
+          }}
+          color='secondary'
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
 
-const RedcapAttribute = ({att_name, attribute_value, update}:{
-  att_name: string,
-  attribute_value: any,
-  update: (newValue:any) => void
+const RedcapAttribute = ({
+  att_name,
+  attribute_value,
+  update
+}: {
+  att_name: string;
+  attribute_value: any;
+  update: (newValue: any) => void;
 }) => {
   const classes = useStyles();
-  const { schema } = useContext(RedcapContext);
+  const {schema} = useContext(RedcapContext);
   const attribute_props = schema?.definitions?.attribute_value?.properties;
 
-  const [ showAddProp, setShowAddProp ] = useState(false);
+  const [showAddProp, setShowAddProp] = useState(false);
 
   let valueComponent;
 
-  const handleUpdateValue = useCallback((field_name: string, newValue: any) => {
-    let v = { ...attribute_value, [field_name]: newValue };
-    if (newValue === undefined) delete v[field_name];
-    update(v);
-  }, [attribute_value, update]);
+  const handleUpdateValue = useCallback(
+    (field_name: string, newValue: any) => {
+      let v = {...attribute_value, [field_name]: newValue};
+      if (newValue === undefined) delete v[field_name];
+      update(v);
+    },
+    [attribute_value, update]
+  );
 
   if (typeof attribute_value === 'string')
-    valueComponent = <TextField placeholder='redcap_field' onChange={ e => update(e.target.value) } value={attribute_value}/>;
+    valueComponent = (
+      <TextField
+        placeholder='redcap_field'
+        onChange={(e) => update(e.target.value)}
+        value={attribute_value}
+      />
+    );
   else {
-    const sort:{ [key:string]:number|undefined}  = { value: 2, redcap_field: 1 }
-    const fieldNames = Object.keys(attribute_value).sort( (a, b) => (sort[b] || 0) - (sort[a] || 0) );
+    const sort: {[key: string]: number | undefined} = {
+      value: 2,
+      redcap_field: 1
+    };
+    const fieldNames = Object.keys(attribute_value).sort(
+      (a, b) => (sort[b] || 0) - (sort[a] || 0)
+    );
 
-    valueComponent = fieldNames.map(
-      field_name => <ValueRow 
+    valueComponent = fieldNames.map((field_name) => (
+      <ValueRow
         key={field_name}
         field_name={field_name}
         value={attribute_value[field_name]}
-        opts={ attribute_props?.[field_name] }
-        update={
-          (newValue:any) => {
-            handleUpdateValue(field_name, newValue);
-          }
-        }
+        opts={attribute_props?.[field_name]}
+        update={(newValue: any) => {
+          handleUpdateValue(field_name, newValue);
+        }}
       />
-    )
+    ));
   }
 
-  return <Grid key={att_name} item container alignItems='center'>
-    <Tooltip placement='left' title={att_name}>
-      <Grid className={ classes.attribute_name} item xs={2}>
-        {att_name}
+  return (
+    <Grid key={att_name} item container alignItems='center'>
+      <Tooltip placement='left' title={att_name}>
+        <Grid className={classes.attribute_name} item xs={2}>
+          {att_name}
+        </Grid>
+      </Tooltip>
+      <Grid item container className={classes.attribute_value}>
+        {valueComponent}
       </Grid>
-    </Tooltip>
-    <Grid item container className={classes.attribute_value}>
-      {valueComponent}
+      <Grid item>
+        <Tooltip title='Add property'>
+          <IconButton onClick={() => setShowAddProp(true)}>
+            <EditIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title='Remove attribute'>
+          <IconButton onClick={() => update(undefined)}>
+            <ClearIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+      </Grid>
+      <AddProp
+        attribute_value={attribute_value}
+        open={showAddProp}
+        close={() => setShowAddProp(false)}
+        update={update}
+        attribute_props={attribute_props}
+      />
     </Grid>
-    <Grid item>
-      <Tooltip title='Add property'><IconButton onClick={() => setShowAddProp(true)}><EditIcon fontSize='small'/></IconButton></Tooltip>
-      <Tooltip title='Remove attribute'><IconButton onClick={() => update(undefined)}><ClearIcon fontSize='small'/></IconButton></Tooltip>
-    </Grid>
-    <AddProp
-      attribute_value={attribute_value}
-      open={showAddProp}
-      close={() => setShowAddProp(false)}
-      update={update}
-      attribute_props={attribute_props}
-    />
-  </Grid>
-}
+  );
+};
 
-const AddAttribute = ({open,close,update,script,modelName}:{
-  open:boolean,
-  close:()=>void,
-  update:Function,
-  script:Script,
-  modelName:string
+const AddAttribute = ({
+  open,
+  close,
+  update,
+  script,
+  modelName
+}: {
+  open: boolean;
+  close: () => void;
+  update: Function;
+  script: Script;
+  modelName: string;
 }) => {
-  const [ newAttribute, setNewAttribute ] = useState('');
+  const [newAttribute, setNewAttribute] = useState('');
 
-  const { models } = useContext(MagmaContext);
+  const {models} = useContext(MagmaContext);
 
-  const attribute_names = Object.values(models[modelName]?.template?.attributes || {})
+  const attribute_names = Object.values(
+    models[modelName]?.template?.attributes || {}
+  )
     .filter((a: any) => !a.hidden)
     .map((a: any) => a.name)
     .sort();
 
-  return <Dialog open={open} onClose={close}>
-    <DialogTitle>Add Attribute</DialogTitle>
-    <DialogContent>
-      <Select displayEmpty value={newAttribute} onChange={ e => setNewAttribute(e.target.value as string)} >
-        <MenuItem value=''><em>None</em></MenuItem>
-        {
-          attribute_names.map( att_name => <MenuItem key={att_name} value={att_name}>{att_name}</MenuItem>)
-        }
-      </Select>
-    </DialogContent>
-    <DialogActions>
-      <Button disabled={ !newAttribute } onClick={ () => {
-        update({ ...script, attributes: { ...script.attributes, [newAttribute]: '' }});
+  return (
+    <Dialog open={open} onClose={close}>
+      <DialogTitle>Add Attribute</DialogTitle>
+      <DialogContent>
+        <Select
+          displayEmpty
+          value={newAttribute}
+          onChange={(e) => setNewAttribute(e.target.value as string)}
+        >
+          <MenuItem value=''>
+            <em>None</em>
+          </MenuItem>
+          {attribute_names.map((att_name) => (
+            <MenuItem key={att_name} value={att_name}>
+              {att_name}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!newAttribute}
+          onClick={() => {
+            update({
+              ...script,
+              attributes: {...script.attributes, [newAttribute]: ''}
+            });
 
-        close();
-      } } color="secondary">Add</Button>
-    </DialogActions>
-  </Dialog>
-}
+            close();
+          }}
+          color='secondary'
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
 
-type Entity = string|{[key:string]:string};
+type Entity = string | {[key: string]: string};
 
-const isFilteredEntity = (e:Entity) => typeof e !== 'string';
+const isFilteredEntity = (e: Entity) => typeof e !== 'string';
 
-const entityName = (e:Entity):string => typeof e === 'string' ? e : Object.keys(e)[0];
-const entityValue = (e:Entity):string => Object.values(e)[0];
+const entityName = (e: Entity): string =>
+  typeof e === 'string' ? e : Object.keys(e)[0];
+const entityValue = (e: Entity): string => Object.values(e)[0];
 
-const AddEntity = ({open,close,update,each}:{
-  open:boolean,
-  close:()=>void,
-  update: (newEach:Entity[]|undefined) => void,
-  each:Entity[]|undefined
+const AddEntity = ({
+  open,
+  close,
+  update,
+  each
+}: {
+  open: boolean;
+  close: () => void;
+  update: (newEach: Entity[] | undefined) => void;
+  each: Entity[] | undefined;
 }) => {
-  const [ newEntity, setNewEntity ] = useState('');
+  const [newEntity, setNewEntity] = useState('');
 
   each = each || [];
 
-  const { schema } = useContext(RedcapContext);
+  const {schema} = useContext(RedcapContext);
   const entity_names = diff(
     Object.keys(schema?.definitions?.each_entity?.properties || {}),
     each.map(entityName)
   );
 
-  return <Dialog open={open} onClose={close}>
-    <DialogTitle>Add Entity</DialogTitle>
-    <DialogContent>
-      <Select displayEmpty value={newEntity} onChange={ e => setNewEntity(e.target.value as string)} >
-        <MenuItem value=''><em>None</em></MenuItem>
-        {
-          entity_names.map( entity_name => <MenuItem key={entity_name} value={entity_name}>{entity_name}</MenuItem>)
-        }
-      </Select>
-    </DialogContent>
-    <DialogActions>
-      <Button disabled={ !newEntity } onClick={ () => {
-        let newEach = each !== undefined ? [ ...each, newEntity ] : [ newEntity ];
+  return (
+    <Dialog open={open} onClose={close}>
+      <DialogTitle>Add Entity</DialogTitle>
+      <DialogContent>
+        <Select
+          displayEmpty
+          value={newEntity}
+          onChange={(e) => setNewEntity(e.target.value as string)}
+        >
+          <MenuItem value=''>
+            <em>None</em>
+          </MenuItem>
+          {entity_names.map((entity_name) => (
+            <MenuItem key={entity_name} value={entity_name}>
+              {entity_name}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!newEntity}
+          onClick={() => {
+            let newEach =
+              each !== undefined ? [...each, newEntity] : [newEntity];
 
-        update(newEach);
+            update(newEach);
 
-        close();
-      } } color="secondary">Add</Button>
-    </DialogActions>
-  </Dialog>
-}
-const RedcapEntity = ({each, allowNull=false, update}:{
-  each: Entity[]|undefined,
-  allowNull?: boolean,
-  update: (newEach:Entity[]|undefined) => void
+            close();
+          }}
+          color='secondary'
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+const RedcapEntity = ({
+  each,
+  allowNull = false,
+  update
+}: {
+  each: Entity[] | undefined;
+  allowNull?: boolean;
+  update: (newEach: Entity[] | undefined) => void;
 }) => {
   const classes = useStyles();
 
   const updateItem = useCallback(
-    (i, entity) => update(Object.assign([], each, {[i]: entity})), [update, each]
+    (i, entity) => update(Object.assign([], each, {[i]: entity})),
+    [update, each]
   );
-  
-  const [ showAddEntity, setShowAddEntity ] = useState(false);
 
-  return <Grid item container alignItems='center'>
-    {
-      !each ? <em>inherited</em> :
-      each.map( (entity,i) => <Grid item key={i}>
-        <Grid container alignContent='center'>
-          <Grid item container alignContent='center' className={classes.entity}>{ entityName(entity) }</Grid>
-          <Grid item container alignContent='center' className={classes.filter_entity}>
-            <Tooltip title='Filter entity'><IconButton
-              color={ isFilteredEntity(entity) ? 'secondary' : 'default' }
-              onClick={ () => isFilteredEntity(entity) ? updateItem(i, entityName(entity)) : updateItem(i, { [entity as string]: '' }) }
-              size='small'><TuneIcon fontSize='small'/></IconButton></Tooltip>
-            {
-              isFilteredEntity(entity) ? 
-                <TextField
-                  onChange={ e => updateItem(i, { [ entityName(entity) ]: e.target.value }) }
-                  placeholder='Filter'
-                  value={entityValue(entity)}/> : null
-            }
-          </Grid>
-          {
-            (entityName(entity) != 'record' || each.length == 1 && allowNull) &&
-            <Grid item container alignContent='center' className={classes.remove_entity}>
-              <Tooltip title='Remove entity'><IconButton onClick={
-                () => each.length == 1 ? update(undefined) : update(each.filter( (e,j) => j != i ))
-                } size='small'><ClearIcon fontSize='small'/></IconButton></Tooltip>
+  const [showAddEntity, setShowAddEntity] = useState(false);
+
+  return (
+    <Grid item container alignItems='center'>
+      {!each ? (
+        <em>inherited</em>
+      ) : (
+        each.map((entity, i) => (
+          <Grid item key={i}>
+            <Grid container alignContent='center'>
+              <Grid
+                item
+                container
+                alignContent='center'
+                className={classes.entity}
+              >
+                {entityName(entity)}
+              </Grid>
+              <Grid
+                item
+                container
+                alignContent='center'
+                className={classes.filter_entity}
+              >
+                <Tooltip title='Filter entity'>
+                  <IconButton
+                    color={isFilteredEntity(entity) ? 'secondary' : 'default'}
+                    onClick={() =>
+                      isFilteredEntity(entity)
+                        ? updateItem(i, entityName(entity))
+                        : updateItem(i, {[entity as string]: ''})
+                    }
+                    size='small'
+                  >
+                    <TuneIcon fontSize='small' />
+                  </IconButton>
+                </Tooltip>
+                {isFilteredEntity(entity) ? (
+                  <TextField
+                    onChange={(e) =>
+                      updateItem(i, {[entityName(entity)]: e.target.value})
+                    }
+                    placeholder='Filter'
+                    value={entityValue(entity)}
+                  />
+                ) : null}
+              </Grid>
+              {(entityName(entity) != 'record' ||
+                (each.length == 1 && allowNull)) && (
+                <Grid
+                  item
+                  container
+                  alignContent='center'
+                  className={classes.remove_entity}
+                >
+                  <Tooltip title='Remove entity'>
+                    <IconButton
+                      onClick={() =>
+                        each.length == 1
+                          ? update(undefined)
+                          : update(each.filter((e, j) => j != i))
+                      }
+                      size='small'
+                    >
+                      <ClearIcon fontSize='small' />
+                    </IconButton>
+                  </Tooltip>
+                </Grid>
+              )}
             </Grid>
-          }
-        </Grid>
-      </Grid>)
-    }
-    {
-      (!each || each.length < 4) &&
-      <Tooltip title='Add entity'><IconButton onClick={
-        ()=> {
-          if (each === undefined || each.length == 0) update(['record']);
-          else setShowAddEntity(true);
-        }
-      } size='small'><AddIcon fontSize='small'/></IconButton></Tooltip>
-    }
-    <AddEntity
-      open={showAddEntity}
-      close={() => setShowAddEntity(false)}
-      update={update}
-      each={each}
-    />
-  </Grid>
-}
+          </Grid>
+        ))
+      )}
+      {(!each || each.length < 4) && (
+        <Tooltip title='Add entity'>
+          <IconButton
+            onClick={() => {
+              if (each === undefined || each.length == 0) update(['record']);
+              else setShowAddEntity(true);
+            }}
+            size='small'
+          >
+            <AddIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+      )}
+      <AddEntity
+        open={showAddEntity}
+        close={() => setShowAddEntity(false)}
+        update={update}
+        each={each}
+      />
+    </Grid>
+  );
+};
 
 type Script = any;
 
-const RedcapScript = ({script, num, update, copy, modelName}:{
-  script: Script,
-  num: number,
-  update: (newScript:Script|undefined) => void,
-  copy: () => void,
-  modelName: string
+const RedcapScript = ({
+  script,
+  num,
+  update,
+  copy,
+  modelName
+}: {
+  script: Script;
+  num: number;
+  update: (newScript: Script | undefined) => void;
+  copy: () => void;
+  modelName: string;
 }) => {
   const classes = useStyles();
-  const { attributes, each } = script;
+  const {attributes, each} = script;
 
-  const [ showAddAttribute, setShowAddAttribute ] = useState(false);
+  const [showAddAttribute, setShowAddAttribute] = useState(false);
 
-  const handleUpdate = useCallback((newScript: Script | undefined) => {
-    update(newScript);
-  }, [update]);
+  const handleUpdate = useCallback(
+    (newScript: Script | undefined) => {
+      update(newScript);
+    },
+    [update]
+  );
 
-  const updateAttributes = useCallback((att_name, newValue) => {
-    let s = { ...script, attributes: { ...attributes, [att_name]: newValue } }
-    if (newValue === undefined) delete s.attributes[att_name];
-    handleUpdate(s);
-  }, [ script, attributes, handleUpdate ]);
+  const updateAttributes = useCallback(
+    (att_name, newValue) => {
+      let s = {...script, attributes: {...attributes, [att_name]: newValue}};
+      if (newValue === undefined) delete s.attributes[att_name];
+      handleUpdate(s);
+    },
+    [script, attributes, handleUpdate]
+  );
 
-  const handleUpdateRedcapEntity = useCallback((newEach: Entity[]|undefined) => {
-    const s = { ...script, each: newEach };
-    if (newEach === undefined) delete s.each;
-    handleUpdate(s);
-  }, [handleUpdate, each, script]);
+  const handleUpdateRedcapEntity = useCallback(
+    (newEach: Entity[] | undefined) => {
+      const s = {...script, each: newEach};
+      if (newEach === undefined) delete s.each;
+      handleUpdate(s);
+    },
+    [handleUpdate, each, script]
+  );
 
-  return <Grid className={ classes.script } container direction='column'>
-    <Typography className={classes.number}>{num}</Typography>
-    <Grid container item className={ classes.script_header} alignItems='center' >
-      <Grid item className={ classes.attribute_name } xs={2}>each</Grid>
-      <Grid item xs={6}>
-        <RedcapEntity each={each} allowNull={true} update={handleUpdateRedcapEntity} />
-      </Grid>
-      <Grid item xs={4}>
-        <Grid container justify='flex-end'>
-          <Tooltip title='Add attribute'><IconButton onClick={ () => setShowAddAttribute(true) }><AddIcon fontSize='small'/></IconButton></Tooltip>
-          <Tooltip title='Copy script'><IconButton onClick={ copy }><CopyIcon fontSize='small'/></IconButton></Tooltip>
-          <Tooltip title='Delete script'><IconButton onClick={ () => update(undefined) }><DeleteIcon fontSize='small'/></IconButton></Tooltip>
+  return (
+    <Grid className={classes.script} container direction='column'>
+      <Typography className={classes.number}>{num}</Typography>
+      <Grid
+        container
+        item
+        className={classes.script_header}
+        alignItems='center'
+      >
+        <Grid item className={classes.attribute_name} xs={2}>
+          each
+        </Grid>
+        <Grid item xs={6}>
+          <RedcapEntity
+            each={each}
+            allowNull={true}
+            update={handleUpdateRedcapEntity}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <Grid container justify='flex-end'>
+            <Tooltip title='Add attribute'>
+              <IconButton onClick={() => setShowAddAttribute(true)}>
+                <AddIcon fontSize='small' />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title='Copy script'>
+              <IconButton onClick={copy}>
+                <CopyIcon fontSize='small' />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title='Delete script'>
+              <IconButton onClick={() => update(undefined)}>
+                <DeleteIcon fontSize='small' />
+              </IconButton>
+            </Tooltip>
+          </Grid>
         </Grid>
       </Grid>
-    </Grid>
-    {
-      Object.keys(attributes).map(
-        att_name => <RedcapAttribute
+      {Object.keys(attributes).map((att_name) => (
+        <RedcapAttribute
           key={att_name}
           att_name={att_name}
           attribute_value={attributes[att_name]}
-          update={ (newValue:any) => updateAttributes(att_name, newValue) } />
-      )
-    }
-    <AddAttribute
-      modelName={modelName}
-      script={script}
-      open={showAddAttribute}
-      close={() => setShowAddAttribute(false)}
-      update={update}
-    />
-  </Grid>
-}
-
-const ModelRow = ({name,children}:{
-  name: string,
-  children: React.ReactNode
-}) => {
-  const classes = useStyles();
-  return <Grid className={classes.model_row} spacing={1} item container>
-    <Grid className={classes.model_row_name} item container justify='flex-end' xs={1} >{name}</Grid>
-    <Grid item alignItems='center' container xs={11}>{ children }</Grid>
-  </Grid>
-}
-
-type Model = {
-  scripts: Script[],
-  each: Entity[],
-  invert?: boolean,
-  identifier_fields?: string[]
+          update={(newValue: any) => updateAttributes(att_name, newValue)}
+        />
+      ))}
+      <AddAttribute
+        modelName={modelName}
+        script={script}
+        open={showAddAttribute}
+        close={() => setShowAddAttribute(false)}
+        update={update}
+      />
+    </Grid>
+  );
 };
 
-const RedcapModel = ({config,modelName, update}:{
-  config: Model,
-  modelName: string,
-  update: (modelConfig:Model|undefined) => void
+const ModelRow = ({
+  name,
+  children,
+  title
+}: {
+  name: string;
+  children: React.ReactNode;
+  title?: string;
 }) => {
   const classes = useStyles();
-  const { each, invert, scripts, identifier_fields } = config;
-  const [ pageSize, setPageSize ] = useState(5);
+  return (
+    <Grid className={classes.model_row} spacing={1} item container>
+      <Tooltip arrow title={title || ''}>
+        <Grid
+          className={classes.model_row_name}
+          item
+          container
+          justify='flex-end'
+          xs={1}
+        >
+          {name}
+        </Grid>
+      </Tooltip>
+      <Grid item alignItems='center' container xs={11}>
+        {children}
+      </Grid>
+    </Grid>
+  );
+};
+
+type Model = {
+  scripts: Script[];
+  each: Entity[];
+  invert?: boolean;
+  identifier_fields?: string[];
+};
+
+const RedcapModel = ({
+  config,
+  modelName,
+  update
+}: {
+  config: Model;
+  modelName: string;
+  update: (modelConfig: Model | undefined) => void;
+}) => {
+  const classes = useStyles();
+  const {each, invert, scripts, identifier_fields} = config;
+  const [pageSize, setPageSize] = useState(5);
 
   const pages = Math.ceil(scripts.length / pageSize);
-  const [ page, setPage ] = useState(1);
+  const [page, setPage] = useState(1);
 
-  const page_scripts = scripts.slice((page-1)*pageSize, page*pageSize);
+  const page_scripts = scripts.slice((page - 1) * pageSize, page * pageSize);
 
-  const handleUpdateScript = (index: number, newScript: Script|undefined) => {
-    const pos = index + (page-1)*pageSize;
-    const newScripts = (newScript === undefined) ?
-      scripts.filter((s,j) => j != pos) :
-      Object.assign([], scripts, {[pos]: newScript});
-    update({ ...config, scripts: newScripts });
-  }
+  const handleUpdateScript = (index: number, newScript: Script | undefined) => {
+    const pos = index + (page - 1) * pageSize;
+    const newScripts =
+      newScript === undefined
+        ? scripts.filter((s, j) => j != pos)
+        : Object.assign([], scripts, {[pos]: newScript});
+    update({...config, scripts: newScripts});
+  };
 
-  const handleCopyScript = useCallback((index: number, script: Script) => {
-    update({
-      ...config,
-      scripts: [ ...scripts.slice(0,index),
-        JSON.parse(JSON.stringify(script)),
-        ...scripts.slice(index)
-      ]
-    })
-  }, [config, update, scripts])
+  const handleCopyScript = useCallback(
+    (index: number, script: Script) => {
+      update({
+        ...config,
+        scripts: [
+          ...scripts.slice(0, index),
+          JSON.parse(JSON.stringify(script)),
+          ...scripts.slice(index)
+        ]
+      });
+    },
+    [config, update, scripts]
+  );
 
-  return <Grid className={classes.model} container>
-    <ModelRow name='remove'><Button onClick={() => update(undefined) }>Remove model</Button></ModelRow>
-    <ModelRow name='each'><RedcapEntity each={each} update={ (newEach:Entity[]|undefined) => {
-      const c = {...config, each: newEach };
-      if (newEach === undefined) delete c.each;
-      update(c as Model);
-    } }/></ModelRow>
-    <ModelRow name='invert'><SmallCheckbox size='small' checked={ !!invert } onChange={ (e:React.ChangeEvent<HTMLInputElement>) => update({ ...config, invert: e.target.checked }) }/></ModelRow>
-    <ModelRow name='identifier_fields'><TextField placeholder='Comma-separated list' value={ (identifier_fields||[]).join(', ') } onChange={ e => update({ ...config, identifier_fields: e.target.value.split(/,\s*/) }) } /></ModelRow>
-    <ModelRow name='scripts'>
-      <Button onClick={ () => update({ ...config, scripts: [ { attributes: {} }, ...scripts ]}) }><AddIcon fontSize='small'/> Add Script</Button>
-      { (pages > 1 || pageSize != 5) && <>
-          <Typography className={classes.page_size}>Page size</Typography>
-          <Select value={pageSize} onChange={e => setPageSize(e.target.value as number)}>
-            {
-              [ 5, 10, 100 ].map( n => <MenuItem key={n} value={n}>{n}</MenuItem>)
-            }
-          </Select>
-          <Pagination count={ pages } page={page} onChange={ (e,v) => setPage(v) }/>
-        </>
-      }
-        { page_scripts.map(
-          (script: Script | undefined, i: number) => 
+  return (
+    <Grid className={classes.model} container>
+      <ModelRow name='remove'>
+        <Button onClick={() => update(undefined)}>Remove model</Button>
+      </ModelRow>
+      <ModelRow name='each'>
+        <RedcapEntity
+          each={each}
+          update={(newEach: Entity[] | undefined) => {
+            const c = {...config, each: newEach};
+            if (newEach === undefined) delete c.each;
+            update(c as Model);
+          }}
+        />
+      </ModelRow>
+      <ModelRow
+        name='invert'
+        title='The `invert` option constructs the REDCap id from the Magma record name; only used for biospecimens where the ID is unknown in REDCap.'
+      >
+        <SmallCheckbox
+          size='small'
+          checked={!!invert}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            update({...config, invert: e.target.checked})
+          }
+        />
+      </ModelRow>
+      <ModelRow
+        name='identifier_fields'
+        title='`identifier_fields` must be specified when the REDCap form provides the Timur record name.'
+      >
+        <TextField
+          placeholder='Comma-separated list'
+          value={(identifier_fields || []).join(', ')}
+          onChange={(e) =>
+            update({...config, identifier_fields: e.target.value.split(/,\s*/)})
+          }
+        />
+      </ModelRow>
+      <ModelRow name='scripts'>
+        <Button
+          onClick={() =>
+            update({...config, scripts: [{attributes: {}}, ...scripts]})
+          }
+        >
+          <AddIcon fontSize='small' /> Add Script
+        </Button>
+        {(pages > 1 || pageSize != 5) && (
+          <>
+            <Typography className={classes.page_size}>Page size</Typography>
+            <Select
+              value={pageSize}
+              onChange={(e) => setPageSize(e.target.value as number)}
+            >
+              {[5, 10, 100].map((n) => (
+                <MenuItem key={n} value={n}>
+                  {n}
+                </MenuItem>
+              ))}
+            </Select>
+            <Pagination
+              count={pages}
+              page={page}
+              onChange={(e, v) => setPage(v)}
+            />
+          </>
+        )}
+        {page_scripts.map((script: Script | undefined, i: number) => (
           <RedcapScript
             key={i}
             script={script}
-            num={i+(page-1)*pageSize+1}
+            num={i + (page - 1) * pageSize + 1}
             modelName={modelName}
-            update={
-              (newScript:Script|undefined) => 
-                handleUpdateScript(i, newScript)
+            update={(newScript: Script | undefined) =>
+              handleUpdateScript(i, newScript)
             }
             copy={() => handleCopyScript(i, script)}
           />
-      )}
-    </ModelRow>
-  </Grid>
+        ))}
+      </ModelRow>
+    </Grid>
+  );
 };
 
-const AddModel = ({open,close,update,config}:{
-  open: boolean,
-  close: ()=>void,
-  update: (config:Config) => void,
-  config: Config
+const AddModel = ({
+  open,
+  close,
+  update,
+  config
+}: {
+  open: boolean;
+  close: () => void;
+  update: (config: Config) => void;
+  config: Config;
 }) => {
-  const [ newModel, setNewModel ] = useState('');
+  const [newModel, setNewModel] = useState('');
 
-  const { models } = useContext(MagmaContext);
+  const {models} = useContext(MagmaContext);
 
-  const model_names = diff( Object.keys(models), Object.keys(config) )
+  const model_names = diff(Object.keys(models), Object.keys(config));
 
-  return <Dialog open={open} onClose={close}>
-    <DialogTitle>Add Model</DialogTitle>
-    <DialogContent>
-      <Select displayEmpty value={newModel} onChange={ e => setNewModel(e.target.value as string)} >
-        <MenuItem value=''><em>None</em></MenuItem>
-        {
-          model_names.map( att_name => <MenuItem key={att_name} value={att_name}>{att_name}</MenuItem>)
-        }
-      </Select>
-    </DialogContent>
-    <DialogActions>
-      <Button disabled={ !newModel } onClick={ () => {
-        update({ ...config, [newModel]: { each: ['record'], scripts: [] } })
+  return (
+    <Dialog open={open} onClose={close}>
+      <DialogTitle>Add Model</DialogTitle>
+      <DialogContent>
+        <Select
+          displayEmpty
+          value={newModel}
+          onChange={(e) => setNewModel(e.target.value as string)}
+        >
+          <MenuItem value=''>
+            <em>None</em>
+          </MenuItem>
+          {model_names.map((att_name) => (
+            <MenuItem key={att_name} value={att_name}>
+              {att_name}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!newModel}
+          onClick={() => {
+            update({...config, [newModel]: {each: ['record'], scripts: []}});
 
-        close();
-      } } color="secondary">Add</Button>
-    </DialogActions>
-  </Dialog>
-}
+            close();
+          }}
+          color='secondary'
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
 
 export type Config = {
-  [modelName: string]: Model
-}
+  [modelName: string]: Model;
+};
 
-const RedcapForm = ({config, project_name, job, update}:{
-  project_name: string,
-  config: Config,
-  job: Job|undefined,
-  update: (config:Config) => void
+const RedcapForm = ({
+  config,
+  project_name,
+  job,
+  update
+}: {
+  project_name: string;
+  config: Config;
+  job: Job | undefined;
+  update: (config: Config) => void;
 }) => {
   const classes = useStyles();
 
-  const { setSchema } = useContext(RedcapContext);
+  const {setSchema} = useContext(RedcapContext);
 
-  useEffect( () => {
+  useEffect(() => {
     if (job) setSchema(job.schema);
-  }, [ job ])
+  }, [job]);
 
   const modelNames = Object.keys(config);
 
-  const [ tab, setTab ] = useState(0);
+  const [tab, setTab] = useState(0);
 
   const modelName = modelNames[tab];
-  const [ showAddModel, setShowAddModel ] = useState(false);
+  const [showAddModel, setShowAddModel] = useState(false);
 
-  const handleUpdateModel = useCallback((modelConfig: Model|undefined) => {
-    let c = { ...config, [modelName]: modelConfig};
-    if (modelConfig === undefined) delete c[modelName];
-    update(c as Config);
-  }, [config, modelName, update]);
+  const handleUpdateModel = useCallback(
+    (modelConfig: Model | undefined) => {
+      let c = {...config, [modelName]: modelConfig};
+      if (modelConfig === undefined) delete c[modelName];
+      update(c as Config);
+    },
+    [config, modelName, update]
+  );
 
   const modelConfig = useMemo(() => {
     return config[modelName];
   }, [config, modelName]);
 
-  return <Grid container className={classes.form} direction='column'>
-    <Grid item container className={classes.tabs}>
-      <Grid item className={classes.tab_scroll}>
-        <Tabs
-          variant="scrollable"
-          indicatorColor="primary"
-          scrollButtons="auto"
-          value={tab}
-          onChange={(e,tab) => setTab(tab)}
-        >
-        {
-          modelNames.map( modelName => <Tab label={modelName} key={modelName}/>)
-        }
-        </Tabs>
+  return (
+    <Grid container className={classes.form} direction='column'>
+      <Grid item container className={classes.tabs}>
+        <Grid item className={classes.tab_scroll}>
+          <Tabs
+            variant='scrollable'
+            indicatorColor='primary'
+            scrollButtons='auto'
+            value={tab}
+            onChange={(e, tab) => setTab(tab)}
+          >
+            {modelNames.map((modelName) => (
+              <Tab label={modelName} key={modelName} />
+            ))}
+          </Tabs>
+        </Grid>
+        <Grid item container className={classes.tab_buttons} justify='flex-end'>
+          <Tooltip title='Add model'>
+            <IconButton onClick={() => setShowAddModel(true)}>
+              <AddIcon />
+            </IconButton>
+          </Tooltip>
+        </Grid>
       </Grid>
-      <Grid item container className={classes.tab_buttons} justify='flex-end'>
-        <Tooltip title='Add model'><IconButton onClick={ () => setShowAddModel(true) }><AddIcon/></IconButton></Tooltip>
+      <Grid item className={classes.tab_pane}>
+        {modelName != undefined && (
+          <RedcapModel
+            key={modelName}
+            modelName={modelName}
+            config={modelConfig}
+            update={handleUpdateModel}
+          />
+        )}
       </Grid>
+      <AddModel
+        open={showAddModel}
+        close={() => setShowAddModel(false)}
+        update={update}
+        config={config}
+      />
     </Grid>
-    <Grid item className={classes.tab_pane}>
-      {
-        modelName != undefined && <RedcapModel
-          key={modelName}
-          modelName={modelName}
-          config={modelConfig}
-          update={handleUpdateModel}/>
-      }
-    </Grid>
-    <AddModel
-      open={showAddModel}
-      close={() => setShowAddModel(false)}
-      update={update}
-      config={config}
-    />
-  </Grid>
-}
+  );
+};
 
-const RedcapFormProvider = (props:any) => <RedcapProvider>
-  <RedcapForm {...props}/>
-</RedcapProvider>
+const RedcapFormProvider = (props: any) => (
+  <RedcapProvider>
+    <RedcapForm {...props} />
+  </RedcapProvider>
+);
 
 export default RedcapFormProvider;

--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -95,9 +95,15 @@ const Param = ({
           fullWidth
           id={name}
           options={modelNames}
-          defaultValue={(value as string)?.split(',') || []}
+          value={'' === value ? [] : (value as string)?.split(',') || []}
           renderInput={(params) => <TextField {...params} variant='standard' />}
-          onChange={(e, v) => update(name, v.join(','))}
+          onChange={(e, v) => {
+            if (v.includes('all')) {
+              update(name, 'all');
+            } else {
+              update(name, v.join(','));
+            }
+          }}
         />
       );
     } else {

--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, {useState, useEffect, useCallback, useMemo} from 'react';
+import * as _ from 'lodash';
+
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -10,15 +12,22 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 import {makeStyles} from '@material-ui/core/styles';
 import EtlPane, {EtlPaneHeader} from './etl-pane';
 
-import { RUN_ONCE, RUN_NEVER, RUN_INTERVAL, getRunState, getRunIntervalTime, runTime } from './run-state';
+import {
+  RUN_ONCE,
+  RUN_NEVER,
+  RUN_INTERVAL,
+  getRunState,
+  getRunIntervalTime,
+  runTime
+} from './run-state';
 
-const useStyles = makeStyles( theme => ({
+const useStyles = makeStyles((theme) => ({
   runbar: {
     width: 'auto',
     justifyContent: 'space-between'
   },
   title: {
-    flex: '0 0 200px',
+    flex: '0 0 200px'
   },
   values: {
     flex: '1 1 auto'
@@ -31,108 +40,203 @@ const useStyles = makeStyles( theme => ({
   }
 }));
 
-type Value = undefined|string|boolean;
+type Value = undefined | string | boolean;
 
-const Param = ({value, opts, name, update}:{
+type SelectParam = {
+  value: string;
+  label: string;
+};
+
+const Param = ({
+  value,
+  opts,
+  name,
+  update
+}: {
   value: Value;
-  opts: string[]|'string'|'boolean',
-  name: string,
-  update: (name:string,value:string|boolean) => void
+  opts: SelectParam[] | 'string' | 'boolean';
+  name: string;
+  update: (name: string, value: string | boolean) => void;
 }) => {
   if (Array.isArray(opts)) {
-    return <Select value={value||''} onChange={e => update(name, e.target.value as string)}>
-      {
-        opts.map(
-          opt => <MenuItem key={opt} value={opt}>{opt}</MenuItem>
-        )
-      }
-    </Select>;
+    return (
+      <Select
+        value={value || ''}
+        onChange={(e) => update(name, e.target.value as string)}
+      >
+        {opts.map((opt) => (
+          <MenuItem key={opt.value} value={opt.value}>
+            {`${opt.value}${opt.label ? ` - ${opt.label}` : ''}`}
+          </MenuItem>
+        ))}
+      </Select>
+    );
   }
 
   if (opts == 'string') {
-    return <TextField size='small' fullWidth value={value== undefined ? '' : value} onChange={e => update(name, e.target.value)}/>;
+    return (
+      <TextField
+        size='small'
+        fullWidth
+        value={value == undefined ? '' : value}
+        onChange={(e) => update(name, e.target.value)}
+      />
+    );
   }
 
   if (opts == 'boolean') {
-    return <Switch size='small' checked={value == undefined ? false : value as boolean} onChange={ e => update(name, e.target.checked)}/>;
+    return (
+      <Switch
+        size='small'
+        checked={value == undefined ? false : (value as boolean)}
+        onChange={(e) => update(name, e.target.checked)}
+      />
+    );
   }
 
-  return null
-}
+  return null;
+};
 
-const RunPane = ({run_interval,update,params,param_opts,selected,error}:{
-  run_interval:number,
-  params:any,
-  param_opts: any,
-  update:Function,
-  error:string,
-  selected:string|null
+const RunPane = ({
+  run_interval,
+  update,
+  params,
+  param_opts,
+  selected,
+  error
+}: {
+  run_interval: number;
+  params: any;
+  param_opts: any;
+  update: Function;
+  error: string;
+  selected: string | null;
 }) => {
-  const [ runState, setRunState ] = useState(getRunState(run_interval));
-  const [ runIntervalTime, setRunIntervalTime ] = useState(getRunIntervalTime(run_interval));
-  const [ newParams, setParams ] = useState<any>({});
+  const [runState, setRunState] = useState(getRunState(RUN_ONCE));
+  const [runIntervalTime, setRunIntervalTime] = useState(
+    getRunIntervalTime(RUN_ONCE)
+  );
+  const [newParams, setParams] = useState<any>({});
 
-  useEffect( () => {
-    setParams(params)
-  }, [ params ] );
+  useEffect(() => {
+    setParams(params);
+  }, [params]);
 
-  const runValue = () => runState == RUN_INTERVAL ? runIntervalTime : runState;
-  const reset = () => { setRunState(getRunState(run_interval)); setRunIntervalTime(getRunIntervalTime(run_interval)); setParams(params) };
+  const runValue = () =>
+    runState == RUN_INTERVAL ? runIntervalTime : runState;
+  const reset = () => {
+    setRunState(getRunState(RUN_ONCE));
+    setRunIntervalTime(getRunIntervalTime(RUN_ONCE));
+    setParams(params);
+  };
 
   const classes = useStyles();
 
-  return <EtlPane mode='run' selected={selected}>
-    <EtlPaneHeader title='Run' error={error}>
-      <Grid className={classes.runbar} spacing={1} container>
-      {
-        (newParams != params || (runState != run_interval && (runState != RUN_INTERVAL || runIntervalTime != run_interval))) && <React.Fragment>
-          <Grid item><Button onClick={ () => update({run_interval: runValue(), params: newParams}) }>Save</Button></Grid>
-          <Grid item><Button onClick={ reset } color='secondary'>Reset</Button></Grid>
-        </React.Fragment>
-      }
-      </Grid>
-    </EtlPaneHeader>
-    <Grid spacing={1} container alignItems='center'>
-      <Grid className={classes.title} item><Typography>Interval</Typography></Grid>
-      <Grid className={classes.values} item><Select value={runState} onChange={e => setRunState(parseInt(e.target.value as string))}>
-        <MenuItem value={RUN_ONCE}>Once</MenuItem>
-        <MenuItem value={RUN_NEVER}>Never</MenuItem>
-        <MenuItem value={RUN_INTERVAL}>Every</MenuItem>
-      </Select>
-      </Grid>
-      {
-        runState == RUN_INTERVAL && <Grid item> <TextField
-          size='small'
-          InputProps={{
-            endAdornment:<InputAdornment position='end'>seconds</InputAdornment>
-          }}
-          value={runIntervalTime}
-          onChange={ e => { setRunIntervalTime(parseInt(e.target.value as string)); } }
-          />
+  const nonBooleanParamOpts = useMemo(() => {
+    return Object.entries(param_opts)
+      .filter(([param, value]) => value !== 'boolean')
+      .map(([param, value]) => param)
+      .sort();
+  }, [param_opts]);
+
+  const formValid = useMemo(() => {
+    return (
+      (_.isEqual(nonBooleanParamOpts, Object.keys(newParams).sort()) ||
+        _.isEqual(
+          Object.keys(param_opts).sort(),
+          Object.keys(newParams).sort()
+        )) &&
+      Object.values(newParams).every((v) => v != null && v !== '')
+    );
+  }, [nonBooleanParamOpts, param_opts, newParams]);
+
+  return (
+    <EtlPane mode='run' selected={selected}>
+      <EtlPaneHeader title='Run' error={error}>
+        <Grid className={classes.runbar} spacing={1} container>
+          <Grid item>
+            <Button
+              onClick={() =>
+                update({run_interval: runValue(), params: newParams})
+              }
+              disabled={!formValid}
+            >
+              Save
+            </Button>
+          </Grid>
+          <Grid item>
+            <Button onClick={reset} color='secondary'>
+              Reset
+            </Button>
+          </Grid>
         </Grid>
-      }
-    </Grid>
-    <Grid spacing={1} container alignItems='flex-start'>
-      <Grid className={classes.title} item><Typography>Parameters</Typography></Grid>
-      <Grid className={classes.params} item>
-        {
-          Object.keys(param_opts).sort().map( param_name =>
-            <Grid alignItems='center' key={param_name} className={classes.param} container>
-              <Grid item xs={4}>{param_name}</Grid>
-              <Grid item xs={5}>
-                <Param name={param_name} value={newParams && newParams[param_name] as Value} opts={param_opts[param_name]} update={
-                  (name,value) => {
-                    console.log({name, value});
-                    setParams({...newParams, [name]: value});
-                  }
-                }/>
-              </Grid>
-            </Grid>
-          )
-        }
+      </EtlPaneHeader>
+      <Grid spacing={1} container alignItems='center'>
+        <Grid className={classes.title} item>
+          <Typography>Interval</Typography>
+        </Grid>
+        <Grid className={classes.values} item>
+          <Select
+            value={runState}
+            onChange={(e) => setRunState(parseInt(e.target.value as string))}
+          >
+            <MenuItem value={RUN_ONCE}>Once</MenuItem>
+            <MenuItem value={RUN_NEVER}>Never</MenuItem>
+            <MenuItem value={RUN_INTERVAL}>Every</MenuItem>
+          </Select>
+        </Grid>
+        {runState == RUN_INTERVAL && (
+          <Grid item>
+            {' '}
+            <TextField
+              size='small'
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position='end'>seconds</InputAdornment>
+                )
+              }}
+              value={runIntervalTime}
+              onChange={(e) => {
+                setRunIntervalTime(parseInt(e.target.value as string));
+              }}
+            />
+          </Grid>
+        )}
       </Grid>
-    </Grid>
-  </EtlPane>
-}
+      <Grid spacing={1} container alignItems='flex-start'>
+        <Grid className={classes.title} item>
+          <Typography>Parameters</Typography>
+        </Grid>
+        <Grid className={classes.params} item>
+          {Object.keys(param_opts)
+            .sort()
+            .map((param_name) => (
+              <Grid
+                alignItems='center'
+                key={param_name}
+                className={classes.param}
+                container
+              >
+                <Grid item xs={4}>
+                  {param_name}
+                </Grid>
+                <Grid item xs={5}>
+                  <Param
+                    name={param_name}
+                    value={newParams && (newParams[param_name] as Value)}
+                    opts={param_opts[param_name]}
+                    update={(name, value) => {
+                      console.log({name, value});
+                      setParams({...newParams, [name]: value});
+                    }}
+                  />
+                </Grid>
+              </Grid>
+            ))}
+        </Grid>
+      </Grid>
+    </EtlPane>
+  );
+};
 
 export default RunPane;

--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -100,6 +100,15 @@ const Param = ({
           onChange={(e, v) => update(name, v.join(','))}
         />
       );
+    } else {
+      return (
+        <TextField
+          size='small'
+          fullWidth
+          value={value == undefined ? '' : value}
+          onChange={(e) => update(name, e.target.value)}
+        />
+      );
     }
   } else if (opts == 'string') {
     return (

--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -45,6 +45,7 @@ type Value = undefined | string | boolean;
 type SelectParam = {
   value: string;
   label: string;
+  default?: boolean;
 };
 
 const Param = ({
@@ -59,9 +60,10 @@ const Param = ({
   update: (name: string, value: string | boolean) => void;
 }) => {
   if (Array.isArray(opts)) {
+    const defaultOption = opts.find((o) => o.default);
     return (
       <Select
-        value={value || ''}
+        value={value || defaultOption?.value || ''}
         onChange={(e) => update(name, e.target.value as string)}
       >
         {opts.map((opt) => (
@@ -146,7 +148,9 @@ const RunPane = ({
           Object.keys(param_opts).sort(),
           Object.keys(newParams).sort()
         )) &&
-      Object.values(newParams).every((v) => v != null && v !== '')
+      Object.values(newParams).every(
+        (v) => v != null && v !== '' && !_.isEqual(v, [])
+      )
     );
   }, [nonBooleanParamOpts, param_opts, newParams]);
 
@@ -226,7 +230,6 @@ const RunPane = ({
                     value={newParams && (newParams[param_name] as Value)}
                     opts={param_opts[param_name]}
                     update={(name, value) => {
-                      console.log({name, value});
                       setParams({...newParams, [name]: value});
                     }}
                   />

--- a/polyphemus/lib/client/jsx/etl/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/run-pane.tsx
@@ -129,14 +129,12 @@ const RunPane = ({
   params,
   param_opts,
   selected,
-  error,
   config
 }: {
   run_interval: number;
   params: any;
   param_opts: any;
   update: Function;
-  error: string;
   selected: string | null;
   config: any;
 }) => {
@@ -182,7 +180,7 @@ const RunPane = ({
 
   return (
     <EtlPane mode='run' selected={selected}>
-      <EtlPaneHeader title='Run' error={error}>
+      <EtlPaneHeader title='Run'>
         <Grid className={classes.runbar} spacing={1} container>
           <Grid item>
             <Button

--- a/polyphemus/lib/client/jsx/etl/secrets-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/secrets-pane.tsx
@@ -24,13 +24,11 @@ const SecretsPane = ({
   selected,
   keys,
   update,
-  error,
   secrets
 }: {
   selected: string | null;
   keys: string[] | null;
   update: Function;
-  error: string;
   secrets: any;
 }) => {
   const classes = useStyles();
@@ -46,7 +44,7 @@ const SecretsPane = ({
 
   return (
     <EtlPane mode='secrets' selected={selected}>
-      <EtlPaneHeader title='Secrets' error={error} />
+      <EtlPaneHeader title='Secrets' />
       <Grid container className={classes.table}>
         {keys &&
           keys.map((key) => (

--- a/polyphemus/lib/client/jsx/etl/secrets-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/secrets-pane.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, {useState, useCallback} from 'react';
 import EtlPane, {EtlPaneHeader} from './etl-pane';
 import {makeStyles} from '@material-ui/core/styles';
-import { Controlled } from 'react-codemirror2';
+import {Controlled} from 'react-codemirror2';
 import Typography from '@material-ui/core/Typography';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
@@ -9,9 +9,8 @@ import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles( theme => ({
-  table: {
-  },
+const useStyles = makeStyles((theme) => ({
+  table: {},
   tablerow: {
     '&:not(:last-of-type)': {
       borderBottom: '1px solid #ccc'
@@ -21,49 +20,82 @@ const useStyles = makeStyles( theme => ({
   }
 }));
 
-const SecretsPane = ({selected, keys, update, error, secrets}:{
-  selected:string|null,
-  keys:string[]|null,
-  update:Function,
-  error: string,
-  secrets:any
+const SecretsPane = ({
+  selected,
+  keys,
+  update,
+  error,
+  secrets
+}: {
+  selected: string | null;
+  keys: string[] | null;
+  update: Function;
+  error: string;
+  secrets: any;
 }) => {
   const classes = useStyles();
 
-  const [ secret, setSecret ] = useState('');
-  const [ value, setValue ] = useState('');
+  const [secret, setSecret] = useState('');
+  const [value, setValue] = useState('');
 
-  return <EtlPane mode='secrets' selected={selected}>
-    <EtlPaneHeader title='Secrets' error={error}/>
-    <Grid container className={classes.table}>
-      {
-        keys && keys.map( key => <Grid item className={classes.tablerow} container key={key}>
-          <Grid item xs={4}>{key}</Grid>
-          <Grid item xs={4}>{secrets[key] ? '●●●' : <em>none</em>}</Grid>
-        </Grid>)
-      }
-    </Grid>
-    <Grid container spacing={1}>
-      <Grid item>
-        <Select displayEmpty value={secret} onChange={e => setSecret(e.target.value as string)}>
-          <MenuItem disabled value=''>Set secret</MenuItem>
-          {
-            keys && keys.map( key => <MenuItem key={key} value={key}>{key}</MenuItem>)
-          }
-        </Select>
+  const handleOnUpdate = useCallback(() => {
+    update({secrets: {[secret]: value}});
+    setSecret('');
+    setValue('');
+  }, [update, secret, value]);
+
+  return (
+    <EtlPane mode='secrets' selected={selected}>
+      <EtlPaneHeader title='Secrets' error={error} />
+      <Grid container className={classes.table}>
+        {keys &&
+          keys.map((key) => (
+            <Grid item className={classes.tablerow} container key={key}>
+              <Grid item xs={4}>
+                {key}
+              </Grid>
+              <Grid item xs={4}>
+                {secrets[key] ? '●●●' : <em>none</em>}
+              </Grid>
+            </Grid>
+          ))}
       </Grid>
-      {
-        secret && <React.Fragment>
-          <Grid item>
-            <TextField onChange={ e => setValue(e.target.value) } fullWidth value={value} placeholder='New value'/>
-          </Grid>
-          <Grid item>
-             <Button onClick={ () => update({secrets: { [secret]: value }}) }>Save</Button>
-          </Grid>
-        </React.Fragment>
-      }
-    </Grid>
-  </EtlPane>
-}
+      <Grid container spacing={1}>
+        <Grid item>
+          <Select
+            displayEmpty
+            value={secret}
+            onChange={(e) => setSecret(e.target.value as string)}
+          >
+            <MenuItem disabled value=''>
+              Set secret
+            </MenuItem>
+            {keys &&
+              keys.map((key) => (
+                <MenuItem key={key} value={key}>
+                  {key}
+                </MenuItem>
+              ))}
+          </Select>
+        </Grid>
+        {secret && (
+          <React.Fragment>
+            <Grid item>
+              <TextField
+                onChange={(e) => setValue(e.target.value)}
+                fullWidth
+                value={value}
+                placeholder='New value'
+              />
+            </Grid>
+            <Grid item>
+              <Button onClick={handleOnUpdate}>Save</Button>
+            </Grid>
+          </React.Fragment>
+        )}
+      </Grid>
+    </EtlPane>
+  );
+};
 
 export default SecretsPane;

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useCallback, useContext } from 'react';
-import { json_get } from 'etna-js/utils/fetch';
-import { getDocuments } from 'etna-js/api/magma_api';
+import React, {useState, useEffect, useCallback, useContext} from 'react';
+import {json_get} from 'etna-js/utils/fetch';
+import {getDocuments} from 'etna-js/api/magma_api';
 
 import Typography from '@material-ui/core/Typography';
 import {makeStyles} from '@material-ui/core/styles';
@@ -9,7 +9,7 @@ import Button from '@material-ui/core/Button';
 import EtlConfig from './etl/etl-config';
 import EtlCreate from './etl/etl-create';
 
-import { MagmaContext } from 'etna-js/contexts/magma-context';
+import {MagmaContext} from 'etna-js/contexts/magma-context';
 
 const useStyles = makeStyles((theme) => ({
   etls: {
@@ -20,59 +20,78 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const PolyphemusMain = ({project_name}:{project_name: string}) => {
-  const [ etls, setEtls ] = useState< Etl[] >([]);
-  const [ jobs, setJobs ] = useState< Job[] | null>(null);
-  const [ create, setCreate ] = useState(false);
-  const { models, setModels } = useContext(MagmaContext);
+const PolyphemusMain = ({project_name}: {project_name: string}) => {
+  const [etls, setEtls] = useState<Etl[]>([]);
+  const [jobs, setJobs] = useState<Job[] | null>(null);
+  const [create, setCreate] = useState(false);
+  const {models, setModels} = useContext(MagmaContext);
 
-  const addEtl = (etl:Etl) => {
-    let index = etls.findIndex( e => e.name == etl.name );
-    let new_etls = (index == -1) ? etls.concat(etl) :
-      etl.archived ? etls.filter( (e, i) => i != index ) :
-      etls.map( (e,i) => i == index ? etl : e );
+  const addEtl = (etl: Etl) => {
+    let index = etls.findIndex((e) => e.name == etl.name);
+    let new_etls =
+      index == -1
+        ? etls.concat(etl)
+        : etl.archived
+        ? etls.filter((e, i) => i != index)
+        : etls.map((e, i) => (i == index ? etl : e));
 
     setEtls(new_etls);
-  }
+  };
 
   const classes = useStyles();
 
-  useEffect( () => {
-    json_get(`/api/etl/${project_name}/configs`).then(setEtls)
+  useEffect(() => {
+    json_get(`/api/etl/${project_name}/configs`).then(setEtls);
     json_get(`/api/etl/jobs`).then(setJobs);
-    getDocuments({
-      project_name,
-      model_name: 'all',
-      record_names: [],
-      attribute_names: 'all',
-    }, fetch).then(
-      ({models}) => setModels(models)
-    ).catch( e => console.log({e}) )
-  }, [] );
+    getDocuments(
+      {
+        project_name,
+        model_name: 'all',
+        record_names: [],
+        attribute_names: 'all'
+      },
+      fetch
+    )
+      .then(({models}) => setModels(models))
+      .catch((e) => console.log({e}));
+  }, []);
 
+  const collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: 'base'
+  });
 
-  return <Grid id='polyphemus-main'>
-    {
-      !jobs ? null :
+  return (
+    <Grid id='polyphemus-main'>
+      {!jobs ? null : (
         <Grid className={classes.etls} item xs={12}>
-          <Typography className={classes.title} variant="h5">
+          <Typography className={classes.title} variant='h5'>
             {project_name} Data Loaders
           </Typography>
-          {
-            etls.map( (etl:Etl) => <EtlConfig key={etl.name} { ...etl } onUpdate={ addEtl } job={ jobs.find( j => j.name == etl.etl ) } />)
-          }
+          {etls
+            .sort((a, b) => collator.compare(a.name, b.name))
+            .map((etl: Etl) => (
+              <EtlConfig
+                key={etl.name}
+                {...etl}
+                onUpdate={addEtl}
+                job={jobs.find((j) => j.name == etl.etl)}
+              />
+            ))}
           <Grid>
-            <Button onClick={ () => setCreate(true) }>Add Loader</Button>
+            <Button onClick={() => setCreate(true)}>Add Loader</Button>
             <EtlCreate
               project_name={project_name}
               open={create}
               onClose={() => setCreate(false)}
               onCreate={addEtl}
-              jobs={ jobs }/>
+              jobs={jobs}
+            />
           </Grid>
         </Grid>
-    }
-  </Grid>;
-}
+      )}
+    </Grid>
+  );
+};
 
 export default PolyphemusMain;

--- a/polyphemus/lib/models/job.rb
+++ b/polyphemus/lib/models/job.rb
@@ -39,8 +39,13 @@ class Polyphemus
           value_opts = job_params[param]
           case value_opts
           when Array
-            unless value_opts.include?(value)
-              errors.push("#{param} must be in: #{value_opts.join(', ')}")
+            options = value_opts.map { |v| v[:value] }
+            unless options.include?(value)
+              errors.push("#{param} must be in: #{options.join(', ')}")
+            end
+          when Hash
+            unless value.is_a?(String)
+              errors.push("#{param} must be a comma-separated string")
             end
           when 'string'
             unless value.is_a?(String)

--- a/polyphemus/lib/models/redcap_job.rb
+++ b/polyphemus/lib/models/redcap_job.rb
@@ -7,7 +7,16 @@ class Polyphemus
         name: "redcap",
         schema: Redcap::Loader.to_schema,
         params: {
-          mode: [ 'default', 'strict', 'existing' ],
+          mode: [ {
+            value: 'default',
+            label: 'copy REDCap data'
+          }, {
+            value: 'strict',
+            label: 'copy REDCap data and delete Magma records not in REDCap'
+          }, {
+            value: 'existing',
+            label: 'only copy records that exist in Magma'
+          } ],
           model_names: 'string',
           commit: 'boolean'
         },

--- a/polyphemus/lib/models/redcap_job.rb
+++ b/polyphemus/lib/models/redcap_job.rb
@@ -9,13 +9,14 @@ class Polyphemus
         params: {
           mode: [ {
             value: 'default',
+            default: true,
             label: 'copy REDCap data'
           }, {
             value: 'strict',
-            label: 'copy REDCap data and delete Magma records not in REDCap'
+            label: 'copy REDCap data and delete Magma records not in this run'
           }, {
             value: 'existing',
-            label: 'only copy records that exist in Magma'
+            label: 'only copy REDCap records that currently exist in Magma'
           } ],
           model_names: 'string',
           commit: 'boolean'

--- a/polyphemus/lib/models/redcap_job.rb
+++ b/polyphemus/lib/models/redcap_job.rb
@@ -10,15 +10,18 @@ class Polyphemus
           mode: [ {
             value: 'default',
             default: true,
-            label: 'copy REDCap data'
+            description: 'copy REDCap data'
           }, {
             value: 'strict',
-            label: 'copy REDCap data and delete Magma records not in this run'
+            description: 'copy REDCap data and delete Magma records not in this run'
           }, {
             value: 'existing',
-            label: 'only copy REDCap records that currently exist in Magma'
+            description: 'only copy REDCap records that currently exist in Magma'
           } ],
-          model_names: 'string',
+          model_names: {
+            type: 'options',
+            value: 'model_names'
+          },
           commit: 'boolean'
         },
         secrets: [ :redcap_tokens ]

--- a/polyphemus/spec/etl_controller_spec.rb
+++ b/polyphemus/spec/etl_controller_spec.rb
@@ -173,12 +173,12 @@ describe EtlController do
         params: {}
       )
 
-      new_params = { problem: 'bogus', zippit: true }
+      new_params = { problem: 'bogus', zippit: true, select_one: ["all"] }
       auth_header(:editor)
       json_post('/api/etl/labors/update/Dummy ETL', params: new_params)
 
       expect(last_response.status).to eq(422)
-      expect(json_body[:error]).to eq('Problem must be in: present, absent; no such param zippit')
+      expect(json_body[:error]).to eq('Problem must be in: present, absent; no such param zippit; select_one must be a comma-separated string')
       expect(Polyphemus::EtlConfig.count).to eq(1)
       etl.refresh
       expect(etl.params.to_h).to eq({})

--- a/polyphemus/spec/spec_helper.rb
+++ b/polyphemus/spec/spec_helper.rb
@@ -356,7 +356,7 @@ end
 
 def stub_magma_update_dry_run
   stub_request(:post, /#{MAGMA_HOST}\/update$/).
-  to_return(lambda { |request| 
+  to_return(lambda { |request|
     {
       headers: {
         'Content-Type': 'application/json'
@@ -366,7 +366,7 @@ def stub_magma_update_dry_run
       }.to_json
     }
   })
-end 
+end
 
 def redcap_choices(*choices)
   choices.map.with_index do |c, i|
@@ -540,8 +540,9 @@ def create_dummy_job
           additionalProperties: false
         },
         params: {
-          problem: [ 'present', 'absent' ],
+          problem: [ {value: 'present'}, {value: 'absent'} ],
           whippit: 'boolean',
+          select_one: {type: 'options', value: 'choices'}
         },
         secrets: [ :rumor, :password ]
       }


### PR DESCRIPTION
This PR makes some small changes to the REDCap config UI, to hopefully give a little more user-help.

* Run panel:
  * Save button disabled until everything filled in
  * Model names pre-populated (along with `all` option) in the `model_names` field
  * Defaults of run `Once` and `default` mode  
  * Explanatory description for the modes, so users better understand effects of each
* "Saved" message on successful save so user can see feedback to their button click (for each panel)
* Secrets clear out after save, so it's obvious something changed
* Some tooltips on the config panel to clarify what some of the options mean and when they would be used
* Sort some select options in the config panel, so more consistent and easier to find the desired option

I'd really like the config panel to have more inline help or documentation, but I'm currently out of ideas for how to provide those in a non-cluttering fashion. 