### PR TITLE
Mountetna python retry metis

### DIFF
--- a/etna/packages/etna-py/src/mountetna/metis.py
+++ b/etna/packages/etna-py/src/mountetna/metis.py
@@ -13,7 +13,8 @@ from serde.json import from_json, to_json
 from .etna_base import EtnaClientBase
 from .utils.multipart import encode_as_multipart
 from .utils.streaming import iterable_to_stream
-from requests import HTTPError
+from requests import RequestException
+from time import sleep
 
 @serialize
 @deserialize
@@ -503,8 +504,9 @@ class Metis(EtnaClientBase):
                 )
 
                 unsent_zero_byte_file = False
-            except HTTPError as e:
+            except RequestException as e:
                 if remaining_attempts > 1:
+                    sleep(30)
                     if e.response.status_code == 422:
                         yield from self.upload_parts(
                             upload, metis_uid, remaining_attempts - 1, True

--- a/etna/packages/etna-py/src/mountetna/metis.py
+++ b/etna/packages/etna-py/src/mountetna/metis.py
@@ -13,7 +13,7 @@ from serde.json import from_json, to_json
 from .etna_base import EtnaClientBase
 from .utils.multipart import encode_as_multipart
 from .utils.streaming import iterable_to_stream
-from requests import RequestException
+from requests import RequestException, HTTPError
 from time import sleep
 
 @serialize

--- a/etna/packages/etna-py/src/mountetna/metis.py
+++ b/etna/packages/etna-py/src/mountetna/metis.py
@@ -450,7 +450,7 @@ class Metis(EtnaClientBase):
         dest_path: str,
         file: typing.IO,
         size: Optional[int] = None,
-        max_retries=3,
+        max_retries=15,
     ) -> typing.Iterable["Upload"]:
         if size is None:
             if file.seekable():


### PR DESCRIPTION
This PR adds a "retry" ability to the `upload_blob` functionality in Metis, for the Python mountetna package. Hope this might make the ETL uploads more stable?

It also catches and retries on [`RequestException`](https://github.com/psf/requests/blob/2a6f290bc09324406708a4d404a88a45d848ddf9/requests/exceptions.py#L12), which is a bit more generic than `HTTPError` and should catch more scenarios, like `metis_client` does (i.e. ProxyErrors, Timeouts, etc.).