### PR TITLE
remove unused argument

### DIFF
--- a/airflow/opt/providers/etna/etna/hooks/etna.py
+++ b/airflow/opt/providers/etna/etna/hooks/etna.py
@@ -140,7 +140,7 @@ class EtnaHook(BaseHook):
         )
         return TokenAuth(token, project_name)
 
-    def get_session(self, auth):
+    def get_session(self):
         return None
 
     @contextlib.contextmanager


### PR DESCRIPTION
Many of the Airflow ETLs are currently broken, throwing this error:

```
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1334, in _run_raw_task
    self._execute_task_with_callbacks(context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1460, in _execute_task_with_callbacks
    result = self._execute_task(context, self.task)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1516, in _execute_task
    result = execute_callable(context=context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/decorators/base.py", line 134, in execute
    return_value = super().execute(context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 174, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 188, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/etna/etls/decorators.py", line 62, in tail_folders
    with hook.metis() as metis:
  File "/usr/local/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/airflow/.local/lib/python3.8/site-packages/etna/hooks/etna.py", line 150, in metis
    auth = self.get_task_auth(project_name, read_only)
  File "/home/airflow/.local/lib/python3.8/site-packages/etna/hooks/etna.py", line 138, in get_task_auth
    token = Janus(token_auth, self.get_hostname("janus"), session=self.get_session()).generate_token(
TypeError: get_session() missing 1 required positional argument: 'auth'
```

This PR fixes a small issue with one of the `EtnaHook` methods having an argument defined but never used or provided in the calls...