### PR TITLE
Airflow box etl fix date range

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/box.py
+++ b/airflow/opt/providers/etna/etna/etls/box.py
@@ -77,7 +77,7 @@ class BoxEtlHelpers:
             etna_hook = EtnaHook.for_project(project_name)
             with etna_hook.metis(project_name, read_only=False) as metis, self.hook.box() as box:
                 self.log.info(f"Attempting to upload {len(files)} files to Metis")
-                for file in files[0:2]:
+                for file in files:
                     with box.ftps() as ftps:
                         sock = box.retrieve_file(ftps, file)
 

--- a/airflow/opt/providers/etna/etna/etls/box.py
+++ b/airflow/opt/providers/etna/etna/etls/box.py
@@ -77,7 +77,7 @@ class BoxEtlHelpers:
             etna_hook = EtnaHook.for_project(project_name)
             with etna_hook.metis(project_name, read_only=False) as metis, self.hook.box() as box:
                 self.log.info(f"Attempting to upload {len(files)} files to Metis")
-                for file in files:
+                for file in files[0:2]:
                     with box.ftps() as ftps:
                         sock = box.retrieve_file(ftps, file)
 
@@ -140,6 +140,6 @@ def _load_box_files_batch(
         f"Searching for Box data from {start.isoformat(timespec='seconds')} to {end.isoformat(timespec='seconds')}"
     )
 
-    files = box.tail(folder_name, start, end)
+    files = box.tail(folder_name, batch_start=start, batch_end=end)
 
     return files

--- a/airflow/opt/providers/etna/etna/hooks/box.py
+++ b/airflow/opt/providers/etna/etna/hooks/box.py
@@ -6,7 +6,6 @@ import os
 import re
 from typing import List, Dict, Optional, ContextManager, Tuple, BinaryIO
 from ftplib import FTP_TLS
-from socket import socket
 
 import cached_property
 from airflow.hooks.base import BaseHook
@@ -117,6 +116,10 @@ class FtpEntry(object):
         return self.full_path[1::] if self.full_path[0] == '/' else self.full_path
 
     def is_in_range(self, batch_start: Optional[datetime] = None, batch_end: Optional[datetime] = None):
+        log = logging.getLogger("airflow.task")
+        log.info(
+            f"in is_in_range, {batch_start}, {batch_end}, {self.mtime}"
+        )
         if batch_start is None and batch_end is None:
             return True
         elif batch_start is None:
@@ -159,6 +162,11 @@ class Box(object):
 
     def _ls_r(self, ftps: FTP_TLS, path: str = "/", batch_start: Optional[datetime] = None, batch_end: Optional[datetime] = None) -> List[FtpEntry]:
         files = []
+        log = logging.getLogger("airflow.task")
+        log.info(
+            f"in ls_r, {batch_start}, {batch_end}"
+        )
+
         for entry in ftps.mlsd(path):
             ftp_entry = FtpEntry(entry, path)
 

--- a/airflow/opt/providers/etna/etna/hooks/box.py
+++ b/airflow/opt/providers/etna/etna/hooks/box.py
@@ -116,10 +116,6 @@ class FtpEntry(object):
         return self.full_path[1::] if self.full_path[0] == '/' else self.full_path
 
     def is_in_range(self, batch_start: Optional[datetime] = None, batch_end: Optional[datetime] = None):
-        log = logging.getLogger("airflow.task")
-        log.info(
-            f"in is_in_range, {batch_start}, {batch_end}, {self.mtime}"
-        )
         if batch_start is None and batch_end is None:
             return True
         elif batch_start is None:
@@ -162,10 +158,6 @@ class Box(object):
 
     def _ls_r(self, ftps: FTP_TLS, path: str = "/", batch_start: Optional[datetime] = None, batch_end: Optional[datetime] = None) -> List[FtpEntry]:
         files = []
-        log = logging.getLogger("airflow.task")
-        log.info(
-            f"in ls_r, {batch_start}, {batch_end}"
-        )
 
         for entry in ftps.mlsd(path):
             ftp_entry = FtpEntry(entry, path)
@@ -174,7 +166,7 @@ class Box(object):
                 continue
 
             if ftp_entry.is_dir():
-                files += self._ls_r(ftps, os.path.join(path, ftp_entry.name))
+                files += self._ls_r(ftps, os.path.join(path, ftp_entry.name), batch_start, batch_end)
             elif ftp_entry.is_in_range(batch_start, batch_end):
                 files.append(ftp_entry)
         return files
@@ -182,7 +174,7 @@ class Box(object):
     @contextlib.contextmanager
     def ftps(self) -> FTP_TLS:
         """
-        Configures an FTP_TLS connection to Box. Using Pythong `with` syntax, so that the
+        Configures an FTP_TLS connection to Box. Using Python `with` syntax, so that the
         connection is closed after usage.
 
         eg:

--- a/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
+++ b/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
@@ -187,7 +187,8 @@ def set_up_mocks():
             ('.', {'modify': '20220101000000.000', 'type': 'dir'}),
             ('folder', {'modify': '20220101000000.000', 'type': 'dir'}),
             ('something.txt', {'modify': '20220201000000.000', 'type': 'file'}),
-            ('other_thing.txt', {'modify': '20220301000000.000', 'type': 'file'})
+            ('other_thing.txt', {'modify': '20220301000000.000', 'type': 'file'}),
+            ('other_things.txt', {'modify': '20220501000000.000', 'type': 'file'})
         ], [
             ('.', {'modify': '20220101000000.000', 'type': 'dir'}),
             ('something_else.txt', {'modify': '20220302000000.000', 'type': 'file'}),

--- a/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
+++ b/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
@@ -190,7 +190,8 @@ def set_up_mocks():
             ('other_thing.txt', {'modify': '20220301000000.000', 'type': 'file'})
         ], [
             ('.', {'modify': '20220101000000.000', 'type': 'dir'}),
-            ('something_else.txt', {'modify': '20220302000000.000', 'type': 'file'})
+            ('something_else.txt', {'modify': '20220302000000.000', 'type': 'file'}),
+            ('yet_another_thing.txt', {'modify': '20220602000000.000', 'type': 'file'}),
         ]
     ]
     mock_ftps.return_value.mlsd = mock_mlsd

--- a/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
+++ b/airflow/opt/providers/etna/etna/tests/test_box_helpers.py
@@ -192,6 +192,7 @@ def set_up_mocks():
             ('.', {'modify': '20220101000000.000', 'type': 'dir'}),
             ('something_else.txt', {'modify': '20220302000000.000', 'type': 'file'}),
             ('yet_another_thing.txt', {'modify': '20220602000000.000', 'type': 'file'}),
+            ('another_thing.txt', {'modify': '20220102000000.000', 'type': 'file'}),
         ]
     ]
     mock_ftps.return_value.mlsd = mock_mlsd


### PR DESCRIPTION
I realized that the Box ETL was re-processing all the files regardless of the date range ... because I wasn't passing the `batch_start` and `batch_end` parameters in when listing sub-directory contents :facepalm: 

This PR fixes that behavior and adds some specs around it.