### PR TITLE
separates out update of config files to own make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export COMPOSE_PROJECT_NAME=monoetna
 export NODE_ENV=development
-export MONOETNA_SHA=$(shell git rev-parse HEAD) 
+export MONOETNA_SHA=$(shell git rev-parse HEAD)
 
 .PHONY: help
 help: ## Display help text
@@ -43,6 +43,11 @@ logs-recent: ## For CI
 update: ## Runs all projects' updates, running bundle and npm install
 	@ make -C docker update-all
 
+
+.PHONY: update-configs
+update-configs: ## Runs all projects' update-configs
+	@ make -C docker update-all-configs
+
 .PHONY: release
 release: ## Builds static docker images staged for release, runs tests against them, and pushes them to dockerhub (requires PUSH_IMAGES=1)
 	@ NO_PRUNE=1 $(MAKE) -f Release.mk
@@ -59,4 +64,5 @@ clean:  ## Cleans many dangling docker references, recovering much disk space.
 	docker images | grep timur_ | cut -d ' ' -f1 | xargs -n1 docker image rm || true
 	docker images | grep vulcan_ | cut -d ' ' -f1 | xargs -n1 docker image rm || true
 	docker images | grep etnaagent | cut -d ' ' -f1 | xargs -n1 docker image rm || true
+	docker images | grep gnomon | cut -d ' ' -f1 | xargs -n1 docker image rm || true
 	docker image prune

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -29,6 +29,10 @@ update:
 update-all: compose-ready ## Runs all projects' updates, running bundle and npm install
 	@ set -e && for project in $(compose_projects); do make -C $$project update; done
 
+.PHONY: update-all-configs
+update-all-configs: compose-ready ## Runs all projects' update-configs
+	@ set -e && for project in $(compose_projects); do make -C $$project update-configs; done
+
 .PHONY: up
 up: compose-ready ## Starts up all containers of this project in the background
 	@ set -e; for project in $(compose_projects); do make -C $$project compose-ready; done

--- a/make-base/etna-ruby.mk
+++ b/make-base/etna-ruby.mk
@@ -3,8 +3,7 @@ app_db_name:=${app_name}_db
 app_name_capitalized:=$(shell echo ${app_name} | tr [a-z] [A-Z])
 EXTRA_DOCKER_ARGS:=
 
-config.yml: config.yml.template
-	$(call find_project_file,build_support,maybe-move-config)
+config.yml: config.yml
 
 config-ready:: $(app_name)_app_fe config.yml Dockerfile
 	@ true
@@ -30,3 +29,6 @@ run-image-test::
 
 update-ready::
 	docker-compose up -d $(app_db_name)
+
+update-configs:: config.yml.template
+	$(call find_project_file,build_support,maybe-move-config)

--- a/make-base/stubs.mk
+++ b/make-base/stubs.mk
@@ -70,6 +70,10 @@ config-ready:: ## Setup step that ensures that configuration files necessary for
 update:: update-ready ## Step to force update of database and development dependencies.
 	@ true
 
+.PHONY: update-configs
+update-configs:: update-ready ## Step to update config.yml from config.yml.template
+	@ true
+
 .PHONY: update-ready
 update-ready::
 	@ true


### PR DESCRIPTION
I think this addresses #1126 ?

Adds a new `make update-configs` command to iterate through the `config.yml.template` files and prompts you if you want to update.

Removes this check / prompt from the `make up` or other `make` commands.

Also adds `gnomon` to the `make clean` task.

To test locally, touch or edit a `config.yml.template` in an app directory. You should be able to run the following without being prompted now if you want to update configs:

* `make up`

But if you then run `make update-configs`, it should catch your updated `config.yml.template` and prompt if you want to update your `config.yml`.
