### PR TITLE
only insert panel_patient if ipi exists

### DIFF
--- a/magma/db/migrations/010_add_link_attribute_name.rb
+++ b/magma/db/migrations/010_add_link_attribute_name.rb
@@ -7,8 +7,10 @@ Sequel.migration do
     Magma.instance.db.execute("UPDATE attributes SET link_model_name=attribute_name WHERE attributes.link_model_name is NULL and attributes.type in ('parent', 'table', 'collection', 'child', 'link')")
 
     Magma.instance.db.execute("UPDATE attributes SET link_attribute_name=model_name WHERE attributes.link_model_name is not NULL and attribute_name!='reference_patient'")
-    Magma.instance.db.execute("INSERT into attributes (project_name, model_name, attribute_name, link_model_name, type, column_name, link_attribute_name) VALUES ('ipi', 'patient', 'panel_patients', 'patient', 'collection', 'panel_patients', 'reference_patient')")
-    Magma.instance.db.execute("UPDATE attributes SET link_attribute_name='panel_patients' WHERE attribute_name='reference_patient' and project_name='ipi' and model_name='patient'")
+    if Magma.instance.get_project("ipi")
+      Magma.instance.db.execute("INSERT into attributes (project_name, model_name, attribute_name, link_model_name, type, column_name, link_attribute_name) VALUES ('ipi', 'patient', 'panel_patients', 'patient', 'collection', 'panel_patients', 'reference_patient')")
+      Magma.instance.db.execute("UPDATE attributes SET link_attribute_name='panel_patients' WHERE attribute_name='reference_patient' and project_name='ipi' and model_name='patient'")
+    end
   end
 
   down do


### PR DESCRIPTION
Small tweak to the last Magma migration, to only insert the `panel_patients` reciprocal link attribute to IPI if the project actually exists. I believe this would only affect dev instances that are newly installed, since you have to stand up Magma before the IPI project exists, but if you try to create IPI you'll get an error like:

```
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack Caught unspecified error
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack Tried to load attributes (panel_patients) from the database on Ipi::Patient but Ipi::Patient doesn't exist
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/project.rb:92:in `block in load_model_attributes'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/project.rb:90:in `each'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/project.rb:90:in `load_model_attributes'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/project.rb:75:in `load_project'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/project.rb:26:in `initialize'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma.rb:66:in `new'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma.rb:66:in `get_or_load_project'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/actions/model_update_actions.rb:145:in `initialize'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/actions/model_update_actions.rb:17:in `new'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/actions/model_update_actions.rb:17:in `build'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /app/lib/magma/server/update_model.rb:6:in `action'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/controller.rb:42:in `response'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/route.rb:131:in `process_call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/instrumentation.rb:27:in `time_it'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/instrumentation.rb:10:in `block in time_it'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/route.rb:90:in `block in call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/yabeda-0.11.0/lib/yabeda/dsl/class_methods.rb:76:in `with_tags'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/instrumentation.rb:46:in `with_yabeda_tags'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/route.rb:88:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/server.rb:77:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/describe_routes.rb:10:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/auth.rb:22:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/symbolize_params.rb:10:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/parse_body.rb:38:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/metrics.rb:22:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/cross_origin.rb:34:in `actual_response'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /etna/lib/etna/cross_origin.rb:11:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/configuration.rb:252:in `call'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/request.rb:77:in `block in handle_request'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/request.rb:76:in `handle_request'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/server.rb:441:in `process_client'
magma_app_1      | ERROR:2022-08-08T14:57:34+00:00 lmjack /bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
```

So basically only insert that attribute if IPI exists.