### PR TITLE
consolidate to single action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,11 @@ concurrency:
 jobs:
   push-staging:
     runs-on: ubuntu-latest
+    env:
+      IS_CI: 1
+      PUSH_IMAGES: 1
+      IMAGES_PREFIX: etnaagent/
+      NO_TEST: 1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,19 +26,13 @@ jobs:
         run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
       - name: Build & Push master tag images to dockerhub
         env:
-          IS_CI: 1
-          PUSH_IMAGES: 1
-          IMAGES_PREFIX: etnaagent/
           IMAGES_POSTFIX: :master
-          NO_TEST: 1
         run: |
           make -j 4 release
-      - uses: actions/checkout@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push to staging branch
-        run: |
-          git config --global user.name 'GithubAction'
-          git config --global user.email 'mountetna@users.noreply.github.com'
-          git config --global core.mergeoptions --no-edit
           git push origin HEAD:staging --force
+      - name: Build & Push staging tag images to dockerhub
+        env:
+          IMAGES_POSTFIX: :staging
+        run: |
+          make -j 4 release
+          git push origin HEAD:staging-build --force

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
Apparently cannot downgrade to v1 of the checkout action for a workflow to trigger another workflow, and per [the docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), you basically can't do this without a PAT. Since the recommendation is for PATs to expire within a year (you can generate forever PATs, but not recommended), this PR just consolidates the staging image build and push to happen on merge into master, since that mimics the desired behavior...