### PR TITLE
Etna server noauth options route

### DIFF
--- a/etna/lib/etna/server.rb
+++ b/etna/lib/etna/server.rb
@@ -3,7 +3,19 @@ module Etna
   class Server
     class << self
       def route(method, path, options={}, &block)
-        @routes ||= []
+        # For healthchecks, set up servers
+        #   with an OPTIONS route on /, with noauth
+        @routes ||= [
+          Etna::Route.new(
+            'OPTIONS',
+            '/',
+            {
+              auth: {
+                noauth: true
+              }
+            }
+          )
+        ]
 
         @routes << Etna::Route.new(
           method,

--- a/etna/spec/server_spec.rb
+++ b/etna/spec/server_spec.rb
@@ -167,13 +167,13 @@ describe Etna::Server do
   it 'sets route names' do
     Arachne::Server.get('/silk/:name', as: :silk_road)
 
-    expect(Arachne::Server.routes.first.name).to eq(:silk_road)
+    expect(Arachne::Server.routes.last.name).to eq(:silk_road)
   end
 
   it 'guesses route names' do
     Arachne::Server.get('/web/:silk', action: 'web#silk')
 
-    expect(Arachne::Server.routes.first.name).to eq(:web_silk)
+    expect(Arachne::Server.routes.last.name).to eq(:web_silk)
   end
 
   it 'looks up route names' do

--- a/etna/spec/server_spec.rb
+++ b/etna/spec/server_spec.rb
@@ -20,6 +20,22 @@ describe Etna::Server do
     Object.send(:remove_const, :WebController)
   end
 
+  it 'should include a noauth OPTIONS / route' do
+    Arachne::Server.route('GET', '/silk') do
+      [ 200, {}, [ 'ok' ] ]
+    end
+
+    expect(Arachne::Server.routes.length).to eq(2)
+
+    @app = setup_app(Arachne::Server, [Etna::DescribeRoutes])
+
+    options '/'
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body =~ /OPTIONS/).not_to eq(nil)
+  end
+
+
   it 'should allow route definitions with blocks' do
     Arachne::Server.route('GET', '/silk') do
       [ 200, {}, [ 'ok' ] ]

--- a/etna/spec/server_spec.rb
+++ b/etna/spec/server_spec.rb
@@ -32,7 +32,7 @@ describe Etna::Server do
     options '/'
 
     expect(last_response.status).to eq(200)
-    expect(last_response.body =~ /OPTIONS/).not_to eq(nil)
+    expect(last_response.body).to match(/OPTIONS/)
   end
 
 

--- a/janus/config.ru
+++ b/janus/config.ru
@@ -18,6 +18,7 @@ use Etna::ParseBody
 use Etna::SymbolizeParams
 use Rack::Static, urls: ['/css', '/js', '/fonts', '/img'], root: 'lib/client'
 use Etna::Auth
+use Etna::DescribeRoutes
 
 use Janus::Throttle, max: 100
 use Janus::RefreshToken


### PR DESCRIPTION
This PR provides a `noauth` endpoint (OPTIONS `/`) for each of the application servers.

It seems like the healthchecks might be noisy in Docker Swarm, because the `/` route has a bit of a conflict with the healthchecks, due to the deployment of `redirect.rb`.

We constantly get this message:

```
2022-06-30 13:10:30 +0000 Rack app ("GET /" - (127.0.0.1)): #<NoMethodError: undefined method `join' for nil:NilClass>
```

While the 500 seems to report as "okay" health (portainer still shows containers as up and healthy), seems like we should provide a working endpoint to get more accurate behavior.

We traced the above exception back to the healthcheck [request against `localhost`](https://github.com/mountetna/monoetna/blob/master/swarm/janus.1655506506.yml#L55) throwing [an exception in the redirect domain checking](https://github.com/mountetna/monoetna/blob/master/etna/lib/etna/redirect.rb#L32-L34). Since `request.hostname == "localhost"`, and `"localhost"` has no `.` in it, the code tries to join `nil` and fails.

It doesn't really make sense to allow a localhost redirect in `redirect.rb`, so here we're providing an alternate `noauth` endpoint that the healthcheck can run against. 

Once this is deployed, I'll edit the Portainer stack configs to point the healthchecks to the new routes, by changing:

```
bash -c 'curl http://localhost:3000 || exit 1'
```

to 

```
bash -c 'curl -X OPTIONS http://localhost:3000 || exit 1'
```

for each of the stacks.