### PR TITLE
Metis issue 1036

### DIFF
--- a/metis/lib/client/jsx/actions/message_actions.jsx
+++ b/metis/lib/client/jsx/actions/message_actions.jsx
@@ -1,14 +1,18 @@
 export const message = (message_type, title, message) => ({
   type: 'SHOW_DIALOG',
-  dialog: { type: 'message', title, message, message_type }
-})
+  dialog: {type: 'message', title, message, message_type}
+});
 
-export const errorMessage = (dispatch, message_type, title, message_handler) =>
-  response => {
+export const errorMessage =
+  (dispatch, message_type, title, message_handler) => (response) => {
     if (response instanceof Promise)
-      response.then(
-        ({error}) => dispatch(message(message_type, title, message_handler(error)))
-      )
-    else
-      dispatch(message(message_type, title, message_handler(response)))
+      response.then(({error, errors}) => {
+        let msg = error;
+        if (errors) {
+          msg = errors.join('\n');
+        }
+
+        dispatch(message(message_type, title, message_handler(msg)));
+      });
+    else dispatch(message(message_type, title, message_handler(response)));
   };

--- a/metis/lib/folder_rename_revision.rb
+++ b/metis/lib/folder_rename_revision.rb
@@ -22,5 +22,47 @@ class Metis
 
       return source_folder
     end
+
+    def validate
+      super
+      validate_non_recursive_rename
+    end
+
+    private
+
+    def validate_non_recursive_rename
+      return unless dest_path_inside_source
+
+      @errors << "Cannot copy folder into itself: \"#{@source.mpath.path}\""
+    end
+
+    def dest_path_inside_source
+      # Copying from root-to-root is okay
+      return false if @source.folder.nil? && @dest.folder.nil?
+
+      # Copying from some subfolder to root is okay
+      return false if @dest.folder.nil?
+      # Not okay where the source folder is a root folder and is the dest folder
+      return @dest.folder.folder_name == @source.mpath.file_name && @dest.folder.folder.nil? if @source.folder.nil?
+
+      # Should return `true` if source is a folder, and it
+      #   lies anywhere on the path of @dest.folder up to root,
+      #   or source_folder == @dest.folder (which is parent of the final dest)
+      @dest.folder == source_folder || @dest.folder.parent_folders.include?(source_folder)
+    end
+
+    def source_folder
+      # source_folder is the @source.mpath.file_name as a Metis::Folder
+      # If we get here past the other validations, there should
+      #   be a Metis::Folder.
+      query_params = {
+        folder_name: @source.mpath.file_name,
+        project_name: @source.mpath.project_name,
+        bucket: @source.bucket
+      }
+      query_params[:folder] = @source.folder unless @source.folder.nil?
+
+      Metis::Folder.where(*query_params).first
+    end
   end
 end

--- a/metis/lib/server/controllers/folder_controller.rb
+++ b/metis/lib/server/controllers/folder_controller.rb
@@ -22,7 +22,7 @@ class FolderController < Metis::Controller
     raise Etna::BadRequest, "Invalid folder: #{@params[:folder_path]}" unless folder
 
     raise Etna::Forbidden, 'Folder is read-only' if folder.read_only?
-    
+
     folder.update(updated_at: Time.now, author: Metis::File.author(@user))
     folder.refresh
 

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -808,6 +808,22 @@ describe FolderController do
       expect(@helmet_folder.folders).to eq([])
     end
 
+    it 'refuses to move a folder into itself' do
+      @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet')
+
+      @sketches_folder = create_folder('athena', 'sketches', folder: @helmet_folder)
+      stubs.create_folder('athena', 'files', 'blueprints/helmet/sketches')
+
+      token_header(:editor)
+      rename_folder('blueprints/helmet/sketches', 'blueprints/helmet/sketches/sketches')
+
+      expect(last_response.status).to eq(422)
+      @sketches_folder.refresh
+      expect(@sketches_folder.folder_path).to eq(['blueprints', 'helmet', 'sketches'])
+      expect(@sketches_folder.id).not_to eq(@sketches_folder.folder_id)
+    end
+
     it 'refuses to move a sub-folder to a non-existent tree' do
       @helmet_folder = create_folder('athena', 'helmet', folder: @blueprints_folder)
       stubs.create_folder('athena', 'files', 'blueprints/helmet')


### PR DESCRIPTION
This PR closes #1036.

It raises an error when a user tries to rename (i.e. move in the UI) a folder into either the same folder or a child of that folder, which results in a cyclic portion of the folder hierarchy that is not viewable from the UI.

You can test the prior behavior locally by using the UI, and "moving" a folder into either itself or a child folder, i.e.

![Screenshot from 2022-09-19 09-29-57](https://user-images.githubusercontent.com/4930129/191028725-4b70af39-c98a-499f-bf34-72feae75f553.png)

Without this PR, Metis will allow this behavior, and the folder will be gone and un-findable in the UI. In the database, you'll see that its `folder_id` refers to itself:

```
=> #<Metis::Folder @values={:id=>1, :project_name=>"ipi", :folder_name=>"test-files", :bucket_id=>3, :folder_id=>1, :read_only=>false, :author=>"developer@ucsf.edu|DeveloperPerson", :created_at=>2022-08-11 15:57:37.622943 +0000, :updated_at=>2022-09-19 13:38:32.826587 +0000}>
```

Which makes it disappear from the UI, and you can only fix this manually in the console or database.

So this PR does a check when doing a folder rename, that the original folder itself does not lie anywhere along the parent path of the new, proposed destination folder. This prevents any sort of cyclic change, and throws an exception instead.

This also fixes the error message handling in the UI so the error reason is rendered for the user. Previously the text of the message(s) was blank.

![Screenshot from 2022-09-19 09-45-15](https://user-images.githubusercontent.com/4930129/191031926-63b2b6a8-4c2c-4606-87fd-316556c90c5f.png)
