### PR TITLE
style the query dropdowns a bit; [close #996]

### DIFF
--- a/timur/lib/client/jsx/components/query/query_filter_clause.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_clause.tsx
@@ -18,9 +18,15 @@ import RemoveIcon from './query_remove_icon';
 import Selector from './query_selector';
 
 const useStyles = makeStyles((theme) => ({
-  popper: {
+  option: {
     width: 'max-content',
     whiteSpace: 'nowrap'
+  },
+  listbox: {
+    width: 'max-content'
+  },
+  paper: {
+    width: 'max-content'
   }
 }));
 
@@ -218,9 +224,9 @@ const QueryFilterClause = ({
             distinctAttributeValues.length > 0 ? (
               <Autocomplete
                 classes={{
-                  option: classes.popper,
-                  listbox: classes.popper,
-                  paper: classes.popper
+                  option: classes.option,
+                  listbox: classes.listbox,
+                  paper: classes.paper
                 }}
                 id={uniqId(`operand-${clauseIndex}`)}
                 freeSolo

--- a/timur/lib/client/jsx/components/query/query_filter_clause.tsx
+++ b/timur/lib/client/jsx/components/query/query_filter_clause.tsx
@@ -6,6 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+import {makeStyles} from '@material-ui/core/styles';
 
 import {Debouncer} from 'etna-js/utils/debouncer';
 import {QueryClause} from '../../contexts/query/query_types';
@@ -15,6 +16,13 @@ import useQueryClause from './query_use_query_clause';
 import {QueryGraph} from '../../utils/query_graph';
 import RemoveIcon from './query_remove_icon';
 import Selector from './query_selector';
+
+const useStyles = makeStyles((theme) => ({
+  popper: {
+    width: 'max-content',
+    whiteSpace: 'nowrap'
+  }
+}));
 
 const QueryFilterClause = ({
   clause,
@@ -49,6 +57,7 @@ const QueryFilterClause = ({
   const [debouncer, setDebouncer] = useState(
     () => new Debouncer({windowMs: waitTime, eager})
   );
+  const classes = useStyles();
 
   // Clear the existing debouncer and accept any new changes to the settings
   useEffect(() => {
@@ -208,6 +217,11 @@ const QueryFilterClause = ({
             {filterOperator.hasPrepopulatedOperandOptions() &&
             distinctAttributeValues.length > 0 ? (
               <Autocomplete
+                classes={{
+                  option: classes.popper,
+                  listbox: classes.popper,
+                  paper: classes.popper
+                }}
                 id={uniqId(`operand-${clauseIndex}`)}
                 freeSolo
                 fullWidth


### PR DESCRIPTION
This PR tweaks the Autocomplete styling a little bit for the pre-populated string values (i.e. table names, population names, etc.). Removes the word wrapping and widens the dropdown option box, so that each option is on a single line, and you can see the entire line at once.

Before:
![signal-2022-09-13-100442_003](https://user-images.githubusercontent.com/4930129/189923242-7bce1e9d-e101-486d-9c51-e84dc20f7637.jpeg)

After:
![signal-2022-09-13-100442_002](https://user-images.githubusercontent.com/4930129/189923269-43359e21-e17a-4289-b099-20fd7afd0834.jpeg)
