### PR TITLE
remove unused tools to free up disk space

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,6 +28,10 @@ jobs:
           NO_TEST: 1
           IMAGES_POSTFIX: :master
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
           git push origin HEAD:staging --force

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,6 +28,10 @@ jobs:
           IMAGES_POSTFIX: :production
           NO_TEST: 1
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
           git push origin HEAD:production-build --force

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,6 +28,10 @@ jobs:
           IMAGES_POSTFIX: :staging
           NO_TEST: 1
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
           git push origin HEAD:staging-build --force


### PR DESCRIPTION
Addresses #1101. 

For the individual test matrix action, `vulcan` is particularly slow (40m), since it also runs / tests `archimedes` and `archimedes-node`. There is probably a way to make that more efficient, without all the redundant testing -- probably some way in which the Makefiles are called and tasks configured. 

It seems like there is an advantage to having all the shared layers when doing the push-and-build actions, so putting in this PR to clean out directories on the action runners for now.