### PR TITLE
update timur create_routes

### DIFF
--- a/etna/lib/etna/route.rb
+++ b/etna/lib/etna/route.rb
@@ -38,11 +38,11 @@ module Etna
 
     UNSAFE=/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/
 
-    def self.path(route, params=nil)
+    def self.path(route, params=nil, &block)
       if params
         PARAM_TYPES.reduce(route) do |path,pat|
           path.gsub(pat) do
-            params[$1.to_sym].split('/').map { |c| URI.encode_www_form_component(c) }.join('/')
+            params[$1.to_sym].split('/').map { |c| block_given? ? yield(c) : URI.encode_www_form_component(c) }.join('/')
           end
         end
       else
@@ -50,8 +50,8 @@ module Etna
       end
     end
 
-    def path(params=nil)
-      self.class.path(@route, params)
+    def path(params=nil, &block)
+      self.class.path(@route, params, &block)
     end
 
     def parts

--- a/etna/spec/server_spec.rb
+++ b/etna/spec/server_spec.rb
@@ -166,9 +166,9 @@ describe Etna::Server do
     end
     @app = setup_app(Arachne::Server)
 
-    get('/silk/tree')
+    get('/silk/The+skill+at+weaving+was+itself+a+web')
     expect(last_response.status).to eq(200)
-    expect(last_response.body).to eq('http://example.org/silk/tree')
+    expect(last_response.body).to eq('http://example.org/silk/The+skill+at+weaving+was+itself+a+web')
   end
 
   it "applies an auth check" do

--- a/timur/lib/commands.rb
+++ b/timur/lib/commands.rb
@@ -95,13 +95,13 @@ EOT
       route_path = route.path(
         Hash[
           required_parts.zip(
-            required_parts.map{|part| %Q{'+#{part}+'} }
+            required_parts.map{|part| %Q{${#{part}}} }
           )
         ]
-      )
+      ) { |c| c }
 
       <<EOT.chomp
-    #{route.name}_path: (#{required_parts.join(', ')}) => ('#{route_path}')
+    #{route.name}_path: (#{required_parts.join(', ')}) => (`#{route_path}`)
 EOT
     end
 

--- a/timur/spec/commands_spec.rb
+++ b/timur/spec/commands_spec.rb
@@ -1,0 +1,10 @@
+describe Timur::CreateRoutes do
+  it 'generates the routes.js' do
+    command = Timur::CreateRoutes.new
+
+    # hard to check this correctly, so let's just ensure
+    # it doesn't encode too zealously
+    expect(command.route_js).not_to match(%r!(`.*%.*`)!)
+  end
+end
+


### PR DESCRIPTION
This repairs an issue in Timur's CreateRoutes command, which creates a JS file containing functions that the Timur client uses for mapping routes. Following the 2.7 upgrade, this (untested) command began to fail, causing the main page for Timur to make a request for magma for the entire `project` record. This, for reasons yet unknown, causes Magma to OOM and kill its container.

This solves a part of the problem by fixing the Timur command, so there is a proper routes.js, so that a view can correctly be retrieved, so that Timur won't ask magma for too much data by default.

It is possible there are other underlying issues having to do with the change to using `URI.encode_www_form_component` and `URI.decode_www_form_component` instead of `URI.encode` and `URI.decode` (for example, outstanding Metis and Vulcan slowness); these are undiscovered so not dealt with here.