### PR TITLE
tweak config for scheduler health check timeout

### DIFF
--- a/airflow/opt/airflow.cfg
+++ b/airflow/opt/airflow.cfg
@@ -833,7 +833,7 @@ pool_metrics_interval = 500.0
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint
-scheduler_health_check_threshold = 60
+scheduler_health_check_threshold = 120
 
 # How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs
 orphaned_tasks_check_interval = 300.0

--- a/airflow/opt/providers/etna/docs/etna/hooks/box.html
+++ b/airflow/opt/providers/etna/docs/etna/hooks/box.html
@@ -155,7 +155,7 @@
 <span class="kn">import</span> <span class="nn">os</span>
 <span class="kn">import</span> <span class="nn">re</span>
 <span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">List</span><span class="p">,</span> <span class="n">Dict</span><span class="p">,</span> <span class="n">Optional</span><span class="p">,</span> <span class="n">ContextManager</span><span class="p">,</span> <span class="n">Tuple</span><span class="p">,</span> <span class="n">BinaryIO</span>
-<span class="kn">from</span> <span class="nn">ftplib</span> <span class="kn">import</span> <span class="n">FTP_TLS</span><span class="p">,</span> <span class="n">error_reply</span>
+<span class="kn">from</span> <span class="nn">ftplib</span> <span class="kn">import</span> <span class="n">FTP_TLS</span>
 <span class="kn">from</span> <span class="nn">socket</span> <span class="kn">import</span> <span class="n">socket</span>
 
 <span class="kn">import</span> <span class="nn">cached_property</span>

--- a/airflow/opt/providers/etna/etna/etls/box.py
+++ b/airflow/opt/providers/etna/etna/etls/box.py
@@ -101,6 +101,7 @@ class BoxEtlHelpers:
 
                             self.log.info(f"Uploading {file.full_path} to {dest_path}.")
 
+                            should_log = True
                             for blob in metis.upload_file(
                                 project_name,
                                 bucket_name,
@@ -109,8 +110,11 @@ class BoxEtlHelpers:
                                 file.size
                             ):
                                 # Only log every 5 seconds, to save log space...
-                                if int(time.time()) % 5 == 0:
+                                if int(time.time()) % 5 == 0 and should_log:
                                     self.log.info("Uploading blob...")
+                                    should_log = False
+                                elif int(time.time()) % 5 != 0:
+                                    should_log = True
 
                             if clean_up:
                                 box.remove_file(ftps, file)

--- a/airflow/opt/providers/etna/etna/etls/box.py
+++ b/airflow/opt/providers/etna/etna/etls/box.py
@@ -110,10 +110,11 @@ class BoxEtlHelpers:
                                 file.size
                             ):
                                 # Only log every 5 seconds, to save log space...
-                                if int(time.time()) % 5 == 0 and should_log:
+                                time_check = int(time.time())
+                                if time_check % 5 == 0 and should_log:
                                     self.log.info("Uploading blob...")
                                     should_log = False
-                                elif int(time.time()) % 5 != 0:
+                                elif time_check % 5 != 0 and not should_log:
                                     should_log = True
 
                             if clean_up:


### PR DESCRIPTION
Trying to run the Box ingest ETLs, and I was running into [this problem](https://github.com/apache/airflow/issues/19277), I think, where the Job would get killed with a Sigterm, like the reported issue (text is from the GH issue, I can't figure out how to get old logs from our Airflow instance?):

```
worker>     [2021-10-28 02:51:29,343] {local_task_job.py:208} WARNING - State of this instance has been externally set to None. Terminating instance.
worker>     [2021-10-28 02:51:29,347] {process_utils.py:100} INFO - Sending Signals.SIGTERM to GPID 25492
worker>     [2021-10-28 02:51:29,347] {taskinstance.py:1236} ERROR - Received SIGTERM. Terminating subprocesses.
```

This happened multiple times today, and each time Airflow restarts the ingest DAG task, which at this point basically re-ingests the same files before it gets killed again :cry: 

Following the threads, seems like it might be an issue with the task job not being able to reach out to the scheduler via a health check within the specified timeout, so the scheduler kills the job. I think this happens during large file uploads (5GB), so seems possible? The threads indicate this should be fixed in 2.2.2, but we're running 2.2.4 already ... so I've already pushed a production image with an increased health check timeout to see if it helps our case. Will only merge this PR if the issue seems to be fixed.
