### PR TITLE
use correct symbol syntax when changing column type, and cast

### DIFF
--- a/magma/lib/magma/migration.rb
+++ b/magma/lib/magma/migration.rb
@@ -144,7 +144,7 @@ class Magma
     end
 
     def column_type_entry name, type
-      "set_column_type :#{name}, #{type}"
+      "set_column_type :#{name}, #{type.is_a?(Symbol) ? ":#{type}, using: '#{name}::#{type}'" : type}"
     end
 
     def column_entry name, type

--- a/magma/spec/migration_spec.rb
+++ b/magma/spec/migration_spec.rb
@@ -223,20 +223,39 @@ EOT
       Labors::Prize.attributes[:worth] = worth
     end
 
-    it 'changes column types' do
-      original_attribute = Labors::Prize.attributes.delete(:worth)
-      Labors::Prize.attributes[:worth] = Magma::Model.float(
-        :worth,
-        column_name: original_attribute.column_name
-      )
+    context 'changes column types' do
+      it 'for simple types' do
+        original_attribute = Labors::Prize.attributes.delete(:worth)
+        Labors::Prize.attributes[:worth] = Magma::Model.float(
+          :worth,
+          column_name: original_attribute.column_name
+        )
 
-      migration = Labors::Prize.migration
-      expect(migration.to_s).to eq <<EOT.chomp
+        migration = Labors::Prize.migration
+        expect(migration.to_s).to eq <<EOT.chomp
     alter_table(Sequel[:labors][:prizes]) do
       set_column_type :#{original_attribute.column_name}, Float
     end
 EOT
-      Labors::Prize.attributes[:worth] = original_attribute
+
+        Labors::Prize.attributes[:worth] = original_attribute
+      end
+
+      it 'for symbol types' do
+        original_attribute = Labors::Prize.attributes.delete(:worth)
+        Labors::Prize.attributes[:worth] = Magma::Model.image(
+          :worth,
+          column_name: original_attribute.column_name
+        )
+
+        migration = Labors::Prize.migration
+        expect(migration.to_s).to eq <<EOT.chomp
+    alter_table(Sequel[:labors][:prizes]) do
+      set_column_type :#{original_attribute.column_name}, :json, using: 'worth::json'
+    end
+EOT
+        Labors::Prize.attributes[:worth] = original_attribute
+      end
     end
   end
 end


### PR DESCRIPTION
This closes #932. I think it only surfaced because my local database must have been set up incorrectly at some point in time: the `tiff_file` attribute was a `text` field instead of `json`, and so the migration was trying to do a column-type change. Unsure why the `Symbol` logic was not applied in this case, except that it is more complex, and I'm not sure the `using:` syntax generalizes? I think `:json` is the only current case where we have to pass in a Symbol, and works okay.

This PR handles converting a column type to `json` for image / file / file_collection attributes correctly, and adds a spec for it.