### PR TITLE
Finish data_block size migration

### DIFF
--- a/metis/db/migrations/026_widen_datablock_size.rb
+++ b/metis/db/migrations/026_widen_datablock_size.rb
@@ -7,12 +7,13 @@ Sequel.migration do
       end
     end
     alter_table(:data_blocks) do
-      set_column_type :size, :bigint, null: false
+      set_column_type :size, :bigint
+      set_column_not_null :size
     end
   end
   down do
     alter_table(:data_blocks) do
-      set_column_type :size, Integer, null: true
+      set_column_type :size, Integer
     end
   end
 end

--- a/metis/db/migrations/026_widen_datablock_size.rb
+++ b/metis/db/migrations/026_widen_datablock_size.rb
@@ -1,12 +1,18 @@
 Sequel.migration do
   up do
+    # for dev environments where the migration was not run by hand.
+    unless Metis.instance.environment == :production
+      from(:data_blocks).where(size: nil).each do |db|
+        db.update(size: db.actual_size || 0)
+      end
+    end
     alter_table(:data_blocks) do
-      set_column_type :size, :bigint
+      set_column_type :size, :bigint, null: false
     end
   end
   down do
     alter_table(:data_blocks) do
-      set_column_type :size, Integer
+      set_column_type :size, Integer, null: true
     end
   end
 end

--- a/metis/db/migrations/026_widen_datablock_size.rb
+++ b/metis/db/migrations/026_widen_datablock_size.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    alter_table(:data_blocks) do
+      set_column_type :size, :bigint
+    end
+  end
+  down do
+    alter_table(:data_blocks) do
+      set_column_type :size, Integer
+    end
+  end
+end

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -68,26 +68,6 @@ class Metis
     end
   end
 
-  class BackfillSize < Etna::Command
-    def execute
-      i = 0
-      Metis::DataBlock.where(size: nil).each do |db|
-        db.update(size: db.actual_size || 0)
-
-        i += 1
-        if i % 100 == 0
-          puts "Processed #{i}"
-        end
-      end
-    end
-
-    def setup(config)
-      super
-      Metis.instance.setup_db
-      Metis.instance.load_models
-    end
-  end
-
   class Schema < Etna::Command
     usage "Show the current database schema."
 

--- a/metis/lib/models/file.rb
+++ b/metis/lib/models/file.rb
@@ -181,7 +181,7 @@ class Metis
         file_hash: file_hash,
         archive_id: data_block.archive_id,
         read_only: read_only?,
-        size: data_block.actual_size,
+        size: data_block.size,
       }
 
       if with_path

--- a/metis/lib/server/controllers/bucket_controller.rb
+++ b/metis/lib/server/controllers/bucket_controller.rb
@@ -108,7 +108,7 @@ class BucketController < Metis::Controller
       if type == 'files'
         head_query = <<QUERY
     SELECT 
-      'file' as type, head.id as id, head.folder_id as parent_id, head.file_name as node_name, head.updated_at, head.created_at, data_blocks.md5_hash as file_hash, data_blocks.archive_id
+      'file' as type, head.id as id, head.folder_id as parent_id, head.file_name as node_name, head.updated_at, head.created_at, data_blocks.md5_hash as file_hash, data_blocks.archive_id, data_blocks.size
     FROM files as head
     JOIN data_blocks ON data_blocks.id = head.data_block_id
     WHERE #{head_cond} AND head.bucket_id = :bucket_id
@@ -116,7 +116,7 @@ QUERY
       else
         head_query = <<QUERY
     SELECT 
-      'folder' as type, head.id as id, folder_id as parent_id, folder_name as node_name, updated_at, created_at, NULL as file_hash, NULL as archive_id
+      'folder' as type, head.id as id, folder_id as parent_id, folder_name as node_name, updated_at, created_at, NULL as file_hash, NULL as archive_id, NULL as size
     FROM folders as head
     WHERE #{head_cond} AND head.bucket_id = :bucket_id
 QUERY
@@ -127,7 +127,7 @@ QUERY
 #{head_query}
     UNION
     SELECT
-      'parent' as type, folders.id as id, folders.folder_id as parent_id, folders.folder_name as node_name, folders.updated_at, folders.created_at, NULL as file_hash, NULL as archive_id
+      'parent' as type, folders.id as id, folders.folder_id as parent_id, folders.folder_name as node_name, folders.updated_at, folders.created_at, NULL as file_hash, NULL as archive_id, NULL as size
     FROM folders
       JOIN tail_nodes ON folders.id = tail_nodes.parent_id
   )

--- a/metis/spec/bucket_spec.rb
+++ b/metis/spec/bucket_spec.rb
@@ -176,6 +176,7 @@ describe BucketController do
           "id",
           "node_name",
           "parent_id",
+          "size",
           "type",
           "updated_at"
         ])
@@ -227,6 +228,7 @@ describe BucketController do
           "id",
           "node_name",
           "parent_id",
+          "size",
           "type",
           "updated_at"
         ])

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -119,7 +119,8 @@ describe 'Metis Commands' do
 
         @zero_hash_data_block = create(:data_block,
           description: 'zero-byte hash',
-          md5_hash: zero_hash
+          md5_hash: zero_hash,
+          size: 0
         )
         stubs.create_file('athena', 'files', @zero_hash_data_block.md5_hash, '')
 

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -409,7 +409,8 @@ end
 def create_file(project_name, file_name, contents, params={})
   data_block = create(:data_block,
     description: file_name,
-    md5_hash: params.delete(:md5_hash) || Digest::MD5.hexdigest(contents)
+    md5_hash: params.delete(:md5_hash) || Digest::MD5.hexdigest(contents),
+    size: contents.length,
   )
 
   create( :file,


### PR DESCRIPTION
1.  Widens the data_block size
2.  Migrates development instances to include size value in db
3.  Migrates column as nullable: false
4.  Uses the column in api response, do not read from disk for each file in a response payload (performance boost!)

Production backfill already completed.