### PR TITLE
Vulcan bug fixes (WIP)

### DIFF
--- a/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workflow/workflow_manager.tsx
@@ -134,7 +134,7 @@ export default function WorkflowManager({
       } else {
         initializeFromSessionAndFigure(
           selectSession(localSession),
-          defaultFigure
+          selectFigure(localSession)
         );
       }
     },


### PR DESCRIPTION
PR aims to fix bugs recently noted in vulcan:
- [x] Newly created figures could only survive 1 page refresh before failing to load
  - on first refresh, the `figure` slot of the vulcan state got its `workflow_snapshot` filled in with an entirely `null`/`{}`/`""` version of a workflow_snapshot that looked like a stub, and indeed it was.  On second refresh, the `workflow_snapshot`, as it is now not empty, is utilized for loading, which leads to the error "Cannot set session, project name / workflow name does not match." because the stubbed info doesn't match expected values. **Fix:** replaced `defaultFigure` with pulling the actual figure info from session storage.
- [ ] Primary inputs not properly retrieved
  - Still investigating...