### PR TITLE
exclude additional test folder

### DIFF
--- a/polyphemus/lib/rsync_files_etl.rb
+++ b/polyphemus/lib/rsync_files_etl.rb
@@ -58,6 +58,7 @@ class Polyphemus
             "--exclude=test",
             "--exclude=Reports",
             "--exclude=Stats",
+            "--exclude=test_DM",
             "--rsh=\"/usr/bin/sshpass -p #{@password} ssh -l #{@username}\""]
         )
 


### PR DESCRIPTION
Adds a new CAT folder to exclude from the ingest pipeline (`test_DM`). Quick fix until this gets migrated to Airflow ... which will hopefully happen sometime... :disappointed: 