### PR TITLE
fix metis_client put

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-#
+
 require 'optparse'
 require 'resolv'
 require 'json'
@@ -18,6 +18,10 @@ require 'singleton'
 
 CONFIG_FILE='~/.metis.json'
 LOG_FILE='~/.metis.log'
+
+def escaped_path(folder_path)
+  folder_path.split('/').map{|fs| CGI.escape(fs) }.join('/')
+end
 
 def test_env?
   ENV['METIS_ENV'] == 'test'
@@ -351,7 +355,7 @@ class MetisClient < Client
   end
 
   def create_folder(project_name, folder_path)
-    response = json_post("/#{project_name}/folder/create/#{URI.encode(folder_path)}")
+    response = json_post("/#{project_name}/folder/create/#{escaped_path(folder_path)}")
     raise MetisClient::Error, "Could not create folder #{folder_path}\n#{error(response)}" unless response.code == "200" || (response.code == "422" && error(response) == 'Folder exists')
   end
 
@@ -362,7 +366,7 @@ class MetisClient < Client
   end
 
   def list_folder(project_name,folder_path)
-    response = get_request( "/#{project_name}/list/#{URI.encode(folder_path || '')}" )
+    response = get_request( "/#{project_name}/list/#{escaped_path(folder_path || '')}" )
 
     return nil if response.code == "404"
     raise MetisClient::Error, "Could not list folder #{folder_path}\n#{error(response)}" unless response.code == "200"
@@ -370,12 +374,12 @@ class MetisClient < Client
   end
 
   def rename_folder(project_name,bucket_name,folder_path,new_folder_path)
-    response = json_post("/#{project_name}/folder/rename/#{bucket_name}/#{URI.encode(folder_path)}", new_folder_path: new_folder_path)
+    response = json_post("/#{project_name}/folder/rename/#{bucket_name}/#{escaped_path(folder_path)}", new_folder_path: new_folder_path)
     raise MetisClient::Error, "Could not rename folder #{folder_path}\n#{error(response)}" unless response.code == "200"
   end
 
   def rename_file(project_name,bucket_name,file_path,new_file_path)
-    response = json_post("/#{project_name}/file/rename/#{bucket_name}/#{URI.encode(file_path)}", new_file_path: new_file_path)
+    response = json_post("/#{project_name}/file/rename/#{bucket_name}/#{escaped_path(file_path)}", new_file_path: new_file_path)
     raise MetisClient::Error, "Could not rename file #{file_path}\n#{error(response)}" unless response.code == "200"
   end
 
@@ -400,12 +404,12 @@ class MetisClient < Client
   end
 
   def remove_folder(project_name, folder_path, recursive=false)
-    response = delete_request("/#{project_name}/folder/remove/#{URI.encode(folder_path)}",recursive ? { recursive: true } : {})
+    response = delete_request("/#{project_name}/folder/remove/#{escaped_path(folder_path)}",recursive ? { recursive: true } : {})
     raise MetisClient::Error, "Could not remove folder #{folder_path}\n#{error(response)}" unless response.code == "200"
   end
 
   def remove_file(project_name, file_path)
-    response = delete_request("/#{project_name}/file/remove/#{URI.encode(file_path)}")
+    response = delete_request("/#{project_name}/file/remove/#{escaped_path(file_path)}")
     raise MetisClient::Error, "Could not remove file #{file_path}\n#{error(response)}" unless response.code == "200"
   end
 
@@ -426,7 +430,7 @@ class MetisClient < Client
       old_file_path = file_path
     end
 
-    response = json_post("/#{project_name}/file/copy/#{URI.encode(old_file_path)}",
+    response = json_post("/#{project_name}/file/copy/#{escaped_path(old_file_path)}",
       new_file_path: new_file_path,
       new_bucket_name: new_bucket_name)
 
@@ -1056,10 +1060,12 @@ EOT
       raise ShellError, 'No input files selected!' if input_files.empty?
 
       # get a listing of the folder
-      folder = @shell.client.list_folder(@shell.project_name, @shell.relative_path(folder_path))
+      folder_path = @shell.relative_path(folder_path)
+
+      folder = @shell.client.list_folder(@shell.project_name, folder_path)
 
       input_files.each do |file_or_folder|
-        upload(file_or_folder, @shell.cwd, folder)
+        upload(file_or_folder, folder_path, folder)
       end
     end
 


### PR DESCRIPTION
Correctly puts to a different folder (not `.`). I also fixed (?) a deprecation warning about `URI.escape`