### PR TITLE
Metis checksum process should not get behind, keep processing

### DIFF
--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -111,9 +111,13 @@ class Metis
     usage "Checksum files."
 
     def execute
-      needs_hash = Metis::DataBlock.where(md5_hash: Metis::DataBlock::TEMP_MATCH, removed: false).order(:updated_at).all[0..10]
-      puts "Found #{needs_hash.count} data blocks to be checksummed."
-      needs_hash.each(&:compute_hash!)
+      while True
+        needs_hash = Metis::DataBlock.where(md5_hash: Metis::DataBlock::TEMP_MATCH, removed: false).order(:updated_at).all[0..10]
+        count = needs_hash.count
+        puts "Found #{count} data blocks to be checksummed."
+        needs_hash.each(&:compute_hash!)
+        break if count == 0
+      end
     end
 
     def setup(config)

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -111,7 +111,7 @@ class Metis
     usage "Checksum files."
 
     def execute
-      while True
+      while true
         needs_hash = Metis::DataBlock.where(md5_hash: Metis::DataBlock::TEMP_MATCH, removed: false).order(:updated_at).all[0..10]
         count = needs_hash.count
         puts "Found #{count} data blocks to be checksummed."


### PR DESCRIPTION
Metis checksum command only processes up to 10 before quitting.  If this value is too low, the delay of running this process results in it getting behind due to fix processing speed (10 per minute).

With more projects uploading, it becomes more likely to get behind with a fixed processing speed, so the change simply keeps processing in a loop until there are no unprocessed checksums.  