### PR TITLE
better error handling for janus token generation; close #957

### DIFF
--- a/etna/lib/etna/test_auth.rb
+++ b/etna/lib/etna/test_auth.rb
@@ -54,6 +54,9 @@ module Etna
 
       return false unless token
 
+      # Useful for testing certain behavior
+      params = request.env["rack.request.params"]
+
       # Here we simply base64-encode our user hash and pass it through
       # In order to behave more like "real" tokens, we expect the user hash to be
       #   in index 1 after splitting by ".".
@@ -63,7 +66,7 @@ module Etna
       request.env['etna.user'] = Etna::User.new(
         update_payload(payload, token, request),
         token
-      )
+      ) unless !!params[:do_not_set_user]
     end
 
     def approve_hmac(request)

--- a/janus/lib/server/controllers/authorization_controller.rb
+++ b/janus/lib/server/controllers/authorization_controller.rb
@@ -87,6 +87,8 @@ class AuthorizationController < Janus::Controller
     end
 
     return success(user.create_token!)
+  rescue JWT::ExpiredSignature => e
+    raise Etna::Unauthorized, "failed to create token"
   end
 
   def build

--- a/janus/spec/token_spec.rb
+++ b/janus/spec/token_spec.rb
@@ -258,6 +258,20 @@ describe "Token Generation" do
       Timecop.return
     end
 
+    it 'refuses to create a task token when main token expired' do
+      now = Time.now
+      Timecop.freeze(Time.at(0))
+
+      header('Authorization', "Etna #{@user.create_token!}")
+
+      Timecop.freeze(now)
+
+      post('/api/tokens/generate', project_name: 'tannel', token_type: 'task', do_not_set_user: true)
+      expect(last_response.status).to eq(401)
+
+      Timecop.return
+    end
+
     it 'refuses to create a task token without project permission' do
       header('Authorization', "Etna #{@user.create_token!}")
       post('/api/tokens/generate', project_name: 'gateway', token_type: 'task')


### PR DESCRIPTION
This PR more gracefully handles a situation where a user uses an expired token to generate a new task token (#957). Had to modify `TestAuth.rb` in order to mimic actual, production behavior.