### PR TITLE
fix name of ucsf

### DIFF
--- a/airflow-code-editor/airflow_code_editor/app_builder_view.py
+++ b/airflow-code-editor/airflow_code_editor/app_builder_view.py
@@ -2,7 +2,7 @@
 #
 #   Copyright 2019 Andrea Bonomi <andrea.bonomi@gmail.com>
 #   Modifications included by DSCOLabs engineering team
-#   University of San Francisco, CA
+#   University of California, San Francisco, San Francisco, CA
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/airflow-code-editor/airflow_code_editor/code_editor_view.py
+++ b/airflow-code-editor/airflow_code_editor/code_editor_view.py
@@ -2,7 +2,7 @@
 #
 #   Copyright 2019 Andrea Bonomi <andrea.bonomi@gmail.com>
 #   Modifications included by DSCOLabs engineering team
-#   University of San Francisco, CA
+#   University of California, San Francisco, San Francisco, CA
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/airflow-code-editor/airflow_code_editor/flask_admin_view.py
+++ b/airflow-code-editor/airflow_code_editor/flask_admin_view.py
@@ -2,7 +2,7 @@
 #
 #   Copyright 2019 Andrea Bonomi <andrea.bonomi@gmail.com>
 #   Modifications included by DSCOLabs engineering team
-#   University of San Francisco, CA
+#   University of California, San Francisco, San Francisco, CA
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Small PR to tweak the UCSF text in the files we've modified for the code editor.

Also, it seems like the `push-subtrees` didn't take for some reason in the previous merge? Wondering if this will re-trigger it to work...?