### PR TITLE
+ model_names and attribute_names verbs

### DIFF
--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -195,7 +195,7 @@ EOT
       end
 
       def verb *args, &block
-        verbs[args] = block
+        (@verbs ||= {})[args] = block
       end
 
       def match_verbs(query_args, predicate, is_conditional = false)

--- a/magma/lib/magma/query/predicate/start.rb
+++ b/magma/lib/magma/query/predicate/start.rb
@@ -1,7 +1,17 @@
 class Magma
   class StartPredicate < Magma::ModelPredicate
     def self.verbs
-      Magma::ModelPredicate.verbs
+      Magma::ModelPredicate.verbs.merge(@verbs)
+    end
+
+    verb '::attribute_names' do
+      child Array
+
+      extract do
+        @model.attributes.keys
+      end
+
+      format { [ 'String' ] }
     end
 
     def add_filters

--- a/magma/lib/magma/server/query.rb
+++ b/magma/lib/magma/server/query.rb
@@ -7,9 +7,13 @@ class QueryController < Magma::Controller
     return failure(401, errors: ["You are unauthorized"]) unless @user && @user.can_view?(@project_name)
 
     begin
-      if @params[:query] == "::predicates"
-        return success(Magma::Predicate.to_json, "application/json")
+      case @params[:query]
+      when "::predicates"
+        return success_json(Magma::Predicate)
+      when "::model_names"
+        return success_json(Magma.instance.get_project(@project_name).models.keys)
       end
+
       question = Magma::Question.new(
         @project_name, JSON.parse(JSON.generate(@params[:query])),
         show_disconnected: @params[:show_disconnected],

--- a/magma/lib/magma/server/query.rb
+++ b/magma/lib/magma/server/query.rb
@@ -11,7 +11,7 @@ class QueryController < Magma::Controller
       when "::predicates"
         return success_json(Magma::Predicate)
       when "::model_names"
-        return success_json(Magma.instance.get_project(@project_name).models.keys)
+        return success_json(answer: Magma.instance.get_project(@project_name).models.keys, format: [ 'String' ])
       end
 
       question = Magma::Question.new(

--- a/magma/lib/magma/server/query.rb
+++ b/magma/lib/magma/server/query.rb
@@ -11,7 +11,7 @@ class QueryController < Magma::Controller
       when "::predicates"
         return success_json(Magma::Predicate)
       when "::model_names"
-        return success_json(answer: Magma.instance.get_project(@project_name).models.keys, format: [ 'String' ])
+        return success_json(answer: Magma.instance.get_project(@project_name).models.keys, type: 'Array', format: [ 'String' ])
       end
 
       question = Magma::Question.new(

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -85,7 +85,7 @@ describe QueryController do
     it 'returns a list of model names' do
       query('::model_names')
 
-      expect(json_body.map(&:to_sym)).to match_array(Magma.instance.get_project('labors').models.keys)
+      expect(json_body[:answer].map(&:to_sym)).to match_array(Magma.instance.get_project('labors').models.keys)
     end
   end
 

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -81,6 +81,12 @@ describe QueryController do
 
       expect(json_body[:predicates].keys).to include(:model, :record)
     end
+
+    it 'returns a list of model names' do
+      query('::model_names')
+
+      expect(json_body.map(&:to_sym)).to match_array(Magma.instance.get_project('labors').models.keys)
+    end
   end
 
   context 'disconnected data' do
@@ -109,6 +115,15 @@ describe QueryController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:answer].map(&:last).sort).to match_array((disconnected_labors).map(&:identifier))
+    end
+  end
+
+  context Magma::StartPredicate do
+    it 'reports attribute names' do
+      query(['monster', '::attribute_names'])
+
+      expect(last_response.status).to eq(200)
+      expect(json_body[:answer].map(&:to_sym)).to match_array(Labors::Monster.attributes.keys)
     end
   end
 

--- a/mountetna.github.io/magma.md
+++ b/mountetna.github.io/magma.md
@@ -372,12 +372,24 @@ Filters may be applied to any model we traverse through:
 
 There are a handful of predicate types, each of which take various arguments. 
 
+##### Start
+
+The first predicate initiates the query and usually takes a model name as an argument:
+
+    <model_name> - a string specifying the model to be searched
+
+You may also pass the following as initial arguments:
+
+    ::predicates - return a list of the available predicates and their verbs
+    ::model_names - return a list of model names for the project being queried
+
 ##### Model
 
 A Model predicate is our query starting point and specifies a set of records. Model predicates can accept an arbitrary number of filter [] arguments, followed by:
 
     ::first - reduce this model to a single item
     ::all - return a vector of values for this model, labeled with this model's identifiers
+    ::attribute_names - return a list of attribute names for this model (only following the start predicate)
 
 ##### Record
 


### PR DESCRIPTION
Adding model_names and attribute_names verbs to the query API, just to make this information easier to retrieve. Again the return types are a bit squirrelly, just bare json arrays.