### PR TITLE
fix UI query builder for matrices and subclause format; [close #1047]

### DIFF
--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -216,8 +216,13 @@ export const attributeIsFile = (
   ]);
 };
 
-export const isMatrixSlice = (slice: QuerySlice) =>
-  '::slice' === slice.clause.operator;
+export const isMatrixSlice = (slice: QuerySlice) => {
+  if (!slice.clause.subclauses) return false;
+
+  return slice.clause.subclauses.some((subclause) => {
+    return '::slice' === subclause.operator;
+  });
+};
 
 export const hasMatrixSlice = (column: QueryColumn) => {
   return column.slices.some((slice) => isMatrixSlice(slice));
@@ -234,9 +239,16 @@ export const queryColumnMatrixHeadings = (column: QueryColumn) => {
   return column.slices
     .filter((slice) => isMatrixSlice(slice))
     .map((slice) => {
-      return (slice.clause.operand as string).split(',');
+      if (!slice.clause.subclauses) return null;
+
+      return (
+        slice.clause.subclauses.find((subclause) => {
+          return '::slice' === subclause.operator;
+        })?.operand as string
+      ).split(',');
     })
-    .flat();
+    .flat()
+    .filter((value) => null != value);
 };
 
 export const isIdentifierQuery = (

--- a/timur/lib/client/jsx/selectors/query_selector.ts
+++ b/timur/lib/client/jsx/selectors/query_selector.ts
@@ -235,17 +235,19 @@ export const emptyQueryClauseStamp = (modelName: string) => {
   };
 };
 
-export const queryColumnMatrixHeadings = (column: QueryColumn) => {
+export const queryColumnMatrixHeadings = (column: QueryColumn): string[] => {
   return column.slices
     .filter((slice) => isMatrixSlice(slice))
     .map((slice) => {
-      if (!slice.clause.subclauses) return null;
-
       return (
-        slice.clause.subclauses.find((subclause) => {
-          return '::slice' === subclause.operator;
-        })?.operand as string
-      ).split(',');
+        // Given the above isMatrixSlice filter, slice.clause.subclauses
+        //   should always exist, but this makes tsc happy.
+        (
+          (slice.clause.subclauses || []).find((subclause) => {
+            return '::slice' === subclause.operator;
+          })?.operand as string
+        ).split(',')
+      );
     })
     .flat()
     .filter((value) => null != value);

--- a/timur/lib/client/jsx/utils/query_builder.ts
+++ b/timur/lib/client/jsx/utils/query_builder.ts
@@ -300,7 +300,6 @@ export class QueryBuilder {
     let includeAttributeName = true;
 
     matchingSlices.forEach((matchingSlice: QuerySlice) => {
-      console.log('matchingSlice', matchingSlice, isMatrixSlice(matchingSlice));
       if (isMatrixSlice(matchingSlice)) {
         // For matrices (i.e. ::slice), we'll construct it
         //   a little differently.

--- a/timur/lib/client/jsx/utils/query_builder.ts
+++ b/timur/lib/client/jsx/utils/query_builder.ts
@@ -300,6 +300,7 @@ export class QueryBuilder {
     let includeAttributeName = true;
 
     matchingSlices.forEach((matchingSlice: QuerySlice) => {
+      console.log('matchingSlice', matchingSlice, isMatrixSlice(matchingSlice));
       if (isMatrixSlice(matchingSlice)) {
         // For matrices (i.e. ::slice), we'll construct it
         //   a little differently.

--- a/timur/test/javascript/components/query/query_results.test.tsx
+++ b/timur/test/javascript/components/query/query_results.test.tsx
@@ -71,10 +71,14 @@ describe('QueryResults', () => {
             {
               modelName: 'prize',
               clause: {
-                attributeName: 'name',
-                operator: '::equals',
-                operand: 'Athens',
-                attributeType: 'text',
+                subclauses: [
+                  {
+                    attributeName: 'name',
+                    operator: '::equals',
+                    operand: 'Athens',
+                    attributeType: 'text'
+                  }
+                ],
                 modelName: 'prize',
                 any: true
               }
@@ -91,10 +95,14 @@ describe('QueryResults', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'year',
-              operator: '::equals',
-              operand: 2,
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'year',
+                  operator: '::equals',
+                  operand: 2,
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -149,10 +157,14 @@ describe('QueryResults', () => {
             {
               modelName: 'prize',
               clause: {
-                attributeName: 'name',
-                operator: '::equals',
-                operand: 'Athens',
-                attributeType: 'text',
+                subclauses: [
+                  {
+                    attributeName: 'name',
+                    operator: '::equals',
+                    operand: 'Athens',
+                    attributeType: 'text'
+                  }
+                ],
                 modelName: 'prize',
                 any: true
               }
@@ -167,10 +179,14 @@ describe('QueryResults', () => {
             {
               modelName: 'labor',
               clause: {
-                attributeName: 'contributions',
-                operator: '::slice',
-                operand: 'Athens,Sparta',
-                attributeType: 'matrix',
+                subclauses: [
+                  {
+                    attributeName: 'contributions',
+                    operator: '::slice',
+                    operand: 'Athens,Sparta',
+                    attributeType: 'matrix'
+                  }
+                ],
                 modelName: 'labor',
                 any: true
               }
@@ -187,10 +203,14 @@ describe('QueryResults', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'year',
-              operator: '::equals',
-              operand: 2,
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'year',
+                  operator: '::equals',
+                  operand: 2,
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }

--- a/timur/test/javascript/components/query/query_use_table_effects.test.tsx
+++ b/timur/test/javascript/components/query/query_use_table_effects.test.tsx
@@ -127,10 +127,14 @@ describe('useTableEffects', () => {
             {
               modelName: 'labor',
               clause: {
-                attributeName: 'contributions',
-                operator: '::slice',
-                operand: 'Athens,Sparta',
-                attributeType: 'matrix',
+                subclauses: [
+                  {
+                    attributeName: 'contributions',
+                    operator: '::slice',
+                    operand: 'Athens,Sparta',
+                    attributeType: 'matrix'
+                  }
+                ],
                 modelName: 'labor',
                 any: true
               }
@@ -205,10 +209,14 @@ describe('useTableEffects', () => {
             {
               modelName: 'labor',
               clause: {
-                attributeName: 'contributions',
-                operator: '::slice',
-                operand: 'Athens,Sparta',
-                attributeType: 'matrix',
+                subclauses: [
+                  {
+                    attributeName: 'contributions',
+                    operator: '::slice',
+                    operand: 'Athens,Sparta',
+                    attributeType: 'matrix'
+                  }
+                ],
                 modelName: 'labor',
                 any: true
               }
@@ -282,10 +290,14 @@ describe('useTableEffects', () => {
             {
               modelName: 'labor',
               clause: {
-                attributeName: 'contributions',
-                operator: '::slice',
-                operand: 'Sparta,Athens',
-                attributeType: 'matrix',
+                subclauses: [
+                  {
+                    attributeName: 'contributions',
+                    operator: '::slice',
+                    operand: 'Sparta,Athens',
+                    attributeType: 'matrix'
+                  }
+                ],
                 modelName: 'labor',
                 any: true
               }
@@ -360,10 +372,14 @@ describe('useTableEffects', () => {
             {
               modelName: 'prize',
               clause: {
-                attributeName: 'name',
-                operator: '::equals',
-                operand: 'Athens',
-                attributeType: 'text',
+                subclauses: [
+                  {
+                    attributeName: 'name',
+                    operator: '::equals',
+                    operand: 'Athens',
+                    attributeType: 'text'
+                  }
+                ],
                 modelName: 'prize',
                 any: true
               }
@@ -378,10 +394,14 @@ describe('useTableEffects', () => {
             {
               modelName: 'prize',
               clause: {
-                attributeName: 'name',
-                operator: '::equals',
-                operand: 'Sparta',
-                attributeType: 'text',
+                subclauses: [
+                  {
+                    attributeName: 'name',
+                    operator: '::equals',
+                    operand: 'Sparta',
+                    attributeType: 'text'
+                  }
+                ],
                 modelName: 'prize',
                 any: true
               }

--- a/timur/test/javascript/fixtures/template_victim.json
+++ b/timur/test/javascript/fixtures/template_victim.json
@@ -68,6 +68,20 @@
       "hidden": false,
       "validation": null,
       "attribute_type": "table"
+    },
+    "weapons": {
+      "name": "weapons",
+      "attribute_name": "weapons",
+      "display_name": "weapons",
+      "options": ["sword", "spear", "sling", "hands"],
+      "restricted": false,
+      "read_only": false,
+      "hidden": false,
+      "validation": {
+        "type": "Array",
+        "value": ["sword", "spear", "sling", "hands"]
+      },
+      "attribute_type": "matrix"
     }
   },
   "identifier": "name",

--- a/timur/test/javascript/utils/query_builder.spec.ts
+++ b/timur/test/javascript/utils/query_builder.spec.ts
@@ -466,7 +466,7 @@ describe('QueryBuilder', () => {
     ]);
   });
 
-  it('adds matrix slice with multiple subclauses', () => {
+  it('adds matrix slice with multiple clauses', () => {
     builder.addRootModel('labor');
     builder.addColumns([
       stamp('labor', 'name', []),

--- a/timur/test/javascript/utils/query_builder.spec.ts
+++ b/timur/test/javascript/utils/query_builder.spec.ts
@@ -494,7 +494,7 @@ describe('QueryBuilder', () => {
                 attributeName: 'name',
                 operator: '::matches',
                 operand: 'ion',
-                attributeType: 'string'
+                attributeType: 'text'
               }
             ],
             modelName: 'monster',

--- a/timur/test/javascript/utils/query_builder.spec.ts
+++ b/timur/test/javascript/utils/query_builder.spec.ts
@@ -56,10 +56,14 @@ describe('QueryBuilder', () => {
           anyMap: {biospecimen: true, sc_seq: true},
           clauses: [
             {
-              attributeName: 'tube_name',
-              operand: '',
-              operator: '::has',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'tube_name',
+                  operand: '',
+                  operator: '::has',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'sc_seq',
               any: true
             }
@@ -97,10 +101,14 @@ describe('QueryBuilder', () => {
         {
           modelName: 'labor',
           clause: {
-            attributeName: 'contributions',
-            operator: '::slice',
-            operand: 'Athens,Sidon',
-            attributeType: 'matrix',
+            subclauses: [
+              {
+                attributeName: 'contributions',
+                operator: '::slice',
+                operand: 'Athens,Sidon',
+                attributeType: 'matrix'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -110,10 +118,14 @@ describe('QueryBuilder', () => {
         {
           modelName: 'prize',
           clause: {
-            attributeName: 'name',
-            operator: '::equals',
-            operand: 'Sparta',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::equals',
+                operand: 'Sparta',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'prize',
             any: true
           }
@@ -127,10 +139,14 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::in',
-            operand: 'lion,hydra,apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::in',
+                operand: 'lion,hydra,apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -141,10 +157,14 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::equals',
-            operand: 'Nemean Lion',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::equals',
+                operand: 'Nemean Lion',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'monster',
             any: true
           }
@@ -155,10 +175,14 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'number',
-            operator: '::equals',
-            operand: '2',
-            attributeType: 'number',
+            subclauses: [
+              {
+                attributeName: 'number',
+                operator: '::equals',
+                operand: '2',
+                attributeType: 'number'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -168,10 +192,14 @@ describe('QueryBuilder', () => {
         modelName: 'prize',
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::equals',
-            operand: 'Apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::equals',
+                operand: 'Apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'prize',
             any: true
           }
@@ -262,26 +290,38 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::in',
-            operand: 'lion,hydra,apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::in',
+                operand: 'lion,hydra,apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'labor',
             any: true
           },
           {
-            attributeName: 'number',
-            operator: '::>',
-            operand: '2',
-            attributeType: 'number',
+            subclauses: [
+              {
+                attributeName: 'number',
+                operator: '::>',
+                operand: '2',
+                attributeType: 'number'
+              }
+            ],
             modelName: 'labor',
             any: true
           },
           {
-            attributeName: 'number',
-            operator: '::<=',
-            operand: '8',
-            attributeType: 'number',
+            subclauses: [
+              {
+                attributeName: 'number',
+                operator: '::<=',
+                operand: '8',
+                attributeType: 'number'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -315,10 +355,14 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::in',
-            operand: 'lion,hydra,apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::in',
+                operand: 'lion,hydra,apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'labor',
             any: true
           },
@@ -369,10 +413,14 @@ describe('QueryBuilder', () => {
         anyMap: {},
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::in',
-            operand: 'lion,hydra,apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::in',
+                operand: 'lion,hydra,apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'monster',
             any: true
           }
@@ -396,10 +444,14 @@ describe('QueryBuilder', () => {
         {
           modelName: 'labor',
           clause: {
-            attributeName: 'contributions',
-            operator: '::slice',
-            operand: 'Athens,Sidon',
-            attributeType: 'matrix',
+            subclauses: [
+              {
+                attributeName: 'contributions',
+                operator: '::slice',
+                operand: 'Athens,Sidon',
+                attributeType: 'matrix'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -414,6 +466,61 @@ describe('QueryBuilder', () => {
     ]);
   });
 
+  it('adds matrix slice with multiple subclauses', () => {
+    builder.addRootModel('labor');
+    builder.addColumns([
+      stamp('labor', 'name', []),
+      stamp('victim', 'weapons', [
+        {
+          modelName: 'victim',
+          clause: {
+            subclauses: [
+              {
+                attributeName: 'weapons',
+                operator: '::slice',
+                operand: 'sword,hands',
+                attributeType: 'matrix'
+              }
+            ],
+            modelName: 'victim',
+            any: true
+          }
+        },
+        {
+          modelName: 'monster',
+          clause: {
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::matches',
+                operand: 'ion',
+                attributeType: 'string'
+              }
+            ],
+            modelName: 'monster',
+            any: true
+          }
+        }
+      ])
+    ]);
+
+    expect(builder.query()).toEqual([
+      'labor',
+      '::all',
+      [
+        [
+          'monster',
+          ['name', '::matches', 'ion'],
+          'victim',
+          '::first',
+          'weapons',
+          '::slice',
+          ['sword', 'hands']
+        ]
+      ]
+    ]);
+  });
+
   it('returns a count query string', () => {
     builder.addRootModel('monster');
     builder.addColumns([
@@ -425,10 +532,14 @@ describe('QueryBuilder', () => {
         {
           modelName: 'prize',
           clause: {
-            attributeName: 'name',
-            operator: '::equals',
-            operand: 'Sparta',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::equals',
+                operand: 'Sparta',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'prize',
             any: true
           }
@@ -440,10 +551,14 @@ describe('QueryBuilder', () => {
         modelName: 'labor',
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::in',
-            operand: 'lion,hydra,apples',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::in',
+                operand: 'lion,hydra,apples',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'labor',
             any: true
           }
@@ -454,10 +569,14 @@ describe('QueryBuilder', () => {
         modelName: 'monster',
         clauses: [
           {
-            attributeName: 'name',
-            operator: '::equals',
-            operand: 'Nemean Lion',
-            attributeType: 'text',
+            subclauses: [
+              {
+                attributeName: 'name',
+                operator: '::equals',
+                operand: 'Nemean Lion',
+                attributeType: 'text'
+              }
+            ],
             modelName: 'monster',
             any: true
           }
@@ -485,10 +604,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -524,10 +647,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -559,10 +686,14 @@ describe('QueryBuilder', () => {
           modelName: 'victim',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::equals',
-              operand: 'Hercules',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::equals',
+                  operand: 'Hercules',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'victim',
               any: true
             }
@@ -589,10 +720,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -632,10 +767,14 @@ describe('QueryBuilder', () => {
           modelName: 'prize',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::equals',
-              operand: 'Apples',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::equals',
+                  operand: 'Apples',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'prize',
               any: true
             }
@@ -662,10 +801,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::in',
-              operand: 'Lion,Hydra',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::in',
+                  operand: 'Lion,Hydra',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -692,10 +835,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -731,10 +878,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -766,10 +917,14 @@ describe('QueryBuilder', () => {
           modelName: 'victim',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::equals',
-              operand: 'Hercules',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::equals',
+                  operand: 'Hercules',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'victim',
               any: true
             }
@@ -796,10 +951,14 @@ describe('QueryBuilder', () => {
           modelName: 'wound',
           clauses: [
             {
-              attributeName: 'location',
-              operator: '::equals',
-              operand: 'arm',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'location',
+                  operator: '::equals',
+                  operand: 'arm',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'wound',
               any: true
             }
@@ -839,10 +998,14 @@ describe('QueryBuilder', () => {
           modelName: 'prize',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::equals',
-              operand: 'Apples',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::equals',
+                  operand: 'Apples',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'prize',
               any: true
             }
@@ -873,10 +1036,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::in',
-              operand: 'Lion,Hydra',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::in',
+                  operand: 'Lion,Hydra',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -902,10 +1069,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'number',
-              operator: '::equals',
-              operand: '2',
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'number',
+                  operator: '::equals',
+                  operand: '2',
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -916,10 +1087,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'number',
-              operator: '::in',
-              operand: '1,3,5',
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'number',
+                  operator: '::in',
+                  operand: '1,3,5',
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -930,10 +1105,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'number',
-              operator: '::notin',
-              operand: '2,4,6',
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'number',
+                  operator: '::notin',
+                  operand: '2,4,6',
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -944,10 +1123,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'number',
-              operator: '::>=',
-              operand: '5,6',
-              attributeType: 'number',
+              subclauses: [
+                {
+                  attributeName: 'number',
+                  operator: '::>=',
+                  operand: '5,6',
+                  attributeType: 'number'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -978,10 +1161,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::equals',
-              operand: '2',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::equals',
+                  operand: '2',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -992,10 +1179,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::in',
-              operand: '1,3,5',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::in',
+                  operand: '1,3,5',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -1006,10 +1197,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::notin',
-              operand: '2,4,6',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::notin',
+                  operand: '2,4,6',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }
@@ -1020,10 +1215,14 @@ describe('QueryBuilder', () => {
           modelName: 'labor',
           clauses: [
             {
-              attributeName: 'name',
-              operator: '::>=',
-              operand: '5,6',
-              attributeType: 'text',
+              subclauses: [
+                {
+                  attributeName: 'name',
+                  operator: '::>=',
+                  operand: '5,6',
+                  attributeType: 'text'
+                }
+              ],
               modelName: 'labor',
               any: true
             }


### PR DESCRIPTION
This PR fixes the matrix slicing in the columns for the new `subclauses` format, so the query builder produces the right output. Also updates the tests to match. Was reported by Chris in #queryfixes channel.

The bug was introduced with #1035.

Note that I discovered #1048 while working on this PR. Will fix that in a subsequent PR, since I think you can restructure most queries to work around the Magma matrix bug in the meanwhile by changing the root model of your query.