### PR TITLE
Timur map show hidden attributes

### DIFF
--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -23,7 +23,9 @@ import MapHeading from './map_heading';
 import EditAttributeModal from './edit_attribute_modal';
 import {
   EDITABLE_ATTRIBUTE_TYPES,
-  REMOVABLE_ATTRIBUTE_TYPES
+  REMOVABLE_ATTRIBUTE_TYPES,
+  UNREMOVABLE_ATTRIBUTE_NAMES,
+  UNEDITABLE_ATTRIBUTE_NAMES
 } from '../../utils/edit_map';
 import useMagmaActions from './use_magma_actions';
 
@@ -117,12 +119,18 @@ const ManageAttributeActions = ({
   }, [handleRemoveLink]);
 
   const isEditableAttribute = useMemo(() => {
-    return EDITABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type);
-  }, [attribute, EDITABLE_ATTRIBUTE_TYPES]);
+    return (
+      EDITABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type) &&
+      !UNEDITABLE_ATTRIBUTE_NAMES.includes(attribute.attribute_name)
+    );
+  }, [attribute, EDITABLE_ATTRIBUTE_TYPES, UNEDITABLE_ATTRIBUTE_NAMES]);
 
   const isRemovableAttribute = useMemo(() => {
-    return REMOVABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type);
-  }, [attribute, REMOVABLE_ATTRIBUTE_TYPES]);
+    return (
+      REMOVABLE_ATTRIBUTE_TYPES.includes(attribute.attribute_type) &&
+      !UNREMOVABLE_ATTRIBUTE_NAMES.includes(attribute.attribute_name)
+    );
+  }, [attribute, REMOVABLE_ATTRIBUTE_TYPES, UNREMOVABLE_ATTRIBUTE_NAMES]);
 
   const isLinkAttribute = useMemo(() => {
     if (!reciprocalAttribute) return false;

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -35,6 +35,7 @@ import LinkIcon from '@material-ui/icons/Link';
 import DeleteIcon from '@material-ui/icons/Delete';
 import SwapHorizIcon from '@material-ui/icons/SwapHoriz';
 import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 
 import AddAttributeModal from './add_attribute_modal';
 import AddLinkModal from './add_link_modal';
@@ -101,6 +102,18 @@ const attributeStyles = makeStyles((theme) => ({
   },
   absent: {
     backgroundColor: 'rgba(255,0,0,0.1)'
+  },
+  hiddenIcon: {
+    marginRight: '1rem'
+  },
+  typeWrapper: {
+    display: 'flex',
+    justifyContent: 'right'
+  },
+  hiddenTypeWrapper: {
+    display: 'flex',
+    justifyContent: 'right',
+    paddingTop: '0.35rem'
   }
 }));
 
@@ -207,7 +220,8 @@ const ModelAttribute = ({
   diffTemplate,
   setAttribute,
   count,
-  modelCount
+  modelCount,
+  isHidden
 }) => {
   const classes = attributeStyles();
 
@@ -241,7 +255,16 @@ const ModelAttribute = ({
         </TableCell>
       )}
       <TableCell className={classes.type} align='right'>
-        {attribute_type}
+        <div
+          className={isHidden ? classes.hiddenTypeWrapper : classes.typeWrapper}
+        >
+          {isHidden ? (
+            <div className={classes.hiddenIcon}>
+              <VisibilityOffIcon />
+            </div>
+          ) : null}
+          {attribute_type}
+        </div>
       </TableCell>
       <TableCell
         className={attribute ? classes.value : classes.missing}
@@ -321,6 +344,7 @@ const ModelReport = ({
   setAttribute,
   isAdminUser
 }) => {
+  const [showHiddenAttributes, setShowHiddenAttributes] = useState(false);
   const [canReparent, setCanReparent] = useState(false);
   const dispatch = useDispatch();
   const invoke = useActionInvoker();
@@ -531,6 +555,16 @@ const ModelReport = ({
           >
             Count attributes
           </MenuItem>
+          {isAdminUser && (
+            <MenuItem
+              onClick={() => {
+                setShowHiddenAttributes(!showHiddenAttributes);
+                setAnchor(null);
+              }}
+            >
+              Toggle hidden attributes
+            </MenuItem>
+          )}
         </Menu>
       </MapHeading>
       <SelectProjectModelDialog
@@ -593,7 +627,9 @@ const ModelReport = ({
           <TableBody>
             {sortByOrder(attributes)
               .filter(
-                (attribute) => !attribute.hidden && matchesFilter(attribute)
+                (attribute) =>
+                  (showHiddenAttributes ? true : !attribute.hidden) &&
+                  matchesFilter(attribute)
               )
               .map((attribute) => (
                 <ModelAttribute
@@ -606,6 +642,7 @@ const ModelReport = ({
                   modelCount={modelCount}
                   template={template}
                   diffTemplate={diffTemplate}
+                  isHidden={attribute.hidden}
                 />
               ))}
           </TableBody>

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -51,7 +51,10 @@ import {
   reparentModel,
   addModel
 } from '../../api/magma_api';
-import {removeModelAction} from 'etna-js/actions/magma_actions';
+import {
+  addTemplatesAndDocuments,
+  removeModelAction
+} from 'etna-js/actions/magma_actions';
 import {isLeafModel} from '../../utils/edit_map';
 import useMagmaActions from './use_magma_actions';
 
@@ -471,7 +474,7 @@ const ModelReport = ({
   }, [model_name, models]);
 
   useEffect(() => {
-    if (counts[model_name]?.count != null) {
+    if (counts[model_name]?.count) {
       setCanReparent(counts[model_name].count <= 0);
     } else {
       getAnswer([model_name, '::count'], (count) => {

--- a/timur/lib/client/jsx/utils/edit_map.ts
+++ b/timur/lib/client/jsx/utils/edit_map.ts
@@ -25,6 +25,10 @@ export const EDITABLE_ATTRIBUTE_TYPES = [
   'identifier'
 ];
 
+export const UNREMOVABLE_ATTRIBUTE_NAMES = ['created_at', 'updated_at'];
+
+export const UNEDITABLE_ATTRIBUTE_NAMES = ['created_at', 'updated_at'];
+
 const CHILD_ATTRIBUTE_TYPES = ['table', 'child', 'collection'];
 
 export const isLeafModel = (model: Model) => {

--- a/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
@@ -415,7 +415,11 @@ exports[`ModelMap renders 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                identifier
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  identifier
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -444,7 +448,11 @@ exports[`ModelMap renders 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                collection
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  collection
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -471,7 +479,11 @@ exports[`ModelMap renders 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                table
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  table
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -867,7 +879,11 @@ exports[`ModelMap renders an incomplete graph 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                identifier
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  identifier
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -896,7 +912,11 @@ exports[`ModelMap renders an incomplete graph 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                collection
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  collection
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -923,7 +943,11 @@ exports[`ModelMap renders an incomplete graph 1`] = `
                 aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
               >
-                table
+                <div
+                  className="makeStyles-typeWrapper-37"
+                >
+                  table
+                </div>
               </td>
               <td
                 aria-sort={null}
@@ -1246,7 +1270,11 @@ exports[`ModelMap renders with model action buttons for admin user (no reparent 
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  identifier
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    identifier
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1268,7 +1296,11 @@ exports[`ModelMap renders with model action buttons for admin user (no reparent 
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  collection
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    collection
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1288,7 +1320,11 @@ exports[`ModelMap renders with model action buttons for admin user (no reparent 
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  table
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    table
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1706,7 +1742,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  parent
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    parent
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1726,7 +1766,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  identifier
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    identifier
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1746,7 +1790,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  collection
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    collection
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1766,7 +1814,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  collection
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    collection
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1786,7 +1838,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  link
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    link
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1806,7 +1862,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  file
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    file
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1826,7 +1886,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  file_collection
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    file_collection
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -1846,7 +1910,11 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  string
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    string
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -2285,7 +2353,11 @@ exports[`ModelMap renders without model action buttons for editor user 1`] = `
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  identifier
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    identifier
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -2307,7 +2379,11 @@ exports[`ModelMap renders without model action buttons for editor user 1`] = `
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  collection
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    collection
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"
@@ -2327,7 +2403,11 @@ exports[`ModelMap renders without model action buttons for editor user 1`] = `
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-type-29 MuiTableCell-alignRight MuiTableCell-sizeSmall"
                 >
-                  table
+                  <div
+                    class="makeStyles-typeWrapper-37"
+                  >
+                    table
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-body makeStyles-value-24 MuiTableCell-alignLeft MuiTableCell-sizeSmall"


### PR DESCRIPTION
This PR gives administrator users a toggle to view hidden attributes, which they can then edit / un-hide / remove.

It does not allow users to edit `created_at` or `updated_at`.

![Screenshot from 2022-11-21 15-33-00](https://user-images.githubusercontent.com/4930129/203328565-bd542a32-d7e4-4909-a762-0f1c4ebc8f0a.png)
![Screenshot from 2022-11-21 15-33-13](https://user-images.githubusercontent.com/4930129/203328591-469df95d-a1fc-47ef-915a-dd0c18ccef66.png)
![Screenshot from 2022-11-21 15-33-29](https://user-images.githubusercontent.com/4930129/203328615-9debdffe-3b21-42a3-b641-a70ae863d7bf.png)


closes #1131 