### PR TITLE
copy figure removes tags and updates search params; [close #790]

### DIFF
--- a/vulcan/lib/client/jsx/components/dashboard.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard.tsx
@@ -81,6 +81,8 @@ export default function Dashboard({project_name}: {project_name: string}) {
               setSearchString={setSearchString}
               setTags={setTags}
               project_name={project_name}
+              tags={tags}
+              searchString={searchString}
             />
           </Grid>
         </Grid>
@@ -89,6 +91,8 @@ export default function Dashboard({project_name}: {project_name: string}) {
           workflowName={selectedWorkflow?.name}
           tags={tags}
           searchString={searchString}
+          setSearchString={setSearchString}
+          setTags={setTags}
         />
       </Grid>
     </main>

--- a/vulcan/lib/client/jsx/components/dashboard/figures_controls.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/figures_controls.tsx
@@ -27,8 +27,7 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     flex: '1 1 auto'
   },
-  tagauto: {
-  },
+  tagauto: {},
   tags: {
     padding: '12.5px !important'
   }
@@ -37,16 +36,17 @@ const useStyles = makeStyles((theme) => ({
 export default function FiguresControls({
   project_name,
   setSearchString,
-  setTags
+  setTags,
+  tags,
+  searchString
 }: {
   project_name: string;
   setSearchString: Function;
   setTags: Function;
+  tags?: string[];
+  searchString?: string;
 }) {
-  const {
-    showErrors,
-    fetchFigures,
-  } = useContext(VulcanContext);
+  const {showErrors, fetchFigures} = useContext(VulcanContext);
 
   const [allFigureSessions, setAllFigureSessions] = useState<
     VulcanFigureSession[]
@@ -89,6 +89,7 @@ export default function FiguresControls({
               </InputAdornment>
             )
           }}
+          value={searchString}
           onChange={(e) => setSearchString(e.target.value)}
         />
       </Grid>
@@ -100,16 +101,21 @@ export default function FiguresControls({
           classes={{
             input: classes.tags
           }}
-          defaultValue={['public']}
+          value={tags}
           options={allTags.sort()}
           renderInput={(params: any) => (
-            <TextField {...params} size='small' label='Tags' variant='outlined' />
+            <TextField
+              {...params}
+              size='small'
+              label='Tags'
+              variant='outlined'
+            />
           )}
           renderOption={(option, state) => <span>{option}</span>}
-          renderTags={
-            (tags, getTagProps) => tags.map(
-              (tag, index) => <Tag {...getTagProps({ index })} label={tag} />
-            )
+          renderTags={(tags, getTagProps) =>
+            tags.map((tag, index) => (
+              <Tag {...getTagProps({index})} label={tag} />
+            ))
           }
           filterOptions={(options, state) => {
             let regex = new RegExp(state.inputValue);

--- a/vulcan/lib/client/jsx/components/dashboard/figures_grid.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/figures_grid.tsx
@@ -30,12 +30,16 @@ export default function FiguresGrid({
   project_name,
   workflowName,
   tags,
-  searchString
+  searchString,
+  setSearchString,
+  setTags
 }: {
   project_name: string;
   workflowName?: string;
   tags?: string[];
   searchString?: string;
+  setSearchString: Function;
+  setTags: Function;
 }) {
   const {
     showErrors,
@@ -69,15 +73,25 @@ export default function FiguresGrid({
       const copy = {
         ...figure,
         figure_id: null,
-        title: `${figure.title} - copy`
+        title: `${figure.title} - copy`,
+        tags: []
       };
       showErrors(
         createFigure(project_name, copy).then((newFigure) => {
           setAllFigureSessions([...allFigureSessions].concat([newFigure]));
+          setTags([]);
+          setSearchString(figure.title);
         })
       );
     },
-    [showErrors, createFigure, project_name, allFigureSessions]
+    [
+      showErrors,
+      createFigure,
+      project_name,
+      allFigureSessions,
+      setTags,
+      setSearchString
+    ]
   );
 
   const handleOnRename = useCallback(


### PR DESCRIPTION
This PR addresses #790 and removes tags from Vulcan figure copies. Also sets the search params so you only see the original + copy(-ies).