### PR TITLE
also change wording for unsaved figure with local stession

### DIFF
--- a/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
@@ -55,6 +55,9 @@ export default function WorkflowManager({
     [projectName, dispatch, state, requestPoll]
   );
 
+  const useLocalPrompt =
+    "You have unsaved changes. Click 'OK' to use your local version, or 'Cancel' to discard all unsaved changes and load the last saved state.";
+
   const initializeFromFigure = useCallback(
     (figureId: number, localSession: VulcanFigureSession | null) => {
       showErrors(
@@ -65,9 +68,7 @@ export default function WorkflowManager({
             localSession &&
             !_.isEqual(localSession.inputs, figureResponse.inputs)
           ) {
-            useLocal = confirm(
-              "You have unsaved changes. Click 'OK' to use your local version, or 'Cancel' to discard all unsaved changes and load the last saved state."
-            );
+            useLocal = confirm(useLocalPrompt);
           }
 
           initializeFromSessionAndFigure(
@@ -104,18 +105,16 @@ export default function WorkflowManager({
       dispatch(setWorkflow(workflow, projectName));
       const defaults = defaultInputs(workflow);
 
-      let discardStoredSession = true;
+      let useLocal = false;
 
       if (
         !_.isEqual(defaults, localSession.inputs) &&
         Object.keys(localSession.inputs) >= Object.keys(defaults)
       ) {
-        discardStoredSession = confirm(
-          'You have an edited, unsaved version of this workflow. Discard it?'
-        );
+        useLocal = confirm(useLocalPrompt);
       }
 
-      if (discardStoredSession) {
+      if (!useLocal) {
         initializeNewSession();
       } else {
         initializeFromSessionAndFigure(


### PR DESCRIPTION
Missed this wording change in #886, when you have a non-figure session but reload the page / try to create a new figure, user also gets prompted about the local session. Updates the wording to flip OK / Cancel, like in the use case with a saved figure.