### PR TITLE
allow for optional private key in ssh connection configuration

### DIFF
--- a/airflow/opt/providers/etna/etna/hooks/c4.py
+++ b/airflow/opt/providers/etna/etna/hooks/c4.py
@@ -39,7 +39,8 @@ class C4Hook(SSHHook):
             "relabeling": {},
             "placeholders": {
                 "host": "c4.ucsf.edu",
-                "extra": "{\n  \"root_path\": \"/airflow/ingest\",\n  \"host_key\": \"ssh-<key type> <ssh-key>\"\n}"
+                "extra": "{\n  \"root_path\": \"/airflow/ingest\",\n  \"host_key\": \"ssh-<key type> <ssh-key>\"\n}",
+                "private_key": "private-key-string"
             },
         }
 


### PR DESCRIPTION
This PR allows the C4 connection to use a provided `private_key` string in the connection definition's `extra` field, enabling #1045.

If a connection provides both password and private key, private key is preferred.

If a connection has only one, then the given one is used.

I've updated production with the private key, so it should automatically used once this PR is deployed.