### PR TITLE
Build change order npm install

### DIFF
--- a/docker/build_support/.dockerignore
+++ b/docker/build_support/.dockerignore
@@ -16,3 +16,4 @@ Dockerfile
 config.yml
 Makefile
 *.mk
+*.swp

--- a/docker/build_support/find-updated-sources
+++ b/docker/build_support/find-updated-sources
@@ -13,7 +13,7 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" 
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
@@ -33,4 +33,4 @@ if type -p gfind; then
   find=gfind
 fi
 
-$find $dir -type f ! -path '*/coverage/*' ! -path '*/logs/*' ! -path "*.marker" ! -path '*/node_modules/*' ! -path '*/.bundle/config' -printf "%T+ %p\n" | sort | tail -1 | cut -d ' ' -f2
+$find $dir -type f ! -path '*/coverage/*' ! -path '*/logs/*' ! -path "*.marker" ! -path '*/node_modules/*' ! -path '*/.bundle/config' ! -path '*/npm-cache/*' ! -path '*/__pycache__/*' -printf "%T+ %p\n" | sort | tail -1 | cut -d ' ' -f2

--- a/etna/Dockerfile
+++ b/etna/Dockerfile
@@ -8,11 +8,13 @@ RUN bundle install -j "$(nproc)"
 
 COPY ./package.json /etna/package.json
 COPY ./package-lock.json /etna/package-lock.json
-COPY ./packages/etna-js /etna/packages/etna-js
-RUN cd /etna && npm run build
 
 # The images tend to build as root, which for host systems is unsafe,
 # but in containers is fine.
 RUN cd /etna && npm install --unsafe-perm
+
+COPY ./packages/etna-js /etna/packages/etna-js
+RUN cd /etna && npm run build
+
 
 COPY . /etna


### PR DESCRIPTION
This PR attempts to fix the slow re-build process due to editing UI files in `etna`, which causes the `etna` image to rebuild (and re-run `npm install`), if you restart one of the apps.

i.e.

```
<edit etna-js/components/Nav.css>
make -C janus restart
<watch etna run npm install and wait for a long time>
```

This moves the `npm install` step before the `etna-js` copy / `npm build`, so if you update a file in `etna-js`, it doesn't trigger the global `npm install` anymore. This should mimic the speed and behavior prior to the NPM consolidation.

Now what you should see is something more like:

```
<edit etna-js/components/Nav.css>
make -C janus restart
<watch etna rebuild quickly and skip npm install for /etna. Note that npm build still runs.>
```

Also added `*.swp` to the docker ignore files, so hopefully those won't trigger rebuilds. And tweaked the `find-updated-sources` script so if a cached / compiled NPM or Python file is updated, it doesn't trigger rebuilds. Only source file changes should trigger rebuilds.