### PR TITLE
Janus create project magma

### DIFF
--- a/janus/config.yml.template
+++ b/janus/config.yml.template
@@ -16,7 +16,7 @@
     :host: https://polyphemus.development.local
   :auth_redirect: https://janus.development.local
   :pass_algo: sha256
-  :pass_salt: 
+  :pass_salt:
   :token_algo: RS256
   :token_salt: qwerty
   :token_name: JANUS_DEV_TOKEN
@@ -76,7 +76,7 @@
   :log_file: /dev/null
 
   :pass_algo: sha256
-  :pass_salt: 
+  :pass_salt:
   :token_algo: RS256
   :token_name: JANUS_TOKEN
   :token_domain: janus.test
@@ -120,3 +120,5 @@
     CgX77PmgC3zcOpKDZW0LVb2x7qhp67Fz1EMnRbV1vJY5L6U4FlUnu59/WiTvCpwu
     NQIDAQAB
     -----END PUBLIC KEY-----
+  :magma:
+    :host: https://magma.test

--- a/janus/lib/janus.rb
+++ b/janus/lib/janus.rb
@@ -7,6 +7,8 @@ class Janus
 
   def setup_db(load_models=true)
     @db = Sequel.connect(config(:db))
+    Sequel::Model.plugin :timestamps, force: true, update_on_create: true
+
     @db.extension :connection_validator
     @db.extension :pg_json
     @db.pool.connection_validation_timeout = -1

--- a/janus/lib/models/user.rb
+++ b/janus/lib/models/user.rb
@@ -1,5 +1,6 @@
 class User < Sequel::Model
   include Etna::Instrumentation
+
   one_to_many :permissions
 
   def validate
@@ -118,7 +119,7 @@ class User < Sequel::Model
         permission.project&.project_name == project
     end
   end
-  
+
   def set_guest_permissions!(project_name)
     # For given project: if agreed, ensure at least guest access; if explicitly !agreed, remove guest access; if no cc aggreement, do nothing
     cc_agreements_project = CcAgreement.where(user_email: email, project_name: project_name).all

--- a/janus/lib/server/controllers/admin_controller.rb
+++ b/janus/lib/server/controllers/admin_controller.rb
@@ -109,6 +109,15 @@ class AdminController < Janus::Controller
           project_name: @params[:project_name],
           project_name_full: @params[:project_name_full]
       )
+
+      magma_client.update_model(
+        Etna::Clients::Magma::UpdateModelRequest.new(
+          project_name: project.project_name,
+          actions: [
+            Etna::Clients::Magma::AddProjectAction.new
+          ]
+        )
+      )
     end
 
     @response.redirect('/')
@@ -196,5 +205,12 @@ class AdminController < Janus::Controller
 
   def valid_contact?
     @params[:contact_email]&.empty? || @params[:contact_email]&.strip&.rpartition('@')&.last == Janus.instance.config(:token_domain)
+  end
+
+  def magma_client
+    Etna::Clients::Magma.new(
+      host: Janus.instance.config(:magma)[:host],
+      token: @user.token
+    )
   end
 end

--- a/janus/lib/server/controllers/admin_controller.rb
+++ b/janus/lib/server/controllers/admin_controller.rb
@@ -157,6 +157,8 @@ class AdminController < Janus::Controller
   def flag_user
     require_params(:flags, :email)
 
+    user = User.find(email: @params[:email])
+
     if @params[:flags] &&
         !(@params[:flags].is_a?(Array) &&
             @params[:flags].all? { |f| f.is_a?(String) && f =~ /^\w+$/ })
@@ -165,9 +167,9 @@ class AdminController < Janus::Controller
 
     raise Etna::BadRequest, "No such user #{@params[:email]}" unless user
 
-    janus_user.update(flags: @params[:flags])
+    user.update(flags: @params[:flags])
 
-    success_json(janus_user.to_hash)
+    success_json(user.to_hash)
   end
 
   def update_cc_agreement

--- a/janus/lib/server/controllers/authorization_controller.rb
+++ b/janus/lib/server/controllers/authorization_controller.rb
@@ -158,12 +158,6 @@ class AuthorizationController < Janus::Controller
     erb_view(:login_form)
   end
 
-  def respond_with_cookie(token, refer)
-    Etna::Redirect(@request).to(refer) do |response|
-      Janus.instance.set_token_cookie(response,token)
-    end
-  end
-
   private
 
   def refer_valid?(refer)

--- a/janus/lib/server/controllers/janus_controller.rb
+++ b/janus/lib/server/controllers/janus_controller.rb
@@ -18,5 +18,11 @@ class Janus
         token_name: Janus.instance.config(:token_name),
       }.merge(config_hosts).to_json
     end
+
+    def respond_with_cookie(token, refer)
+      Etna::Redirect(@request).to(refer) do |response|
+        Janus.instance.set_token_cookie(response,token)
+      end
+    end
   end
 end

--- a/janus/spec/spec_helper.rb
+++ b/janus/spec/spec_helper.rb
@@ -251,3 +251,11 @@ end
 def parse_cookie(set_cookie='')
   Hash[set_cookie.split(/; /).map { |param| param.split(/=/) }]
 end
+
+def create_zeus
+  super_user = create(:user, name: 'Zeus Almighty', email: 'zeus@olympus.org')
+  admin = create(:project, project_name: 'administration', project_name_full: 'Administration')
+  perm = create(:permission, project: admin, user: super_user, role: 'administrator', privileged: true)
+
+  super_user
+end

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -34,7 +34,6 @@ export const requestView = (model_name, success, error) => (dispatch) =>
       return e.then((body) => {
         if (body && body.error && body.error.includes('No such view')) {
           // Default view
-          console.log('adding default view', model_name)
           dispatch(addView(model_name, {}));
           return {};
         }

--- a/timur/lib/client/jsx/actions/view_actions.js
+++ b/timur/lib/client/jsx/actions/view_actions.js
@@ -34,6 +34,7 @@ export const requestView = (model_name, success, error) => (dispatch) =>
       return e.then((body) => {
         if (body && body.error && body.error.includes('No such view')) {
           // Default view
+          console.log('adding default view', model_name)
           dispatch(addView(model_name, {}));
           return {};
         }

--- a/timur/lib/client/jsx/components/browser/view_tab.jsx
+++ b/timur/lib/client/jsx/components/browser/view_tab.jsx
@@ -26,8 +26,8 @@ const ViewTab = ({tab, ...pane_props}) => {
     <div id='tab'>
       {Object.keys(tab_groups).map((pane_group, i) => (
         <div className='pane_group' key={i}>
-          {tab_groups[pane_group].map((pane) => (
-            <ViewPane {...pane_props} pane={pane} key={pane.name} />
+          {tab_groups[pane_group].map((pane, j) => (
+            <ViewPane {...pane_props} pane={pane} key={j} />
           ))}
         </div>
       ))}

--- a/timur/lib/client/jsx/selectors/tab_selector.jsx
+++ b/timur/lib/client/jsx/selectors/tab_selector.jsx
@@ -51,7 +51,8 @@ const basicView = ({attributes}) => {
     ]
   };
 
-  return [overview, tables].filter((t) => t.panes[0].items.length);
+  if (0 === tables.panes[0].items.length) return [overview];
+  else return [overview, tables];
 };
 
 const groupView = ({attributes}) => {
@@ -87,7 +88,7 @@ const groupView = ({attributes}) => {
 };
 
 export const getDefaultTab = (view) =>
-  view && view.tabs ? view.tabs[0].name : 'default';
+  view && view.tabs && view.tabs[0] ? view.tabs[0].name : 'default';
 
 export const hasMagmaAttribute = (item) =>
   item.type == 'magma' ||


### PR DESCRIPTION
One of those small things that someone brought up (Dan?), that would make our lives easier ... but just tieing the entire "make project in Magma" workflow to the action in the Janus UI. Means that you don't need the gem to do it, and automatically adds the user as an admin on the project. If you want to test it locally, you'll have to make sure to update your `config.yml` to include a `:magma: -> :host: https://magma.development.local` entry for `:development` and similarly `:magma: -> :host: https://magma.test` for `:test` environment.

Also fixed a couple of other small things:

* Added `created_at` and `updated_at` timestamps to Janus User and Project, so we can track creation of these over time, moving forward. Currently, User has a `user_create_stamp` column ... but unfortunately it's only set to the time of the original migration (like 2017). So not useful for this purpose. 
* Fixed a bug with Timur "browse" where a new project with no defined view or attributes would not load. 