### PR TITLE
Build update ruby gem version

### DIFF
--- a/.github/workflows/gem-etna-push.yml
+++ b/.github/workflows/gem-etna-push.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby 2.5
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.5.x
+          ruby-version: 2.7.x
 
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/gem-etna-push.yml
+++ b/.github/workflows/gem-etna-push.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby 2.5
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7
 
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
The CI action for building the Ruby gem seems broken [due to 2.5.x syntax not being supported anymore?](https://github.com/mountetna/monoetna/actions/runs/3526795970/jobs/5915131384)...so trying `2.7` instead.