### PR TITLE
reduce concurrency on gne etl to 1

### DIFF
--- a/polyphemus/lib/etls/materialize_gne_magma_records_etl.rb
+++ b/polyphemus/lib/etls/materialize_gne_magma_records_etl.rb
@@ -14,7 +14,7 @@ class Polyphemus::MaterializeGneMagmaRecordsEtl < Polyphemus::MagmaRecordEtl
         model_filters: model_filters,
         metis_client: metis_client, magma_client: magma_client, logger: logger,
         project_name: 'mvir1', model_name: 'patient', filesystem: filesystem,
-        concurrency: 5)
+        concurrency: 1)
 
     workflow.materialize_all("Upload")
     logger.info("Done")


### PR DESCRIPTION
This is already running on production and seems very stable ... I wonder if the concurrency + expanding time-based-scanner was overloading Metis before? 