### PR TITLE
Vulcan timur fix query plot

### DIFF
--- a/etna/packages/etna-py/pyproject.toml
+++ b/etna/packages/etna-py/pyproject.toml
@@ -1,13 +1,14 @@
 [tool.poetry]
 name = "mountetna"
-version = "0.1.4"
+version = "0.1.5"
 description = "Client package for Mount Etna data library"
 
 license = "GPL-2.0-only"
 
 authors = [
     "Zachary Collins <zachary.collins@ucsf.edu>",
-    "Saurabh Asthana <saurabh.asthana@ucsf.edu>"
+    "Saurabh Asthana <saurabh.asthana@ucsf.edu>",
+    "Cole Shaw <cole.shaw@ucsf.edu>"
 ]
 
 readme = 'README.md'  # Markdown files are supported

--- a/etna/packages/etna-py/src/mountetna/magma.py
+++ b/etna/packages/etna-py/src/mountetna/magma.py
@@ -1,5 +1,6 @@
 import dataclasses
 import typing
+from io import StringIO
 from inspect import isgenerator
 from typing import Dict, Optional, List
 from serde import serialize, deserialize
@@ -297,6 +298,8 @@ class Magma(EtnaClientBase):
             data=to_json(query),
             headers={"Content-Type": "application/json"},
         )
+        if 'tsv' == query['format']:
+            return StringIO(response.text)
 
         return from_json(QueryResponse, response.content)
 

--- a/etna/packages/etna-py/src/mountetna/magma.py
+++ b/etna/packages/etna-py/src/mountetna/magma.py
@@ -298,8 +298,8 @@ class Magma(EtnaClientBase):
             data=to_json(query),
             headers={"Content-Type": "application/json"},
         )
-        if 'tsv' == query['format']:
-            return StringIO(response.text)
+        if 'format' in query and 'tsv' == query['format']:
+            return StringIO(response.text).read()
 
         return from_json(QueryResponse, response.content)
 

--- a/etna/packages/etna-py/src/mountetna/magma.py
+++ b/etna/packages/etna-py/src/mountetna/magma.py
@@ -1,10 +1,14 @@
 import dataclasses
 import typing
 from io import StringIO
+from functools import partial
 from inspect import isgenerator
 from typing import Dict, Optional, List
 from serde import serialize, deserialize
 from serde.json import from_json, to_json
+
+import pandas as pd
+
 from .etna_base import EtnaClientBase
 from requests import HTTPError
 from .utils.iterables import batch_iterable
@@ -299,7 +303,9 @@ class Magma(EtnaClientBase):
             headers={"Content-Type": "application/json"},
         )
         if 'format' in query and 'tsv' == query['format']:
-            return StringIO(response.text).read()
+            pd_wrapper = partial(pd.read_csv, sep="\t")
+            tsv_data = StringIO(response.text)
+            return pd_wrapper(tsv_data)
 
         return from_json(QueryResponse, response.content)
 

--- a/etna/packages/etna-py/src/mountetna/tests/test_magma.py
+++ b/etna/packages/etna-py/src/mountetna/tests/test_magma.py
@@ -73,3 +73,21 @@ def test_magma_query():
     )
     response = client.query({ "project_name":"ipi", "query": [ 'labor', [ 'country', '::equals', 'Nemea' ], '::all', 'country' ]})
     assert response.answer == [ [ 'The Nemean Lion', 'Nemea' ] ]
+
+
+@responses.activate
+def test_magma_query_tsv():
+    ''' it queries magma '''
+    body = "identifier\tcolumn1\tcolumn2\nrecord1\t1\tblahblah\nrecord2\t3.4\tanything you want"
+    responses.add(
+        responses.POST,
+        "https://magma.test/query",
+        body=body,
+        status=200
+    )
+    client = Magma(
+        auth=TokenAuth(token='token'),
+        hostname='magma.test'
+    )
+    response = client.query({ "project_name":"ipi", "query": [ 'labor', [ 'country', '::equals', 'Nemea' ], '::all', 'country' ], "format": "tsv"})
+    assert response.text == body

--- a/etna/packages/etna-py/src/mountetna/tests/test_magma.py
+++ b/etna/packages/etna-py/src/mountetna/tests/test_magma.py
@@ -90,4 +90,4 @@ def test_magma_query_tsv():
         hostname='magma.test'
     )
     response = client.query({ "project_name":"ipi", "query": [ 'labor', [ 'country', '::equals', 'Nemea' ], '::all', 'country' ], "format": "tsv"})
-    assert response.text == body
+    assert response == body

--- a/etna/packages/etna-py/src/mountetna/tests/test_magma.py
+++ b/etna/packages/etna-py/src/mountetna/tests/test_magma.py
@@ -89,5 +89,6 @@ def test_magma_query_tsv():
         auth=TokenAuth(token='token'),
         hostname='magma.test'
     )
+
     response = client.query({ "project_name":"ipi", "query": [ 'labor', [ 'country', '::equals', 'Nemea' ], '::all', 'country' ], "format": "tsv"})
-    assert response == body
+    assert response.to_json() == '{"identifier":{"0":"record1","1":"record2"},"column1":{"0":1.0,"1":3.4},"column2":{"0":"blahblah","1":"anything you want"}}'

--- a/timur/lib/client/jsx/components/query/query_plot_menu.tsx
+++ b/timur/lib/client/jsx/components/query/query_plot_menu.tsx
@@ -239,7 +239,13 @@ const QueryPlotMenu = () => {
       .then(({workflows}) => {
         setPlottingWorkflows(workflows);
       })
-      .catch((e) => invoke(showMessages(['Error fetching workflows from Vulcan. Plotting disabled.'])));
+      .catch((e) =>
+        invoke(
+          showMessages([
+            'Error fetching workflows from Vulcan. Plotting disabled.'
+          ])
+        )
+      );
   }, []);
 
   const buttonDisabled = !plottingWorkflows || plottingWorkflows.length === 0;

--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -295,6 +295,13 @@ export const createFigurePayload = ({
       if (!query.hasOwnProperty(inputSource)) return;
 
       payload.inputs[cwlInput] = query[inputSource as keyof QueryPayload];
+
+      if (Array.isArray(payload.inputs[cwlInput]) || (
+        typeof payload.inputs[cwlInput] === 'object' &&
+        payload.inputs[cwlInput] !== null
+      )) {
+        payload.inputs[cwlInput] = JSON.stringify(payload.inputs[cwlInput]);
+      }
     }
   );
 

--- a/timur/test/javascript/selectors/query_selectors.test.ts
+++ b/timur/test/javascript/selectors/query_selectors.test.ts
@@ -237,13 +237,15 @@ describe('createFigurePayload', () => {
     const result = createFigurePayload({
       query: {
         user_columns: ["foo", "bar"],
-        query: "this is a query"
+        query: "this is a query",
+        something: {key: "value"}
       },
       title: "A plot",
       workflow: {
         inputQueryMap: {
           "1": "query",
-          "2": "user_columns"
+          "2": "user_columns",
+          "3": "something"
         },
         name: 'test'
       }
@@ -254,7 +256,8 @@ describe('createFigurePayload', () => {
       workflow_name: 'test',
       inputs: {
         "1": "this is a query",
-        "2": JSON.stringify(["foo", "bar"])
+        "2": JSON.stringify(["foo", "bar"]),
+        "3": JSON.stringify({key: "value"})
       }
     })
   })

--- a/timur/test/javascript/selectors/query_selectors.test.ts
+++ b/timur/test/javascript/selectors/query_selectors.test.ts
@@ -4,7 +4,8 @@ import {
   selectMatrixAttributes,
   stepIsOneToMany,
   pathToColumn,
-  getPath
+  getPath,
+  createFigurePayload
 } from '../../../lib/client/jsx/selectors/query_selector';
 
 const models = {
@@ -230,3 +231,31 @@ describe('stepIsOneToMany', () => {
     expect(stepIsOneToMany(models, 'labor', 'victim')).toEqual(false);
   });
 });
+
+describe('createFigurePayload', () => {
+  it('stringifies elements in the query', () => {
+    const result = createFigurePayload({
+      query: {
+        user_columns: ["foo", "bar"],
+        query: "this is a query"
+      },
+      title: "A plot",
+      workflow: {
+        inputQueryMap: {
+          "1": "query",
+          "2": "user_columns"
+        },
+        name: 'test'
+      }
+    });
+
+    expect(result).toEqual({
+      title: 'A plot',
+      workflow_name: 'test',
+      inputs: {
+        "1": "this is a query",
+        "2": JSON.stringify(["foo", "bar"])
+      }
+    })
+  })
+})


### PR DESCRIPTION
This PR attempts to close #989 and #990. I noticed on production that if you try to go from Query -> Vulcan to do any new visualiztion, the query part breaks when you click "Run" in Vulcan, now...

Probably works for existing figures that have already fetched data and the data exists in the cache. I suspect those will break if you try to modify the queries and re-run, unfortunately...

So far the PR only addresses #989 on the Timur-side of things, to make sure JSON strings are sent to Vulcan.

 - [x] Fix Vulcan query to Magma (currently throws a JSON error, I suspect because something is wrong with the token or query formulation?)

@dtm2451 , I will try to figure out a fix for #990 before Monday or on the plane, but it may (likely) be a hack that you may decide to improve later on ... 