### PR TITLE
refresh cursor from db before saving to prevent overwrites

### DIFF
--- a/airflow/opt/providers/etna/docs/etna/hooks/cat.html
+++ b/airflow/opt/providers/etna/docs/etna/hooks/cat.html
@@ -475,6 +475,9 @@
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Save the cursor to the database.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">latest_cursor</span> <span class="o">=</span> <span class="n">Variable</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="n">default_var</span><span class="o">=</span><span class="p">{},</span> <span class="n">deserialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+
+        <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]</span> <span class="o">=</span> <span class="p">{</span><span class="o">**</span><span class="n">latest_cursor</span><span class="p">,</span> <span class="o">**</span><span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]}</span>
         <span class="n">Variable</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">],</span> <span class="n">serialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">variable_key</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">postfix</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
@@ -1219,6 +1222,9 @@ for the efficiency of imports.</p>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Save the cursor to the database.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">latest_cursor</span> <span class="o">=</span> <span class="n">Variable</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="n">default_var</span><span class="o">=</span><span class="p">{},</span> <span class="n">deserialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+
+        <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]</span> <span class="o">=</span> <span class="p">{</span><span class="o">**</span><span class="n">latest_cursor</span><span class="p">,</span> <span class="o">**</span><span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]}</span>
         <span class="n">Variable</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">],</span> <span class="n">serialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">variable_key</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">postfix</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
@@ -1488,6 +1494,9 @@ subset of the data.</p>
         <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">        Save the cursor to the database.</span>
 <span class="sd">        &quot;&quot;&quot;</span>
+        <span class="n">latest_cursor</span> <span class="o">=</span> <span class="n">Variable</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="n">default_var</span><span class="o">=</span><span class="p">{},</span> <span class="n">deserialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+
+        <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]</span> <span class="o">=</span> <span class="p">{</span><span class="o">**</span><span class="n">latest_cursor</span><span class="p">,</span> <span class="o">**</span><span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">]}</span>
         <span class="n">Variable</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">variable_key</span><span class="p">(</span><span class="n">postfix</span><span class="p">),</span> <span class="bp">self</span><span class="o">.</span><span class="n">cursors</span><span class="p">[</span><span class="n">postfix</span><span class="p">],</span> <span class="n">serialize_json</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </pre></div>
 

--- a/airflow/opt/providers/etna/etna/hooks/cat.py
+++ b/airflow/opt/providers/etna/etna/hooks/cat.py
@@ -317,9 +317,8 @@ class Cat(SSHBase):
         Save the cursor to the database.
         """
         latest_cursor = Variable.get(self.variable_key(postfix), default_var={}, deserialize_json=True)
-        latest_cursor.update(self.cursors[postfix])
 
-        self.cursors[postfix] = latest_cursor
+        self.cursors[postfix] = {**latest_cursor, **self.cursors[postfix]}
         Variable.set(self.variable_key(postfix), self.cursors[postfix], serialize_json=True)
 
     def variable_key(self, postfix: str):

--- a/airflow/opt/providers/etna/etna/hooks/cat.py
+++ b/airflow/opt/providers/etna/etna/hooks/cat.py
@@ -316,6 +316,10 @@ class Cat(SSHBase):
         """
         Save the cursor to the database.
         """
+        latest_cursor = Variable.get(self.variable_key(postfix), default_var={}, deserialize_json=True)
+        latest_cursor.update(self.cursors[postfix])
+
+        self.cursors[postfix] = latest_cursor
         Variable.set(self.variable_key(postfix), self.cursors[postfix], serialize_json=True)
 
     def variable_key(self, postfix: str):

--- a/airflow/opt/providers/etna/etna/tests/test_cat_helpers.py
+++ b/airflow/opt/providers/etna/etna/tests/test_cat_helpers.py
@@ -534,7 +534,7 @@ def test_mark_ingested_updates_cursor(mock_get, reset_db):
     assert test_file.hash == cat.cursors["c4"][test_file.full_path]
 
 
-@mock.patch.object(Variable, 'get', side_effect=[mock_var_get("c4"), mock_var_get("metis")])
+@mock.patch.object(Variable, 'get', side_effect=[mock_var_get("c4"), mock_var_get("metis"), mock_var_get("c4")])
 @mock.patch.object(Variable, 'set')
 def test_update_cursor_saves_variable(mock_set, mock_get, reset_db):
     set_up_mocks()
@@ -554,7 +554,13 @@ def test_update_cursor_saves_variable(mock_set, mock_get, reset_db):
     mock_set.assert_called_with(
         'cat_ingest_cursor-c4',
         {
-            '/file.txt': '1-2-3'
+            "parent/child/grandchild/123.txt": f"1-{timestamp(2022, 1, 1)}",
+            "something.txt": f"1-{timestamp(2022, 1, 1)}",
+            "other_thing.txt": f"2-{timestamp(2022, 3, 1)}",
+            "other_things.txt": f"3-{timestamp(2022, 5, 1)}",
+            "folder/yet_another_thing.txt": f"5-{timestamp(2022, 6, 2)}",
+            "folder/another_thing.txt": f"6-{timestamp(2022, 1, 2)}",
+            "/file.txt": "1-2-3"
         },
         serialize_json=True)
 


### PR DESCRIPTION
Small changes to Airflow CAT to prevent multiple tasks from clobbering each other's cursors.