### PR TITLE
fix behavior of column labels and model / attribute changes to be mor…

### DIFF
--- a/timur/lib/client/jsx/components/query/query_select_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_select_pane.tsx
@@ -64,9 +64,7 @@ const QuerySelectPane = () => {
     (columnIndex: number, column: QueryColumn, attributeName: string) => {
       const previousDefaultLabel = `${column.model_name}.${column.attribute_name}`;
 
-      const newDefaultLabel = ['', previousDefaultLabel].includes(
-        column.display_label
-      )
+      const newLabel = ['', previousDefaultLabel].includes(column.display_label)
         ? `${column.model_name}.${attributeName}`
         : column.display_label;
 
@@ -74,7 +72,7 @@ const QuerySelectPane = () => {
         model_name: column.model_name,
         slices: [],
         attribute_name: attributeName,
-        display_label: newDefaultLabel
+        display_label: newLabel
       });
     },
     [patchQueryColumn]

--- a/timur/lib/client/jsx/components/query/query_select_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_select_pane.tsx
@@ -74,7 +74,7 @@ const QuerySelectPane = () => {
         model_name: column.model_name,
         slices: [],
         attribute_name: attributeName,
-        display_label: `${newDefaultLabel}`
+        display_label: newDefaultLabel
       });
     },
     [patchQueryColumn]

--- a/timur/lib/client/jsx/components/query/query_select_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_select_pane.tsx
@@ -62,15 +62,19 @@ const QuerySelectPane = () => {
 
   const handleOnSelectAttribute = useCallback(
     (columnIndex: number, column: QueryColumn, attributeName: string) => {
+      const previousDefaultLabel = `${column.model_name}.${column.attribute_name}`;
+
+      const newDefaultLabel = ['', previousDefaultLabel].includes(
+        column.display_label
+      )
+        ? `${column.model_name}.${attributeName}`
+        : column.display_label;
+
       patchQueryColumn(columnIndex, {
         model_name: column.model_name,
         slices: [],
         attribute_name: attributeName,
-        display_label: `${
-          column.display_label === ''
-            ? `${column.model_name}.${attributeName}`
-            : column.display_label
-        }`
+        display_label: `${newDefaultLabel}`
       });
     },
     [patchQueryColumn]
@@ -213,11 +217,7 @@ const QuerySelectPane = () => {
                     canEdit={0 !== index}
                     graph={graph}
                     onSelectModel={(modelName: string) =>
-                      handleOnSelectModel(
-                        index,
-                        modelName,
-                        column.display_label
-                      )
+                      handleOnSelectModel(index, modelName, '')
                     }
                     onSelectAttribute={(attributeName: string) =>
                       handleOnSelectAttribute(index, column, attributeName)


### PR DESCRIPTION
…e intuitive

Closes #1096.

If the attribute in a column changes, and the label is the previous default, then it updates to reflect the new attribute name. If the label has been changed manually, then the label will not change.

i.e.

"patient.notes" => "patient.processor"
"custom column name" => "custom column name"

If the model changes, the label resets to empty string (previously it stayed the same ... which doesn't quite make sense, either).