### PR TITLE
fix formatting of author for metis files

### DIFF
--- a/etna/packages/etna-js/components/ListEntry.jsx
+++ b/etna/packages/etna-js/components/ListEntry.jsx
@@ -22,7 +22,7 @@ export const ListEntryTypeColumn = ({icon, widths}) => (
 export const ListEntryUpdatedColumn = ({obj, widths}) => (
   <ListEntryColumn className='updated' widths={widths}>
     <div className='list-entry-updated-name'>
-      {dateFormat(obj.updated_at)} by {authorFormat(obj.author)}
+      {dateFormat(obj.updated_at)} by {authorFormat(obj.author).name}
     </div>
   </ListEntryColumn>
 );

--- a/etna/packages/etna-js/components/__tests__/ListEntry.spec.jsx
+++ b/etna/packages/etna-js/components/__tests__/ListEntry.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {render, screen, waitFor, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import {ListEntryUpdatedColumn} from '../ListEntry';
+
+describe('ListEntryUpdatedColumn', () => {
+  it('renders correctly', async () => {
+    const testObject = {
+      updated_at: '2022-09-19T13:43:09+00:00',
+      author: 'zeus@olympus.org|Zeus Almighty'
+    };
+    const testWidths = {};
+    const {asFragment} = render(
+      <ListEntryUpdatedColumn obj={testObject} widths={testWidths} />
+    );
+
+    await waitFor(() => screen.getByText(/by/));
+
+    expect(screen.queryByText(/Zeus Almighty/)).toBeTruthy();
+    expect(screen.queryByText(/zeus@olympus.org/)).toBeFalsy();
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/etna/packages/etna-js/components/__tests__/__snapshots__/ListEntry.spec.jsx.snap
+++ b/etna/packages/etna-js/components/__tests__/__snapshots__/ListEntry.spec.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListEntryUpdatedColumn renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="list-entry-column-group updated"
+  >
+    <div
+      class="list-entry-updated-name"
+    >
+      Sep 19, 2022 by Zeus Almighty
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
This PR (I think?) fixes a bug I'm hitting in Metis, where the use of [`authorFormat()`](https://github.com/mountetna/monoetna/blob/master/etna/packages/etna-js/utils/format.jsx#L5-L9) returns an object, not a string, and Metis UI doesn't know how to render that. I get the following error:

```
Uncaught Error: Objects are not valid as a React child (found: object with keys {name, email}). If you meant to render a collection of children, use an array instead.
    in div (created by ListEntryUpdatedColumn)
    in div (created by ListEntryColumn)
    in ListEntryColumn (created by ListEntryUpdatedColumn)
    in ListEntryUpdatedColumn (created by ListFile)
```

And the app crashes with a white screen if you try to load files or folders in a bucket (main Metis root view works fine).