### PR TITLE
try using v1 of checkout?

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
           NO_TEST: 1
         run: |
           make -j 4 release
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to staging branch

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,5 +36,4 @@ jobs:
           git config --global user.name 'GithubAction'
           git config --global user.email 'mountetna@users.noreply.github.com'
           git config --global core.mergeoptions --no-edit
-          git commit -m "Empty commit to trigger staging images build on merge" --allow-empty
           git push origin HEAD:staging --force


### PR DESCRIPTION
From this comment thread:

https://github.com/ad-m/github-push-action/issues/32

In lieu of using a PAT, seeing if v1 of the checkout action works with `GITHUB_TOKEN` to trigger downstream actions.