### PR TITLE
fix bug with closing edit modal; allow edit identifier

### DIFF
--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -21,7 +21,10 @@ import {
 } from '../../api/magma_api';
 import MapHeading from './map_heading';
 import EditAttributeModal from './edit_attribute_modal';
-import {EDITABLE_ATTRIBUTE_TYPES} from '../../utils/edit_map';
+import {
+  EDITABLE_ATTRIBUTE_TYPES,
+  REMOVABLE_ATTRIBUTE_TYPES
+} from '../../utils/edit_map';
 import useMagmaActions from './use_magma_actions';
 
 const ATT_ATTS = [
@@ -117,6 +120,10 @@ const ManageAttributeActions = ({
     return EDITABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type);
   }, [attribute, EDITABLE_ATTRIBUTE_TYPES]);
 
+  const isRemovableAttribute = useMemo(() => {
+    return REMOVABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type);
+  }, [attribute, REMOVABLE_ATTRIBUTE_TYPES]);
+
   const isLinkAttribute = useMemo(() => {
     if (!reciprocalAttribute) return false;
 
@@ -145,17 +152,19 @@ const ManageAttributeActions = ({
 
   return (
     <>
-      <Tooltip title='Remove Attribute'>
-        <Button
-          startIcon={<DeleteIcon />}
-          onClick={handleConfirmRemove}
-          size='small'
-          color='primary'
-          className={classes.button}
-        >
-          Remove
-        </Button>
-      </Tooltip>
+      {isRemovableAttribute && (
+        <Tooltip title='Remove Attribute'>
+          <Button
+            startIcon={<DeleteIcon />}
+            onClick={handleConfirmRemove}
+            size='small'
+            color='primary'
+            className={classes.button}
+          >
+            Remove
+          </Button>
+        </Tooltip>
+      )}
       <Tooltip title='Edit Attribute'>
         <Button
           startIcon={<EditIcon />}
@@ -202,8 +211,7 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
         updateAttribute({
           model_name,
           ...params
-        }),
-        false
+        })
       );
     },
     [executeAction, model_name, updateAttribute]

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -51,10 +51,7 @@ import {
   reparentModel,
   addModel
 } from '../../api/magma_api';
-import {
-  addTemplatesAndDocuments,
-  removeModelAction
-} from 'etna-js/actions/magma_actions';
+import {removeModelAction} from 'etna-js/actions/magma_actions';
 import {isLeafModel} from '../../utils/edit_map';
 import useMagmaActions from './use_magma_actions';
 
@@ -474,7 +471,7 @@ const ModelReport = ({
   }, [model_name, models]);
 
   useEffect(() => {
-    if (counts[model_name]?.count) {
+    if (counts[model_name]?.count != null) {
       setCanReparent(counts[model_name].count <= 0);
     } else {
       getAnswer([model_name, '::count'], (count) => {

--- a/timur/lib/client/jsx/utils/edit_map.ts
+++ b/timur/lib/client/jsx/utils/edit_map.ts
@@ -8,7 +8,7 @@ export const COMMA_SEP = '^[a-zA-Z0-9]*(,[a-zA-Z0-9]*)*$';
 
 export const VALIDATION_TYPES = ['Array', 'Regexp'];
 
-export const EDITABLE_ATTRIBUTE_TYPES = [
+export const REMOVABLE_ATTRIBUTE_TYPES = [
   'string',
   'date_time',
   'shifted_date_time',
@@ -18,6 +18,11 @@ export const EDITABLE_ATTRIBUTE_TYPES = [
   'file',
   'image',
   'file_collection'
+];
+
+export const EDITABLE_ATTRIBUTE_TYPES = [
+  ...REMOVABLE_ATTRIBUTE_TYPES,
+  'identifier'
 ];
 
 const CHILD_ATTRIBUTE_TYPES = ['table', 'child', 'collection'];


### PR DESCRIPTION
This PR fixes a couple of bugs with the map editing:

* The "edit attribute" modal wasn't closing upon save :facepalm: 
* Allows users to edit an identifier attribute, but not remove it.
* Fixes a small corner-case bug where if a model has 0 records in it, wound up in an infinite loop of making Magma `::count` queries when you have that model selected.

Closes #1135 