### PR TITLE
merge records instead of overwriting

### DIFF
--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -105,9 +105,11 @@ module Redcap
 
       records = {}
       @scripts.each do |script|
-        records.update(
-          invert? ? script.inverse_load : script.load
-        )
+        script_records = invert? ? script.inverse_load : script.load
+
+        script_records.each do |model_name, record|
+          (records[model_name] ||= {}).update( record )
+        end
       end
 
       records

--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -107,8 +107,8 @@ module Redcap
       @scripts.each do |script|
         script_records = invert? ? script.inverse_load : script.load
 
-        script_records.each do |model_name, record|
-          (records[model_name] ||= {}).update( record )
+        script_records.each do |record_name, record|
+          (records[record_name] ||= {}).update( record )
         end
       end
 

--- a/polyphemus/spec/etls/redcap/loader_spec.rb
+++ b/polyphemus/spec/etls/redcap/loader_spec.rb
@@ -121,6 +121,84 @@ describe Redcap::Loader do
     end
   end
 
+
+  context 'loading' do
+    before(:each) do
+      stub_magma_models(fixture: 'spec/fixtures/magma_test2_models.json')
+      stub_redcap(
+        hash_including(content: 'metadata') => redcap_metadata(
+          cars: [
+            [ "company_name" ],
+            [ "dof", "date of founding" ],
+            [ "car_class" ],
+            [ "year", "calendar year", "date" ],
+            {
+              field_name: "feature",
+              field_type: "checkbox",
+              select_choices_or_calculations: redcap_choices("Window", "Door", "Spoiler", "Radio", "Engine", "Carbuerator", "Wheels")
+            },
+            [ "award_name", "Awards" ]
+          ]
+        )
+      )
+      @magma_client = Etna::Clients::Magma.new(host: MAGMA_HOST, token: TEST_TOKEN)
+    end
+
+    it 'combines records by record name' do
+      Redcap::Model.define("Make").class_eval do
+        def identifier(record_name, identifier_fields: nil)
+          record_name
+        end
+
+        def offset_id(record_name)
+          record_name
+        end
+      end
+
+      stub_redcap(
+        /fields/ => (redcap_records(
+          { redcap_event_name: "Base", field_name: "dof" },
+          [
+            { record: "Jatsun", "value": "1956-02-03" },
+            { "record": "ToyoT", "value": "1933-08-11" },
+            { "record": "Caudillac", "value": "1901-03-01" },
+          ]
+        )+redcap_records(
+          { redcap_event_name: "Base", field_name: "country" },
+          [
+            { record: "Jatsun", "value": "Japan" },
+            { "record": "ToyoT", "value": "Japan" },
+            { "record": "Caudillac", "value": "Spain" },
+          ]
+        )).to_json
+      )
+
+      records = run_loader(
+        make: {
+          each: [ "record" ],
+          scripts: [
+            {
+              attributes: {
+                date_of_founding: "dof"
+              }
+            },
+            {
+              attributes: {
+                country: "country"
+              }
+            }
+          ]
+        }
+      )
+
+      expect(records.keys).to match_array([:make])
+      expect(records[:make].keys).to match_array(["Jatsun", "ToyoT", "Caudillac"])
+      expect(records[:make].values.map(&:keys)).to all( match_array([:country, :date_of_founding]) )
+
+      Kernel.send(:remove_const,:Make)
+    end
+  end
+
   context 'entity iteration' do
     before(:each) do
       stub_magma_models(fixture: 'spec/fixtures/magma_test2_models.json')

--- a/polyphemus/spec/fixtures/magma_test2_models.json
+++ b/polyphemus/spec/fixtures/magma_test2_models.json
@@ -24,6 +24,16 @@
             "validation": null,
             "attribute_type": "date_time"
           },
+          "country": {
+            "name": "country",
+            "attribute_name": "country",
+            "display_name": "Country",
+            "restricted": false,
+            "read_only": false,
+            "hidden": false,
+            "validation": null,
+            "attribute_type": "string"
+          },
           "model": {
             "name": "model",
             "attribute_name": "model",


### PR DESCRIPTION
A small tweak to the redcap loader - previously if two scripts for a model yielded the same identifier, only the last one would make it into an update. Here instead we merge records by identifier, so that all of the scripts updating a single record are part of the final update. I don't attempt to resolve attribute collisions; I don't think these should ever exist in fact, so they continue to just overwrite.