### PR TITLE
fix path for getting projects list

### DIFF
--- a/etna/packages/etna-js/api/janus-api.jsx
+++ b/etna/packages/etna-js/api/janus-api.jsx
@@ -1,7 +1,7 @@
 import {json_get} from '../utils/fetch';
 
 export const getProjects = () => {
-  return json_get(`${CONFIG.janus_host}/projects`).then((projects) => {
+  return json_get(`${CONFIG.janus_host}/api/user/projects`).then((projects) => {
     return new Promise((resolve, reject) => {
       resolve(projects.projects);
     });


### PR DESCRIPTION
This is a small PR that fixes an issue with the Janus route for getting list of user projects. You may have noticed on the root page for each app, it's not showing resource projects nor the project titles -- this is because the root view is using the old Janus API route. So this updates to the new route.