### PR TITLE
Cs/build remove sync subtrees

### DIFF
--- a/.github/workflows/gem-etna-push.yml
+++ b/.github/workflows/gem-etna-push.yml
@@ -1,0 +1,31 @@
+name: Ruby Gem
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.5
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.5.x
+
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          REMOTE_VERSION=$(gem list ^etna$ --remote | grep -Po "\d+\.\d+\.\d+")
+          LOCAL_VERSION=$(ls *.gem | grep -Po "\d+\.\d+\.\d+")
+          [ "$REMOTE_VERSION" == "$LOCAL_VERSION" ] && exit
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/.github/workflows/gem-etna-push.yml
+++ b/.github/workflows/gem-etna-push.yml
@@ -22,6 +22,7 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          cd etna/
           gem build *.gemspec
           REMOTE_VERSION=$(gem list ^etna$ --remote | grep -Po "\d+\.\d+\.\d+")
           LOCAL_VERSION=$(ls *.gem | grep -Po "\d+\.\d+\.\d+")

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,4 @@
-name: Sync subtrees for master, and push to staging
+name: Push from master to staging
 on:
   push:
     branches:
@@ -7,13 +7,9 @@ on:
 # Ensure only one of these builds at a given time.
 concurrency:
   group: master-build
-  # do not cancel mid subtree syncing, allow it to complete before
-  # we even proceed.
-  # cancel-in-progress: false
-
 
 jobs:
-  sync-subtrees:
+  push-staging:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,20 +32,9 @@ jobs:
         with:
           token: ${{ secrets.SYNC_ACCESS_TOKEN }}
           fetch-depth: 0
-          path: tmp/subtrees
-      - name:  sync-subtrees
+      - name: push-staging
         env:
           IS_CI: 1
         run: |
-          cd tmp/subtrees
-          git config --global user.name 'GithubAction'
-          git config --global user.email 'mountetna@users.noreply.github.com'
-          git config --global core.mergeoptions --no-edit
-          bin/pull-subtrees master
-          bin/push-subtrees master
-          bin/pull-subtrees master
           git push
           git push origin HEAD:staging --force
-
-
-

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,13 +28,4 @@ jobs:
           NO_TEST: 1
         run: |
           make -j 4 release
-      - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
-          fetch-depth: 0
-      - name: push-staging
-        env:
-          IS_CI: 1
-        run: |
-          git push
           git push origin HEAD:staging --force


### PR DESCRIPTION
As we talked about yesterday, this PR removes the subtree syncing to improve build / CI performance. This means that the individual app repos will not be updated, but no one uses those for their workflow anyways ... so basically they will be deprecated.