### PR TITLE
Improve feedback on bad foreign key updates and projects.

### DIFF
--- a/magma/lib/magma/attributes/foreign_key.rb
+++ b/magma/lib/magma/attributes/foreign_key.rb
@@ -11,7 +11,9 @@ class Magma
       return [ foreign_id, nil ] if value.nil?
 
       if value.is_a? Magma::TempId
-        [ foreign_id, value.real_id ]
+        id = value.real_id
+        raise Magma::LoadFailed(["#{model_name}.#{attribute_name} value was not a valid #{link_model.model_name} identifier."]) if id.nil?
+        [ foreign_id, id ]
       elsif link_identity && loader.identifier_exists?(link_model, value)
         [ foreign_id, loader.identifier_id(link_model, value) ]
       end

--- a/magma/lib/magma/loader/temp_id.rb
+++ b/magma/lib/magma/loader/temp_id.rb
@@ -11,6 +11,7 @@ class Magma
     end
 
     def real_id
+      return nil if record_entry.nil?
       record_entry.real_id
     end
   end

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -67,7 +67,7 @@ class Magma
         child_extract(
           table.group_by do |row|
             row[identity]
-          end.first.last,
+          end.first&.last,
           identity
         )
       end

--- a/magma/lib/magma/server/retrieve.rb
+++ b/magma/lib/magma/server/retrieve.rb
@@ -101,6 +101,11 @@ class RetrieveController < Magma::Controller
   end
 
   def json_payload
+    project = Magma.instance.get_project(@project_name)
+    if project.nil?
+      return failure(404, "Project #{@project_name} does not exist.")
+    end
+
     if @model_name == 'all'
       Magma.instance.get_project(@project_name).models.each do |model_name, model|
         next if @attribute_names == 'identifier' && !model.has_identifier?
@@ -111,8 +116,10 @@ class RetrieveController < Magma::Controller
         )
       end
     else
+      model = Magma.instance.get_model(@project_name, @model_name)
+
       retrieve_model(
-        Magma.instance.get_model(@project_name, @model_name),
+        model,
         @record_names,
         @attribute_names,
         filter,

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -39,6 +39,19 @@ describe RetrieveController do
     expect(last_response.status).to eq(404)
   end
 
+  it 'fails for non-existent projects' do
+    retrieve(
+      {
+        model_name: 'labor',
+        record_names: [],
+        attribute_names: [],
+        project_name: 'laborsvvvv'
+      },
+      :superuser
+    )
+    expect(last_response.status).to eq(404)
+  end
+
   it 'calls the retrieve endpoint and returns a template.' do
     retrieve(
       model_name: 'aspect',

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -171,6 +171,20 @@ describe UpdateController do
         expect(monster.labor).to eq(hydra)
       end
 
+      it 'provides a useful error message when updating with a non existent parent' do
+        monster = create(:monster, name: 'Lernean Hydra')
+        update(
+          monster: {
+            'Lernean Hydra': {
+              labor: 'The Lernean Hydra'
+            }
+          }
+        )
+
+        expect(last_response.status).to eq(422)
+        expect(json_body[:errors]).to eql(["monster.labor 'The Lernean Hydra' does not exist."])
+      end
+
       it 'updates a parent attribute for parent-collection' do
         lion = create(:labor, name: 'The Nemean Lion', year: '0002-01-01', project: @project)
         hydra = create(:labor, name: 'The Lernean Hydra', year: '0003-01-01')


### PR DESCRIPTION
Fixes taken from rollbar error messages.

1.  Admin users may have permission to view projects that don't exist, so explicitly catch and handle that case.
2. Temp id code handling is a bit... not great.  Many errors in rollbar exist in these paths, so I clarified some typing and added more explicit error messages when updating foreign keys with values that do not exist.