### PR TITLE
use etna::redirect

### DIFF
--- a/etna/lib/etna.rb
+++ b/etna/lib/etna.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative './etna/redirect'
 require_relative './etna/environment_variables'
 require_relative './etna/injection'
 require_relative './etna/ext'

--- a/etna/lib/etna/auth.rb
+++ b/etna/lib/etna/auth.rb
@@ -65,7 +65,7 @@ module Etna
         application.config(:auth_redirect).chomp('/') + '/login'
       )
       uri.query = URI.encode_www_form(refer: request.url)
-      return [ 302, { 'Location' => uri.to_s }, [] ]
+      Etna::Redirect(request).to(uri.to_s)
     end
 
     def approve_noauth(request)

--- a/etna/lib/etna/redirect.rb
+++ b/etna/lib/etna/redirect.rb
@@ -1,0 +1,36 @@
+module Etna
+  def self.Redirect(req)
+    Redirect.new(req)
+  end
+
+  class Redirect
+    def initialize(request)
+      @request = request
+    end
+
+    def to(path, &block)
+      return Rack::Response.new(
+        [ { errors: [ 'Cannot redirect out of domain' ] }.to_json ], 422,
+        { 'Content-Type' => 'application/json' }
+      ).finish unless matches_domain?(path)
+
+      response = Rack::Response.new
+
+      response.redirect(path.gsub("http://", "https://"), 302)
+
+      yield response if block_given?
+
+      response.finish
+    end
+
+    private
+
+    def matches_domain?(path)
+      top_domain(@request.server_name) == top_domain(URI(path).host)
+    end
+
+    def top_domain(host_name)
+      host_name.split('.')[-2..-1].join('.')
+    end
+  end
+end

--- a/etna/lib/etna/redirect.rb
+++ b/etna/lib/etna/redirect.rb
@@ -26,7 +26,7 @@ module Etna
     private
 
     def matches_domain?(path)
-      top_domain(@request.server_name) == top_domain(URI(path).host)
+      top_domain(@request.hostname) == top_domain(URI(path).host)
     end
 
     def top_domain(host_name)

--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -184,7 +184,7 @@ module Etna
         application.config(:auth_redirect).chomp('/') + "/#{params[:project_name]}/cc"
       )
       uri.query = URI.encode_www_form(refer: request.url)
-      return [ 302, { 'Location' => uri.to_s }, [] ]
+      Etna::Redirect(request).to(uri.to_s)
     end
 
     def application

--- a/etna/spec/auth_spec.rb
+++ b/etna/spec/auth_spec.rb
@@ -132,15 +132,15 @@ describe Etna::Auth do
           test: {
             rsa_private: @private_key,
             rsa_public: @public_key,
-            janus: { host: 'https://janus.test/' },
+            janus: { host: 'https://janus.example.org/' },
             token_name: 'ARACHNE_TOKEN',
             token_algo: 'RS256',
-            auth_redirect: 'https://janus.test'
+            auth_redirect: 'https://janus.example.org'
           }
         )
         clear_cookies
 
-        stub_request(:any, /janus.test/).
+        stub_request(:any, /janus.example.org/).
           to_return(body: {
             projects: [{
               project_name: "test_project",
@@ -163,7 +163,7 @@ describe Etna::Auth do
         get('/test_project')
         expect(last_response.status).to eq(302)
         expect(last_response.headers['Location']).to eq(
-          "https://janus.test/test_project/cc?refer=http%3A%2F%2Fexample.org%2Ftest_project"
+          "https://janus.example.org/test_project/cc?refer=http%3A%2F%2Fexample.org%2Ftest_project"
         )
       end
   
@@ -253,7 +253,7 @@ describe Etna::Auth do
             rsa_private: @private_key,
             rsa_public: @invalid_public_key,
             token_algo: 'RS256',
-            auth_redirect: "https://janus.test"
+            auth_redirect: "https://janus.example.org"
 
           }
         )
@@ -270,7 +270,7 @@ describe Etna::Auth do
         # the auth endpoint.
         expect(last_response.status).to eq(302)
         expect(last_response.headers['Location']).to eq(
-          "https://janus.test/login?refer=http%3A%2F%2Fexample.org%2Ftest"
+          "https://janus.example.org/login?refer=http%3A%2F%2Fexample.org%2Ftest"
         )
       end
     end
@@ -289,7 +289,7 @@ describe Etna::Auth do
           test: {
             rsa_private: @private_key,
             rsa_public: @public_key,
-            janus: { host: 'https://janus.test/' },
+            janus: { host: 'https://janus.example.org/' },
             token_name: 'ARACHNE_TOKEN',
             token_algo: 'RS256'
           }
@@ -298,7 +298,7 @@ describe Etna::Auth do
       end
 
       it "calls Janus for a task token" do
-        stub_request(:any, /janus.test/)
+        stub_request(:any, /janus.example.org/)
 
         token = Arachne.instance.sign.jwt_token(
           email: 'janus@two-faces.org',
@@ -314,11 +314,11 @@ describe Etna::Auth do
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('Etna::User')
         expect(authenticated_user.token).to eq(token)
-        expect(WebMock).to have_requested(:post, %r!janus.test/api/!)
+        expect(WebMock).to have_requested(:post, %r!janus.example.org/api/!)
       end
 
       it "rejects the request if janus rejects the task token" do
-        stub_request(:any, /janus.test/).
+        stub_request(:any, /janus.example.org/).
           to_return(status: 401)
 
         token = Arachne.instance.sign.jwt_token(
@@ -333,11 +333,11 @@ describe Etna::Auth do
         auth_header(token)
         get('/test')
         expect(last_response.status).to eq(401)
-        expect(WebMock).to have_requested(:post, %r!janus.test/api/!)
+        expect(WebMock).to have_requested(:post, %r!janus.example.org/api/!)
       end
 
       it "allows the request if janus is ignored" do
-        stub_request(:any, /janus.test/).to_return(status: 401)
+        stub_request(:any, /janus.example.org/).to_return(status: 401)
 
         token = Arachne.instance.sign.jwt_token(
           email: 'janus@two-faces.org',
@@ -353,7 +353,7 @@ describe Etna::Auth do
         auth_header(token)
         get('/test2')
         expect(last_response.status).to eq(200)
-        expect(WebMock).not_to have_requested(:post, %r!janus.test/api/!)
+        expect(WebMock).not_to have_requested(:post, %r!janus.example.org/api/!)
       end
     end
 
@@ -371,14 +371,14 @@ describe Etna::Auth do
           test: {
             rsa_private: @private_key,
             rsa_public: @public_key,
-            janus: { host: 'https://janus.test/' },
+            janus: { host: 'https://janus.example.org/' },
             token_name: 'ARACHNE_TOKEN',
             token_algo: 'RS256'
           }
         )
         clear_cookies
 
-        stub_request(:any, /janus.test\/api\/user\/projects/).to_return(body: {
+        stub_request(:any, /janus.example.org\/api\/user\/projects/).to_return(body: {
           projects: [{
             project_name: 'secret',
             resource: false
@@ -394,7 +394,7 @@ describe Etna::Auth do
 
       context 'with task token' do
         before(:each) do
-          stub_request(:any, /janus.test\/api\/tokens/).to_return(status: 200)
+          stub_request(:any, /janus.example.org\/api\/tokens/).to_return(status: 200)
         end
 
         it "allows the request if user has permissions to project" do
@@ -410,7 +410,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/labors')
           expect(last_response.status).to eq(200)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!)
         end
   
         it "denies the request if user does not have permission to non-resource project" do
@@ -426,7 +426,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/secret')
           expect(last_response.status).to eq(403)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!).times(2)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!).times(2)
         end
   
         it "allows the request if user does not have permission to resource project" do
@@ -442,7 +442,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/public')
           expect(last_response.status).to eq(200)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!)
         end
       end
       
@@ -459,7 +459,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/labors')
           expect(last_response.status).to eq(200)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!)
         end
   
         it "denies the request if user does not have permission to non-resource project" do
@@ -474,7 +474,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/secret')
           expect(last_response.status).to eq(403)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!).times(2)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!).times(2)
         end
   
         it "allows the request if user does not have permission to resource project" do
@@ -489,7 +489,7 @@ describe Etna::Auth do
           auth_header(token)
           get('/public')
           expect(last_response.status).to eq(200)
-          expect(WebMock).to have_requested(:get, %r!janus.test/api/user/projects!)
+          expect(WebMock).to have_requested(:get, %r!janus.example.org/api/user/projects!)
         end
       end
     end

--- a/etna/spec/redirect_spec.rb
+++ b/etna/spec/redirect_spec.rb
@@ -1,0 +1,54 @@
+describe Etna::Redirect do
+  include Rack::Test::Methods
+  attr_reader :app
+
+  before(:each) do
+    class Arachne
+      include Etna::Application
+      class Server < Etna::Server; end
+    end
+  end
+
+  after(:each) do
+    Object.send(:remove_const, :Arachne)
+  end
+
+  def auth_header
+    header(*Etna::TestAuth.token_header(
+      email: 'janus@two-faces.org',
+      perm: 'e:labors'
+    ))
+  end
+
+  it "redirects to a safe url" do
+    Arachne::Server.get('/test') { Etna::Redirect(@request).to('http://somewhere.example.org') }
+
+    @app = setup_app(
+      Arachne::Server,
+      [ Etna::TestAuth ]
+    )
+
+    auth_header
+    get('/test')
+
+    expect(last_response.status).to eq(302)
+    expect(last_response.headers['Location']).to eq(
+      "https://somewhere.example.org"
+    )
+  end
+
+  it "won't redirect outside of the app domain" do
+    Arachne::Server.get('/test') { Etna::Redirect(@request).to('https://somewhere.bad.org') }
+
+    @app = setup_app(
+      Arachne::Server,
+      [ Etna::TestAuth ]
+    )
+
+    auth_header
+    get('/test')
+
+    expect(last_response.status).to eq(422)
+    expect(json_body[:errors]).to eq([ "Cannot redirect out of domain"])
+  end
+end

--- a/etna/spec/spec_helper.rb
+++ b/etna/spec/spec_helper.rb
@@ -315,6 +315,10 @@ def stub_polyphemus_setup
     })
 end
 
+def json_body
+  JSON.parse(last_response.body, symbolize_names: true)
+end
+
 def configure_etna_yml
   EtnaApp.instance.configure({
       development: {

--- a/janus/lib/server/controllers/authorization_controller.rb
+++ b/janus/lib/server/controllers/authorization_controller.rb
@@ -15,8 +15,7 @@ class AuthorizationController < Janus::Controller
       raise unless user
 
       # they have a valid token
-      @response.redirect(@params[:refer], 302)
-      @response.finish
+      Etna::Redirect(@request).to(@params[:refer])
     rescue
       if Janus.instance.config(:auth_method) == 'shibboleth'
         return login_shib
@@ -153,11 +152,9 @@ class AuthorizationController < Janus::Controller
   end
 
   def respond_with_cookie(token, refer)
-    # Set redirect.
-    @response.redirect(refer.gsub("http://", "https://"), 302)
-
-    Janus.instance.set_token_cookie(@response,token)
-    return @response.finish
+    Etna::Redirect(@request).to(refer) do |response|
+      Janus.instance.set_token_cookie(response,token)
+    end
   end
 
   private

--- a/timur/lib/server/controllers/timur_controller.rb
+++ b/timur/lib/server/controllers/timur_controller.rb
@@ -4,11 +4,6 @@ class Timur
 
     private
 
-    def redirect_to(path)
-      @response.redirect(path,302)
-      @response.finish
-    end
-
     def success_json(hash)
       success(hash.to_json, 'application/json')
     end

--- a/vulcan/lib/server/controllers/vulcan_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_controller.rb
@@ -17,11 +17,6 @@ class Vulcan
       @storage ||= Vulcan::Storage.new
     end
 
-    def redirect_to(path)
-      @response.redirect(path,302)
-      @response.finish
-    end
-
     def token
       @token ||= @request.cookies[Vulcan.instance.config(:token_name)]
     end


### PR DESCRIPTION
This adds + uses Etna::Redirect, which has some safety-checking to make sure that the route being redirected to is (1) https and (2) comes from this subdomain. This should trap any attempts to inject bad redirects via refer=, etc.

In the event that the redirect is bad, this returns a 422, which was my best guess for response code.