### PR TITLE
Support comma separate attribute group entries

### DIFF
--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -221,7 +221,9 @@ class Magma
     end
 
     def validate_attribute_group_format
-      return if !attribute_group || attribute_group =~ SNAKE_CASE_WORD
+      return unless attribute_group
+      parts = attribute_group.split(",", -1)
+      return if parts.all? { |p| p =~ SNAKE_CASE_WORD }
       errors.add(:attribute_group, "must be snake_case with no spaces")
     end
 

--- a/magma/spec/actions/add_attribute_actions_spec.rb
+++ b/magma/spec/actions/add_attribute_actions_spec.rb
@@ -129,6 +129,23 @@ describe Magma::AddAttributeAction do
       end
     end
 
+    context "when attribute_group contains multiple values" do
+      let(:attribute_group) { attribute_groups.join(",")}
+      let(:action_errors) { action.validate; action.errors.map { |v| v[:message] }.first }
+
+      let(:attribute_groups) { ["a", "b", "c"] }
+      it "works" do
+        expect(action_errors).to be_nil
+      end
+
+      context "but one of the elements is non snake_case" do
+        let(:attribute_groups) { ["a", "b-!A.A", "c"] }
+        it "works" do
+          expect(action_errors).to eql("attribute_group must be snake_case with no spaces")
+        end
+      end
+    end
+
     context "when attribute_group is not a snake_case word" do
       let(:attribute_group) { @attribute_group }
 


### PR DESCRIPTION
Support comma separate attribute group entries for @dtm2451 effort to update coprojects template.

work to use attribute groups in the frontend to follow up.