### PR TITLE
fix path to population etl script

### DIFF
--- a/polyphemus/lib/etls/ipi/ipi_load_magma_population_tables_etl.rb
+++ b/polyphemus/lib/etls/ipi/ipi_load_magma_population_tables_etl.rb
@@ -15,7 +15,7 @@ class Polyphemus::IpiLoadMagmaPopulationTablesEtl < Polyphemus::MagmaRecordFileE
     record_names = records.map { |r| r.keys.first }
     logger.info("Processing population tables for patients #{record_names.join(", ")}...")
 
-    ipi_flowjo_script = File.join(File.dirname(__FILE__), "magma", "scripts", "ipi+patient+flowjo.rb")
+    ipi_flowjo_script = File.join(File.dirname(__FILE__), "..", "magma", "scripts", "ipi+patient+flowjo.rb")
 
     runner = Polyphemus::MagmaEtlScriptRunner.new(ipi_flowjo_script)
 


### PR DESCRIPTION
This PR fixes an issue with the IPI Population loader ETL, where the path to the ETL script file recently changed, so the ETL was throwing this exception:

```
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:31+00:00 Finding batch...
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:36+00:00 Attempting to process
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:36+00:00 Processing population tables for patients IPIMEL341...
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - ERROR:2022-06-13T12:52:36+00:00 No such file or directory @ rb_sysopen - /app/lib/etls/ipi/magma/scripts/ipi+patient+flowjo.rb
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - ["/app/lib/etls/etl_script_runner.rb:33:in `initialize'", "/app/lib/etls/etl_script_runner.rb:33:in `open'", "/app/lib/etls/etl_script_runner.rb:33:in `run_script'", "/app/lib/etls/magma/magma_etl_script_runner.rb:28:in `run'", "/app/lib/etls/ipi/ipi_load_magma_population_tables_etl.rb:31:in `block in process'", "/app/lib/etls/ipi/ipi_load_magma_population_tables_etl.rb:24:in `each'", "/app/lib/etls/ipi/ipi_load_magma_population_tables_etl.rb:24:in `process'", "/app/lib/etl.rb:199:in `block in run_once'", "/app/lib/etl.rb:209:in `block in run_once'", "/app/lib/etl_cursor.rb:148:in `block in with_next'", "/app/lib/etl_cursor.rb:147:in `each'", "/app/lib/etl_cursor.rb:147:in `with_next'", "/app/lib/etl.rb:202:in `run_once'", "/app/lib/etl.rb:34:in `execute'", "/etna/lib/etna/application.rb:190:in `run_command'", "/app/bin/polyphemus:13:in `<main>'"]
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:36+00:00 Done
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:36+00:00 Continuing to process...
[2022-06-13, 05:52:37 PDT] {docker_operator_base.py:317} INFO - INFO:2022-06-13T12:52:36+00:00 Starting loop
```

I'm pushing the change to production to test it, so would merge this after it runs okay in Airflow. I think this is the only record affected, given the lack of recent flow gating updates :crossed_fingers: 