### PR TITLE
Fix polyphemus log CSS for scrolling

### DIFF
--- a/polyphemus/lib/client/jsx/etl/logs-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/logs-pane.tsx
@@ -17,7 +17,8 @@ const useStyles = makeStyles((theme) => ({
     border: '1px solid #ccc',
     height: '200px',
     resize: 'vertical',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    overflowY: 'auto'
   }
 }));
 


### PR DESCRIPTION
Adds right CSS property to Polyphemus log container so you can scroll the log. Sorry, must have missed this before! :facepalm: 