### PR TITLE
Metis copy from magma buckets [close #997]

### DIFF
--- a/etna/lib/etna/clients/metis/workflows/sync_metis_data_workflow.rb
+++ b/etna/lib/etna/clients/metis/workflows/sync_metis_data_workflow.rb
@@ -22,26 +22,27 @@ module Etna
         end
 
         def copy_file(dest:, url:, stub: false)
-          # This does not work due to the magma bucket's restrictions, but if it did work, it'd be super sweet.
-          # url_match = DOWNLOAD_REGEX.match(url)
-          #
-          # if filesystem.instance_of?(Etna::Filesystem::Metis) && !url_match.nil?
-          #   bucket_name = url_match[:bucket_name]
-          #   project_name = url_match[:project_name]
-          #   file_path = url_match[:file_path]
-          #
-          #   metis_client.copy_files(
-          #     Etna::Clients::Metis::CopyFilesRequest.new(
-          #       project_name: project_name,
-          #       revisions: [
-          #         Etna::Clients::Metis::CopyRevision.new(
-          #           source: "metis://#{project_name}/#{bucket_name}/#{file_path}",
-          #           dest: "metis://#{filesystem.project_name}/#{filesystem.bucket_name}#{dest}",
-          #         )
-          #       ]
-          #     )
-          #   )
-          # end
+          url_match = DOWNLOAD_REGEX.match(url)
+
+          if filesystem.instance_of?(Etna::Filesystem::Metis) && !url_match.nil?
+            bucket_name = url_match[:bucket_name]
+            project_name = url_match[:project_name]
+            file_path = url_match[:file_path]
+
+            metis_client.copy_files(
+              Etna::Clients::Metis::CopyFilesRequest.new(
+                project_name: project_name,
+                revisions: [
+                  Etna::Clients::Metis::CopyRevision.new(
+                    source: "metis://#{project_name}/#{bucket_name}/#{file_path}",
+                    dest: "metis://#{filesystem.project_name}/#{filesystem.bucket_name}/#{dest}",
+                  )
+                ]
+              )
+            )
+
+            return
+          end
 
           metadata = metis_client.file_metadata(url)
           size = metadata[:size]

--- a/metis/lib/models/bucket.rb
+++ b/metis/lib/models/bucket.rb
@@ -15,6 +15,8 @@ class Metis
       guest: 3
     }
 
+    READ_ONLY_BUCKETS = ['magma']
+
     def self.valid_bucket_name?(bucket_name)
       !!(bucket_name =~ /\A\w+\z/)
     end

--- a/metis/lib/server/controllers/file_controller.rb
+++ b/metis/lib/server/controllers/file_controller.rb
@@ -166,10 +166,13 @@ class FileController < Metis::Controller
     revision_bucket_folders = {}
 
     # The only read-only buckets that have the name matching
-    #   the owner should be from other apps, i.e. Magma
+    #   the owner should be from other apps, i.e. Magma.
+    # Also restrict this to magma bucket within the same project,
+    #   so you cannot copy out of another project.
     read_only_buckets = Metis::Bucket.where(
       owner: Metis::Bucket::READ_ONLY_BUCKETS,
-      name: Metis::Bucket::READ_ONLY_BUCKETS
+      name: Metis::Bucket::READ_ONLY_BUCKETS,
+      project_name: @params[:project_name]
     ).all
 
     revisions.each do |rev|

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -373,6 +373,13 @@ only breath, words
 which I command
 are immortal
 EOT
+MAGMA_WISDOM=<<EOT
+Although they are
+only breath, words
+which I command
+are immortal
+-- (c) Magma
+EOT
 HELMET=<<EOT
   xXx
  xO|Ox
@@ -424,6 +431,11 @@ def default_bucket(project_name)
     stubs.create_bucket(project_name, 'files')
     create( :bucket, project_name: project_name, name: 'files', owner: 'metis', access: 'viewer')
   end
+end
+
+def create_read_only_bucket(project_name, bucket_name)
+  stubs.create_bucket(project_name, bucket_name)
+  create( :bucket, project_name: project_name, name: bucket_name, owner: bucket_name, access: 'administrator')
 end
 
 def create_upload(project_name, file_name, uid, params={})

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -380,6 +380,13 @@ which I command
 are immortal
 -- (c) Magma
 EOT
+BACKUP_WISDOM=<<EOT
+Although they are
+only breath, words
+which I command
+are immortal
+-- copy
+EOT
 HELMET=<<EOT
   xXx
  xO|Ox

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -442,7 +442,7 @@ end
 
 def create_read_only_bucket(project_name, bucket_name)
   stubs.create_bucket(project_name, bucket_name)
-  create( :bucket, project_name: project_name, name: bucket_name, owner: bucket_name, access: 'administrator')
+  create( :bucket, project_name: project_name, name: bucket_name, owner: bucket_name, access: 'viewer')
 end
 
 def create_upload(project_name, file_name, uid, params={})


### PR DESCRIPTION
This PR updates Metis's `file_controller#bulk_copy` endpoint, to allow the following behavior:

* Copy files out of the `magma` bucket into somewhere else in the same project.
* Copy files out of the `magma` bucket into some other project, where you have permissions.
* Use of the Timur UI to upload new files.
* Use of the Timur UI to link files via the Metis path.

This should **not** allow the following behavior:

* Copy files **into** the `magma` bucket for the same project.
* Copy files **out of** a different project's `magma` bucket, if you do not have permissions for that project.

I have tested this manually and it seems to behave as expected. Also includes some new specs to verify.

CI seems to be dying due to some issue between GH and the Docker registry ... so will try kicking that again later / next week?
