### PR TITLE
installs some missing libraries

### DIFF
--- a/swarm/swarm-keeper/Dockerfile
+++ b/swarm/swarm-keeper/Dockerfile
@@ -3,8 +3,8 @@ FROM etna-base-dev
 
 FROM alpine
 RUN mkdir /app
-RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client
-RUN pip install -U requests[socks] yq
+RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client vim
+RUN pip install -U requests[socks] yq rich
 COPY lib/* /usr/lib/
 COPY --from=0 /mocker /usr/lib/mocker
 COPY --from=1 /bin/post-to-slack.sh /usr/local/bin/post-to-slack


### PR DESCRIPTION
Reviewing this container with Harry this morning, and ran into some missing package dependencies. This PR just adds them to the container (`vim` and `rich`, a Python package).