### PR TITLE
refactor and extract test

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis.py
+++ b/airflow/opt/providers/etna/etna/etls/metis.py
@@ -575,13 +575,9 @@ class MetisEtlHelpers:
             project_name = matches[0].project_name
             bucket_name = matches[0].bucket_name
             with self.hook.metis() as metis:
-                files_by_parent_id = {}
-                for f in metis.tail(project_name, bucket_name, 'files', folder_id=[m.folder_id for m in matches])[0]:
-                    folder_id = f.folder_id
-                    if folder_id not in files_by_parent_id:
-                        files_by_parent_id[folder_id] = []
-
-                    files_by_parent_id[folder_id].append(f)
+                files_by_parent_id = self._group_files_by_folder(
+                    metis.tail(project_name, bucket_name, 'files', folder_id=[m.folder_id for m in matches])[0]
+                )
 
                 return [
                     (m, files_by_parent_id.get(m.folder_id) or [])
@@ -589,6 +585,21 @@ class MetisEtlHelpers:
                 ]
 
         return list_match_folders(matches)
+
+    def _group_files_by_folder(
+        self,
+        files: List[File]):
+
+        files_by_parent_id = {}
+        for f in files:
+            folder_id = f.folder_id
+            if folder_id not in files_by_parent_id:
+                files_by_parent_id[folder_id] = []
+
+            files_by_parent_id[folder_id].append(f)
+
+        return files_by_parent_id
+
 
 
 def filter_by_exists_in_timur(

--- a/airflow/opt/providers/etna/etna/etls/metis.py
+++ b/airflow/opt/providers/etna/etna/etls/metis.py
@@ -601,7 +601,6 @@ class MetisEtlHelpers:
         return files_by_parent_id
 
 
-
 def filter_by_exists_in_timur(
     magma: Magma,
     matched: List[MatchedRecordFolder],

--- a/airflow/opt/providers/etna/etna/tests/test_metis_files_etl.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_files_etl.py
@@ -144,7 +144,20 @@ def test_metis_files_etl_e2e(reset_db, token_etna_connection: Connection):
         end_date, test_loading_metis_files, record_matches_task_id
     )
     assert len(results) > 0
-    assert all([len(r[1]) != 1 for r in results])
+
+
+def test_metis_helpers_group_files(reset_db):
+    helpers = MetisEtlHelpers([], [], None)
+
+    grouped_files = helpers._group_files_by_folder(
+        [
+            File(folder_id=1, file_name="file_01.txt"),
+            File(folder_id=2, file_name="file_02.txt"),
+            File(folder_id=1, file_name="file_03.txt"),
+            File(folder_id=2, file_name="file_04.txt")
+        ]
+    )
+    assert all([len(v) == 2 for k, v in grouped_files.items()])
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
Small refactor to improve testing around the metis file grouping logic, so it's not reliant on the cassette and thus won't get clobbered on re-recording ... :man_facepalming:  