### PR TITLE
Airflow docker operator placement constraints [close #1031]

### DIFF
--- a/airflow/opt/providers/etna/etna/operators/__init__.py
+++ b/airflow/opt/providers/etna/etna/operators/__init__.py
@@ -30,7 +30,7 @@ def run_on_docker(
     cpu_reservation: Optional[int] = None,
     mem_reservation: Optional[int] = None,
     allow_manager_nodes=False,
-    constraints: Optional[List[str]] = None,
+    additional_constraints: Optional[List[str]] = None,
 ) -> DockerOperatorBase:
     if os.environ.get("DEV_MODE"):
         return run_in_container(
@@ -56,7 +56,7 @@ def run_on_docker(
         cpu_reservation=cpu_reservation,
         mem_reservation=mem_reservation,
         mem_limit=mem_limit,
-        constraints=constraints
+        additional_constraints=additional_constraints
     )
 
 
@@ -76,7 +76,7 @@ def run_in_swarm(
     cpu_reservation: Optional[int] = None,
     mem_reservation: Optional[int] = None,
     allow_manager_nodes=False,
-    constraints: Optional[List[str]] = None,
+    additional_constraints: Optional[List[str]] = None,
 ) -> DockerSwarmOperator:
     serialize_last_output = _prepare_input_outputs(output_b64, output_json)
 
@@ -93,7 +93,7 @@ def run_in_swarm(
         cpu_reservation=cpu_reservation,
         mem_reservation=mem_reservation,
         mem_limit=mem_limit,
-        constraints=constraints
+        additional_constraints=additional_constraints
     )
 
 

--- a/airflow/opt/providers/etna/etna/operators/__init__.py
+++ b/airflow/opt/providers/etna/etna/operators/__init__.py
@@ -30,6 +30,7 @@ def run_on_docker(
     cpu_reservation: Optional[int] = None,
     mem_reservation: Optional[int] = None,
     allow_manager_nodes=False,
+    constraints: Optional[List[str]] = None,
 ) -> DockerOperatorBase:
     if os.environ.get("DEV_MODE"):
         return run_in_container(
@@ -55,6 +56,7 @@ def run_on_docker(
         cpu_reservation=cpu_reservation,
         mem_reservation=mem_reservation,
         mem_limit=mem_limit,
+        constraints=constraints
     )
 
 
@@ -74,6 +76,7 @@ def run_in_swarm(
     cpu_reservation: Optional[int] = None,
     mem_reservation: Optional[int] = None,
     allow_manager_nodes=False,
+    constraints: Optional[List[str]] = None,
 ) -> DockerSwarmOperator:
     serialize_last_output = _prepare_input_outputs(output_b64, output_json)
 
@@ -90,6 +93,7 @@ def run_in_swarm(
         cpu_reservation=cpu_reservation,
         mem_reservation=mem_reservation,
         mem_limit=mem_limit,
+        constraints=constraints
     )
 
 

--- a/airflow/opt/providers/etna/etna/operators/swarm_operator.py
+++ b/airflow/opt/providers/etna/etna/operators/swarm_operator.py
@@ -58,6 +58,7 @@ def create_service_definition(
     local_network_ids: Optional[Set[str]] = None,
     allow_manager_nodes: Optional[bool] = False,
     resources: Optional[Resources] = None,
+    constraints: Optional[List[str]] = None,
 ) -> SwarmServiceDefinition:
 
     spec = data["Spec"]
@@ -76,6 +77,9 @@ def create_service_definition(
         ]
         constraints.append("node.role!=manager")
         placement["Constraints"] = constraints
+
+    if constraints is not None:
+        placement["Constraints"] += constraints
 
     return SwarmServiceDefinition(
         image=container_spec["Image"],
@@ -169,6 +173,7 @@ class DockerSwarmOperator(DockerOperatorBase):
     mem_limit: Optional[int]
     cpu_reservation: Optional[int]
     mem_reservation: Optional[int]
+    constraints: Optional[List[str]]
 
     def __init__(
             self,
@@ -182,6 +187,7 @@ class DockerSwarmOperator(DockerOperatorBase):
         mem_limit: Optional[int] = None,
         cpu_reservation: Optional[int] = None,
         mem_reservation: Optional[int] = None,
+        constraints: Optional[List[str]] = None,
         **kwds,
     ):
         self.mem_reservation = mem_reservation
@@ -191,6 +197,7 @@ class DockerSwarmOperator(DockerOperatorBase):
         self.source_service = source_service
         self.include_external_networks = include_external_networks
         self.allow_manager_nodes = allow_manager_nodes
+        self.constraints = constraints
         super(DockerSwarmOperator, self).__init__(*args, **kwds)
 
     def _start_task(self):
@@ -204,6 +211,7 @@ class DockerSwarmOperator(DockerOperatorBase):
             service_data,
             local_network_ids,
             allow_manager_nodes=self.allow_manager_nodes,
+            constraints=self.constraints,
             resources=Resources(
                 cpu_limit=self.cpu_limit,
                 cpu_reservation=self.cpu_reservation,

--- a/airflow/opt/providers/etna/etna/operators/swarm_operator.py
+++ b/airflow/opt/providers/etna/etna/operators/swarm_operator.py
@@ -58,7 +58,7 @@ def create_service_definition(
     local_network_ids: Optional[Set[str]] = None,
     allow_manager_nodes: Optional[bool] = False,
     resources: Optional[Resources] = None,
-    constraints: Optional[List[str]] = None,
+    additional_constraints: Optional[List[str]] = None,
 ) -> SwarmServiceDefinition:
 
     spec = data["Spec"]
@@ -78,8 +78,8 @@ def create_service_definition(
         constraints.append("node.role!=manager")
         placement["Constraints"] = constraints
 
-    if constraints is not None:
-        placement["Constraints"] += constraints
+    if additional_constraints is not None:
+        placement["Constraints"] += additional_constraints
 
     return SwarmServiceDefinition(
         image=container_spec["Image"],
@@ -173,7 +173,7 @@ class DockerSwarmOperator(DockerOperatorBase):
     mem_limit: Optional[int]
     cpu_reservation: Optional[int]
     mem_reservation: Optional[int]
-    constraints: Optional[List[str]]
+    additional_constraints: Optional[List[str]]
 
     def __init__(
             self,
@@ -187,7 +187,7 @@ class DockerSwarmOperator(DockerOperatorBase):
         mem_limit: Optional[int] = None,
         cpu_reservation: Optional[int] = None,
         mem_reservation: Optional[int] = None,
-        constraints: Optional[List[str]] = None,
+        additional_constraints: Optional[List[str]] = None,
         **kwds,
     ):
         self.mem_reservation = mem_reservation
@@ -197,7 +197,7 @@ class DockerSwarmOperator(DockerOperatorBase):
         self.source_service = source_service
         self.include_external_networks = include_external_networks
         self.allow_manager_nodes = allow_manager_nodes
-        self.constraints = constraints
+        self.additional_constraints = additional_constraints
         super(DockerSwarmOperator, self).__init__(*args, **kwds)
 
     def _start_task(self):

--- a/airflow/opt/providers/etna/etna/operators/swarm_operator.py
+++ b/airflow/opt/providers/etna/etna/operators/swarm_operator.py
@@ -211,7 +211,7 @@ class DockerSwarmOperator(DockerOperatorBase):
             service_data,
             local_network_ids,
             allow_manager_nodes=self.allow_manager_nodes,
-            constraints=self.constraints,
+            additional_constraints=self.additional_constraints,
             resources=Resources(
                 cpu_limit=self.cpu_limit,
                 cpu_reservation=self.cpu_reservation,


### PR DESCRIPTION
This PR adds in an argument to supplement the Docker Swarm ETLs with additional constraints. The idea will be that app services (like `polyphemus_app`) can have a set of constraints in the main service definition, but when we run ETLs in Airflow, we may need additional constraints (i.e. sync files to a partner may require using specific nodes with allowed IP addresses). This is detailed in #1031. 

I opted to add additional constraints to the Airflow service definition instead of just overwriting them, because the main app service defintions may have some core constraints that we want to keep (i.e. having the `/data3` NFS mount available). I don't think there would be scenarios where we would want to run a Swarm ETL without those core service constraints...