### PR TITLE
Bug Fix: Vulcan Session Load for the Viz workflow

### DIFF
--- a/vulcan/lib/client/jsx/api_types.ts
+++ b/vulcan/lib/client/jsx/api_types.ts
@@ -102,7 +102,7 @@ export interface Workflow {
   steps: [WorkflowStep[]];
   vignette?: string;
   image?: string;
-  projects?: string[];
+  projects?: string[] | null;
   authors?: string[];
   displayName?: string;
   description?: string;

--- a/vulcan/lib/client/jsx/components/dashboard/workflows_carousel.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/workflows_carousel.tsx
@@ -39,7 +39,7 @@ export default function WorkflowsCarousel({
   const {workflows} = state;
 
   const projectWorkflows = workflows
-    ? workflows.filter(({projects}: {projects?: string[]}) =>
+    ? workflows.filter(({projects}: {projects?: string[] | null}) =>
         projects?.includes(project_name)
       )
     : [];

--- a/vulcan/lib/client/jsx/reducers/vulcan_reducer.ts
+++ b/vulcan/lib/client/jsx/reducers/vulcan_reducer.ts
@@ -82,7 +82,7 @@ export default function VulcanReducer(
       };
     case 'SET_WORKFLOW':
       const workflowProjects = action.workflow.projects;
-      if (!workflowProjects || !workflowProjects.includes(action.projectName))
+      if ( !workflowProjects || (workflowProjects != null && !workflowProjects.includes(action.projectName)) )
         return state;
 
       return {

--- a/vulcan/lib/client/jsx/reducers/vulcan_reducer.ts
+++ b/vulcan/lib/client/jsx/reducers/vulcan_reducer.ts
@@ -82,7 +82,7 @@ export default function VulcanReducer(
       };
     case 'SET_WORKFLOW':
       const workflowProjects = action.workflow.projects;
-      if ( !workflowProjects || (workflowProjects != null && !workflowProjects.includes(action.projectName)) )
+      if ( workflowProjects===undefined || (workflowProjects !== null && !workflowProjects.includes(action.projectName)) )
         return state;
 
       return {


### PR DESCRIPTION
Adds:
- projects=null case in 'okay to set this?' check of the vulcan reducer action setWorkflow
- `string[] | null` as typing of `projects?` in Workflow interface to help remind us of that case when writing code.