### PR TITLE
add gnomon_db service

### DIFF
--- a/gnomon/docker-compose.yml
+++ b/gnomon/docker-compose.yml
@@ -13,7 +13,7 @@ volumes:
     driver: local
   gnomon-node-modules:
     driver: local
-      
+
 x-base-etna-service:
   &base-etna-service # Base configuration used by most etna services.
   image: etna-base
@@ -55,6 +55,18 @@ x-base-etna-services:
     <<: *base-etna-service
     command: npm run webpack
 
+  'gnomon_db':
+    &base-etna-db # The application specific database.  Overwrite with development-psql-9 to use psql 9 instead.
+    image: development-psql
+    volumes:
+      - gnomon-db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: 'gnomon_db_development'
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: developer
+      APP_NAME: 'gnomon'
+    container_name: 'gnomon_db_1'
+
   'gnomon_app_fe':
     &base-etna-fe # The application level apache frontend serving static assets, data, and proxying the main app.
     image: etna-apache
@@ -67,7 +79,7 @@ x-base-etna-services:
     environment:
       APP_NAME: 'gnomon_app_fe'
 
-version: "3.4"
+version: '3.4'
 
 networks:
   edge_net:


### PR DESCRIPTION
This is a small PR to add the definition for `gnomon_db` into the `docker-compose.yml`. Without it, you cannot run `make -C gnomon update` to install NPM dependencies. This is due to how the Makefile build process works, where on `update` it always tries to bring up the `_db` service, so one much exist. Since they are double-colon targets, I'm not sure there is a way around that.

Post-merge of #1019, it **may** be possible to rethink the build process and remove this requirement, since then all Ruby and NPM packages would be installed exclusively in the `etna` image. However, the other apps will (perhaps) need to run DB migrations on `update`... so may still need a `gnomon_db` service.