### PR TITLE
remove sourcemaps

### DIFF
--- a/etna/webpack.config.js
+++ b/etna/webpack.config.js
@@ -7,7 +7,6 @@ var webpack = require('webpack');
 module.exports = (env) => ({
   mode: process.env.NODE_ENV || 'development',
   context: '/app',
-  devtool: 'source-map',
   resolve: {
     modules: ['/etna/node_modules'],
     extensions: [


### PR DESCRIPTION
Removes building of sourcemaps, which greatly speeds up the hot-reloading behavior in development.