### PR TITLE
do not allow user to remove all where clauses [close #1004]

### DIFF
--- a/timur/lib/client/jsx/components/query/query_filter_clause.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_clause.tsx
@@ -24,7 +24,7 @@ const QueryFilterClause = ({
   isColumnFilter,
   waitTime,
   eager,
-  canRemove,
+  showRemoveIcon,
   patchClause,
   removeClause
 }: {
@@ -35,7 +35,7 @@ const QueryFilterClause = ({
   isColumnFilter: boolean;
   waitTime?: number;
   eager?: boolean;
-  canRemove: boolean;
+  showRemoveIcon: boolean;
   patchClause: (clause: QueryClause) => void;
   removeClause: () => void;
 }) => {
@@ -235,13 +235,11 @@ const QueryFilterClause = ({
         ) : null}
       </Grid>
       <Grid item xs={1} container justify='flex-end'>
-        {canRemove ? (
-          <RemoveIcon
-            canEdit={!isColumnFilter}
-            onClick={removeClause}
-            label='clause'
-          />
-        ) : null}
+        <RemoveIcon
+          showRemoveIcon={showRemoveIcon}
+          onClick={removeClause}
+          label='clause'
+        />
       </Grid>
     </Grid>
   );

--- a/timur/lib/client/jsx/components/query/query_filter_clause.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_clause.tsx
@@ -24,6 +24,7 @@ const QueryFilterClause = ({
   isColumnFilter,
   waitTime,
   eager,
+  canRemove,
   patchClause,
   removeClause
 }: {
@@ -34,6 +35,7 @@ const QueryFilterClause = ({
   isColumnFilter: boolean;
   waitTime?: number;
   eager?: boolean;
+  canRemove: boolean;
   patchClause: (clause: QueryClause) => void;
   removeClause: () => void;
 }) => {
@@ -233,11 +235,13 @@ const QueryFilterClause = ({
         ) : null}
       </Grid>
       <Grid item xs={1} container justify='flex-end'>
-        <RemoveIcon
-          canEdit={!isColumnFilter}
-          onClick={removeClause}
-          label='clause'
-        />
+        {canRemove ? (
+          <RemoveIcon
+            canEdit={!isColumnFilter}
+            onClick={removeClause}
+            label='clause'
+          />
+        ) : null}
       </Grid>
     </Grid>
   );

--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -149,7 +149,9 @@ const QueryFilterControl = ({
                         handlePatchClause(updatedClause, index)
                       }
                       removeClause={() => handleRemoveClause(index)}
-                      canRemove={!(0 === index && 1 === filter.clauses.length)}
+                      showRemoveIcon={
+                        !(0 === index && 1 === filter.clauses.length)
+                      }
                     />
                   </Grid>
                 </Grid>
@@ -171,7 +173,11 @@ const QueryFilterControl = ({
       </Grid>
       <Grid item xs={1} container justify='flex-end'>
         <CopyIcon canEdit={true} onClick={copyFilter} label='filter' />
-        <RemoveIcon canEdit={true} onClick={removeFilter} label='filter' />
+        <RemoveIcon
+          showRemoveIcon={true}
+          onClick={removeFilter}
+          label='filter'
+        />
       </Grid>
     </>
   );

--- a/timur/lib/client/jsx/components/query/query_filter_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_control.tsx
@@ -149,6 +149,7 @@ const QueryFilterControl = ({
                         handlePatchClause(updatedClause, index)
                       }
                       removeClause={() => handleRemoveClause(index)}
+                      canRemove={!(0 === index && 1 === filter.clauses.length)}
                     />
                   </Grid>
                 </Grid>

--- a/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
+++ b/timur/lib/client/jsx/components/query/query_model_attribute_selector.tsx
@@ -236,7 +236,7 @@ const QueryModelAttributeSelector = React.memo(
           <Grid item container justify='flex-end' xs={1}>
             <CopyIcon canEdit={canEdit} onClick={onCopyColumn} label='column' />
             <RemoveIcon
-              canEdit={canEdit}
+              showRemoveIcon={canEdit}
               onClick={onRemoveColumn}
               label='column'
             />

--- a/timur/lib/client/jsx/components/query/query_remove_icon.tsx
+++ b/timur/lib/client/jsx/components/query/query_remove_icon.tsx
@@ -6,15 +6,15 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 const RemoveIcon = React.memo(
   ({
-    canEdit,
+    showRemoveIcon,
     onClick,
     label
   }: {
-    canEdit: boolean;
+    showRemoveIcon: boolean;
     onClick: () => void;
     label: string;
   }) => {
-    if (!canEdit) return null;
+    if (!showRemoveIcon) return null;
 
     return (
       <Tooltip title={`Remove ${label}`} aria-label={`remove ${label}`}>

--- a/timur/lib/client/jsx/components/query/query_slice_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_control.tsx
@@ -39,7 +39,7 @@ const QuerySliceControl = ({
           modelNames={modelNames}
           isColumnFilter={true}
           patchClause={handlePatchClause}
-          removeClause={removeSlice}
+          removeClause={() => {}}
           showRemoveIcon={false}
         />
       </Grid>

--- a/timur/lib/client/jsx/components/query/query_slice_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_control.tsx
@@ -39,12 +39,12 @@ const QuerySliceControl = ({
           modelNames={modelNames}
           isColumnFilter={true}
           patchClause={handlePatchClause}
-          removeClause={() => {}}
-          canRemove={false}
+          removeClause={removeSlice}
+          showRemoveIcon={false}
         />
       </Grid>
       <Grid item xs={1} container justify='flex-end'>
-        <RemoveIcon canEdit={true} onClick={removeSlice} label='slice' />
+        <RemoveIcon showRemoveIcon={true} onClick={removeSlice} label='slice' />
       </Grid>
     </>
   );

--- a/timur/lib/client/jsx/components/query/query_slice_control.tsx
+++ b/timur/lib/client/jsx/components/query/query_slice_control.tsx
@@ -40,6 +40,7 @@ const QuerySliceControl = ({
           isColumnFilter={true}
           patchClause={handlePatchClause}
           removeClause={() => {}}
+          canRemove={false}
         />
       </Grid>
       <Grid item xs={1} container justify='flex-end'>

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -525,33 +525,7 @@ exports[`QueryBuilder renders with Plot button 1`] = `
                             </div>
                             <div
                               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
-                            >
-                              <button
-                                aria-label="remove clause"
-                                class="MuiButtonBase-root MuiIconButton-root"
-                                tabindex="0"
-                                title="Remove clause"
-                                type="button"
-                              >
-                                <span
-                                  class="MuiIconButton-label"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorAction"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </button>
-                            </div>
+                            />
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
This PR removes the "remove clause" icon from the Where filters in Timur Query, when there is one and only one clause in a given filter. As noted in #1004, previously, if a user clicked the "x" and tried removing the last clause, the app would crash with a white-screen. 