### PR TITLE
Janus guest permission setter function

### DIFF
--- a/janus/lib/models/user.rb
+++ b/janus/lib/models/user.rb
@@ -116,12 +116,8 @@ class User < Sequel::Model
     end
   end
   
-  def fix_guest_permissions!
-    # Get all coc agreements for user
-    # For each project
-    # Pick most recent
-    # if agreed, ensure have a permission, add guest if not
-    # if not agreed, remove permission if role==guest
+  def set_guest_permissions!
+    # Per project, if agreed, add guest access when no access already; remove guest access if !agreed
     CcAgreement.where(user_email: email).all.group_by(&:project_name).each do |project_name, cc_agreements|
       most_recent = cc_agreements.sort_by(&:updated_at).last
       project = Project[project_name: project_name]

--- a/janus/spec/spec_helper.rb
+++ b/janus/spec/spec_helper.rb
@@ -188,6 +188,9 @@ FactoryBot.define do
   factory :project do
     to_create(&:save)
   end
+  factory :cc_agreement do
+    to_create(&:save)
+  end
 end
 
 

--- a/janus/spec/user_spec.rb
+++ b/janus/spec/user_spec.rb
@@ -75,6 +75,80 @@ describe User do
 
     expect(payload['flags']).to eq(user.flags.join(';'))
   end
+  
+  it 'adds guest permission if user has agreed to coc, not on project already' do
+    user = create(
+      :user, name: 'Portunus', email: 'portunus@two-faces.org'
+    )
+
+    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
+    
+    cc = create(
+      :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
+      agreed: true, project_name: 'gateway'
+    )
+    
+    user.fix_guest_permissions!
+    expect(Permission.count).to eq(1)
+    
+    perm = Permission.first
+    expect(perm.project_name).to eq('gateway')
+    expect(perm.user).to eq(user)
+    expect(perm.role).to eq('guest')
+  end
+  
+  it 'does nothing if user has agreed to coc but already has viewer+ permission' do
+    user = create(
+      :user, name: 'Portunus', email: 'portunus@two-faces.org'
+    )
+
+    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
+    
+    permission = create(
+      :permission, project: gateway, user: user, role: 'viewer'
+    )
+    
+    cc = create(
+      :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
+      agreed: true, project_name: 'gateway'
+    )
+    
+    user.fix_guest_permissions!
+    expect(Permission.count).to eq(1)
+    
+    perm = Permission.first
+    expect(perm.project_name).to eq('gateway')
+    expect(perm.user).to eq(user)
+    expect(perm.role).to eq('viewer')
+  end
+  
+  it 'removes guest permission if user most recently did not agree to coc' do
+    user = create(
+      :user, name: 'Portunus', email: 'portunus@two-faces.org'
+    )
+
+    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
+    
+    permission = create(
+      :permission, project: gateway, user: user, role: 'guest'
+    )
+    
+    now = Time.now
+    
+    cc1 = create(
+      :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
+      agreed: true, project_name: 'gateway', updated_at: now-10
+    )
+    
+    cc2 = create(
+      :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
+      agreed: false, project_name: 'gateway', updated_at: now
+    )
+    
+    user.fix_guest_permissions!
+    
+    expect(Permission.count).to eq(0)
+  end
 end
 
 describe UserController do

--- a/janus/spec/user_spec.rb
+++ b/janus/spec/user_spec.rb
@@ -75,47 +75,48 @@ describe User do
 
     expect(payload['flags']).to eq(user.flags.join(';'))
   end
-  
+
   it 'adds guest permission if user has agreed to coc, not on project already' do
     user = create(
       :user, name: 'Portunus', email: 'portunus@two-faces.org'
     )
-
-    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
-    
+    gateway = create(
+      :project, project_name: 'gateway', project_name_full: 'Gateway',
+      resource: true, requires_agreement: true
+    )
     cc = create(
       :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
       agreed: true, project_name: 'gateway'
     )
-    
-    user.fix_guest_permissions!
+
+    user.set_guest_permissions!
     expect(Permission.count).to eq(1)
-    
+
     perm = Permission.first
     expect(perm.project_name).to eq('gateway')
     expect(perm.user).to eq(user)
     expect(perm.role).to eq('guest')
   end
-  
+
   it 'does nothing if user has agreed to coc but already has viewer+ permission' do
     user = create(
       :user, name: 'Portunus', email: 'portunus@two-faces.org'
     )
-
-    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
-    
+    gateway = create(
+      :project, project_name: 'gateway', project_name_full: 'Gateway',
+      resource: true, requires_agreement: true
+    )
     permission = create(
       :permission, project: gateway, user: user, role: 'viewer'
     )
-    
     cc = create(
       :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
       agreed: true, project_name: 'gateway'
     )
-    
-    user.fix_guest_permissions!
+
+    user.set_guest_permissions!
     expect(Permission.count).to eq(1)
-    
+
     perm = Permission.first
     expect(perm.project_name).to eq('gateway')
     expect(perm.user).to eq(user)
@@ -126,27 +127,25 @@ describe User do
     user = create(
       :user, name: 'Portunus', email: 'portunus@two-faces.org'
     )
-
-    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway', resource: true, requires_agreement: true)
-    
+    gateway = create(
+      :project, project_name: 'gateway', project_name_full: 'Gateway',
+      resource: true, requires_agreement: true
+    )
     permission = create(
       :permission, project: gateway, user: user, role: 'guest'
     )
     
     now = Time.now
-    
     cc1 = create(
       :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
       agreed: true, project_name: 'gateway', updated_at: now-10
     )
-    
     cc2 = create(
       :cc_agreement, user_email: 'portunus@two-faces.org', cc_text: 'blah blah blah',
       agreed: false, project_name: 'gateway', updated_at: now
     )
     
-    user.fix_guest_permissions!
-    
+    user.set_guest_permissions!
     expect(Permission.count).to eq(0)
   end
 end


### PR DESCRIPTION
Creates a function which adds/removes guest permissions for a user based on their most recent CoC agreements entries per project.

(Bases off #866 so can either merge in there or rebase to master after that goes in)