### PR TITLE
Vulcan bug fix - stepui drawer unwanted closing

### DIFF
--- a/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
@@ -46,7 +46,6 @@ export default function StepUserInputWrapper({
 }: {
   group: WorkflowStepGroup;
 }) {
-  const [open, setOpen] = useState(true);
   const {state} = useContext(VulcanContext);
 
   const {status} = state;
@@ -60,20 +59,11 @@ export default function StepUserInputWrapper({
     () => allInnerStatus.every((s) => s && s.status === STATUS.COMPLETE),
     [allInnerStatus]
   );
+  const [open, setOpen] = useState(allStepsComplete);
 
   const hasValidationErrors = group.steps.some((step) =>
     state.validationErrors.some(([stepName]) => stepName === step.name)
   );
-  const shouldOpen = hasValidationErrors;
-  const shouldClose = allStepsComplete && !hasValidationErrors;
-
-  useEffect(() => {
-    if (shouldClose) {
-      setOpen(false);
-    } else if (shouldOpen) {
-      setOpen(true);
-    }
-  }, [shouldOpen, shouldClose]);
 
   const classes = useStyles();
 

--- a/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/steps/step_user_input_wrapper.tsx
@@ -50,7 +50,6 @@ export default function StepUserInputWrapper({
 
   const {status} = state;
 
-  const toggleInputs = useCallback(() => setOpen(!open), [setOpen, open]);
   const allInnerStatus = useMemo(
     () => group.steps.map((step) => statusOfStep(step, status)),
     [group, status]
@@ -59,7 +58,8 @@ export default function StepUserInputWrapper({
     () => allInnerStatus.every((s) => s && s.status === STATUS.COMPLETE),
     [allInnerStatus]
   );
-  const [open, setOpen] = useState(allStepsComplete);
+  const [open, setOpen] = useState(!allStepsComplete);
+  const toggleInputs = useCallback(() => setOpen(!open), [setOpen, open]);
 
   const hasValidationErrors = group.steps.some((step) =>
     state.validationErrors.some(([stepName]) => stepName === step.name)


### PR DESCRIPTION
Simplifies the control of when 'StepUserInputWrapper' are open/closed so that we won't close the drawer unnecessarily.

The fix: Instead of constantly trying to determine whether the drawer should be open/closed, we can just set 'open'ness on mount. The drawer will still auto-close upon step completion because once `Run` is hit, the system will unmount the drawer while the step runs and the remount it afterwards.
-> exact change = determine 'open'ness within the `useState` call and remove the `useEffect` that controlled 'open'ness later on.