### PR TITLE
account for value being empty string; [close #860]

### DIFF
--- a/polyphemus/lib/client/jsx/etl/redcap-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/redcap-form.tsx
@@ -240,7 +240,7 @@ const ValueRow = ({
       <TextField
         placeholder='Comma-separated list'
         fullWidth
-        value={localValue.join(', ')}
+        value={Array.isArray(localValue) ? localValue.join(', ') : localValue}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           debouncedUpdate(e.target.value.split(/,\s*/))
         }


### PR DESCRIPTION
This PR fixes a small bug in switching between model config tabs, when the `identifier fields` text box is empty string (default?), switching tabs crashes the app because `localValue` is `""`, which you cannot call `.join` on. So we only call `join` if it is an Array, otherwise just take the given string value.