### PR TITLE
account for no results in model ::first verb; [close #1080]

### DIFF
--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -6,7 +6,7 @@ class Magma
     #
     # This is a request for all objects of type "sample", so it's return type should be:
     #   [ Sample ]
-    # 
+    #
 
     # This object takes several arguments:
     #   1) It can accept an arbitrary list of filters, which are
@@ -64,12 +64,14 @@ class Magma
     verb '::first' do
       child :record_child
       extract do |table,return_identity|
-        child_extract(
-          table.group_by do |row|
-            row[identity]
-          end.first&.last,
-          identity
-        )
+        table.empty? ?
+          nil :
+          child_extract(
+            table.group_by do |row|
+              row[identity]
+            end.first&.last,
+            identity
+          )
       end
       format do
         child_format

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -244,6 +244,27 @@ describe QueryController do
         expect(json_body[:answer].map(&:last)).to match_array([ 'poison' ])
         expect(json_body[:format]).to eq([ 'labors::prize#id', 'labors::prize#name' ])
       end
+
+      it 'supports ::first' do
+        poison = create(:prize, name: 'poison', worth: 5, labor: @hydra)
+        poop = create(:prize, name: 'poop', labor: @stables)
+
+        query(['prize', ['worth', '::>', 1], '::first', 'name'])
+
+        expect(json_body[:answer]).to eq('poison')
+        expect(json_body[:format]).to eq('labors::prize#name')
+      end
+
+      it 'supports ::first with no results' do
+        poison = create(:prize, name: 'poison', worth: 5, labor: @hydra)
+        poop = create(:prize, name: 'poop', labor: @stables)
+
+        query(['prize', ['worth', '::>', 10], '::first', 'name'])
+
+        expect(last_response.status).to eq(200)
+        expect(json_body[:answer]).to eq(nil)
+        expect(json_body[:format]).to eq('labors::prize#name')
+      end
     end
 
     it 'supports ::first' do


### PR DESCRIPTION
This PR implements a small fix for Magma, where the `::first` verb could not handle an empty table before. Instead of trying to extract a column value from `[]`, this just returns `nil`, which is the provided answer.