### PR TITLE
file properties dialog

### DIFF
--- a/metis/lib/client/css/dialog.scss
+++ b/metis/lib/client/css/dialog.scss
@@ -66,7 +66,8 @@
 
     .config-dialog,
     .move-folder-dialog,
-    .move-file-dialog {
+    .move-file-dialog,
+    .file-properties-dialog {
       width: 300px;
       font-family: $base-font;
       padding: 5px;
@@ -109,7 +110,8 @@
           }
         }
       }
-      .submit {
+      .submit,
+      .close {
         display: flex;
         padding: 10px 80px 5px;
         .button {

--- a/metis/lib/client/jsx/components/dialogs/file-properties-dialog.tsx
+++ b/metis/lib/client/jsx/components/dialogs/file-properties-dialog.tsx
@@ -1,0 +1,34 @@
+import React, {useCallback} from 'react';
+
+import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
+
+import {File} from '../../types/metis-types';
+import ConfigRow from './config-row';
+
+const FilePropertiesDialog = ({file}: {file: File}) => {
+  const invoke = useActionInvoker();
+
+  const close = useCallback(() => {
+    invoke({type: 'DISMISS_DIALOG'});
+  }, []);
+
+  return (
+    <div className='file-properties-dialog'>
+      <div className='title'>File properties</div>
+      {Object.entries(file).map(([key, value], index) => {
+        return (
+          <ConfigRow label={key} key={index}>
+            <input type='text' readOnly={true} value={value?.toString()} />
+          </ConfigRow>
+        );
+      })}
+      <div className='close'>
+        <span className={`button`} onClick={close}>
+          Close
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default FilePropertiesDialog;

--- a/metis/lib/client/jsx/components/list/file-control.tsx
+++ b/metis/lib/client/jsx/components/list/file-control.tsx
@@ -104,10 +104,22 @@ const FileControl = ({
     });
   }, [moveFile, bucket_name]);
 
+  const filePropertiesDialog = useCallback(() => {
+    let dialog = {
+      type: 'file-properties',
+      file
+    };
+    invoke({
+      type: 'SHOW_DIALOG',
+      dialog
+    });
+  }, [file]);
+
   let items: UiControlItem[] = [
     {label: 'Download file', callback: downloadFile, role: 'viewer'},
     {label: 'Copy download link', callback: copyLink, role: 'viewer'},
-    {label: 'Copy metis path', callback: copyMetisPath, role: 'viewer'}
+    {label: 'Copy metis path', callback: copyMetisPath, role: 'viewer'},
+    {label: 'FIle properties', callback: filePropertiesDialog, role: 'viewer'}
   ].concat(
     file.read_only
       ? [

--- a/metis/lib/client/jsx/components/modal-dialog.jsx
+++ b/metis/lib/client/jsx/components/modal-dialog.jsx
@@ -7,8 +7,9 @@ import Message from './dialogs/message-dialog';
 import UploadDialog from "./dialogs/upload-dialog";
 import MoveFolder from './dialogs/move-folder-dialog';
 import MoveFile from './dialogs/move-file-dialog';
+import FileProperties from './dialogs/file-properties-dialog';
 
-const DIALOGS = { ConfigureBucket, Message, UploadDialog, MoveFolder, MoveFile };
+const DIALOGS = { ConfigureBucket, Message, UploadDialog, MoveFolder, MoveFile, FileProperties };
 
 const ModalDialog = ({ dialog, dismissDialog }) => {
   if (!dialog || !Object.keys(dialog).length) return null;


### PR DESCRIPTION
Per request in Slack, this is a small PR that adds a "File properties" item to the Metis file dropdown menu, and it brings up a dialog with the saved properties. Each property is in a read-only text field that allows folks to copy out the value.

![Screenshot from 2022-05-04 15-24-09](https://user-images.githubusercontent.com/4930129/166810957-c4174b83-a15c-43dc-943c-47b7c91733a2.png)
