### PR TITLE
Metis copy folder

### DIFF
--- a/metis/lib/client/jsx/actions/folder_actions.jsx
+++ b/metis/lib/client/jsx/actions/folder_actions.jsx
@@ -1,85 +1,166 @@
 import {
-  postCreateFolder, postProtectFolder, postUnprotectFolder, postRenameFolder, deleteFolder,
-  getTouchFolder
+  postCreateFolder,
+  postProtectFolder,
+  postUnprotectFolder,
+  postRenameFolder,
+  deleteFolder,
+  getTouchFolder,
+  postCopyFolder
 } from '../api/folders_api';
-import { errorMessage } from './message_actions';
+import {errorMessage} from './message_actions';
 import {selectFoldersInCurrentFolder} from '../selectors/folder-selector';
 
-const addFolders = (folders) => ({ type: 'ADD_FOLDERS', folders });
-const removeFolders = (folders) => ({ type: 'REMOVE_FOLDERS', folders });
+const addFolders = (folders) => ({type: 'ADD_FOLDERS', folders});
+const removeFolders = (folders) => ({type: 'REMOVE_FOLDERS', folders});
 
-export const createFolder = ({bucket_name, folder_name, parent_folder}) => (dispatch) =>
-  postCreateFolder(CONFIG.project_name, bucket_name, parent_folder ? `${parent_folder}/${folder_name}` : folder_name)
-    .then(({folders}) => dispatch(addFolders(folders)))
-    .catch(
-      errorMessage(dispatch, 'warning', 'Folder creation failed', error => error)
-    );
+export const createFolder =
+  ({bucket_name, folder_name, parent_folder}) =>
+  (dispatch) =>
+    postCreateFolder(
+      CONFIG.project_name,
+      bucket_name,
+      parent_folder ? `${parent_folder}/${folder_name}` : folder_name
+    )
+      .then(({folders}) => dispatch(addFolders(folders)))
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder creation failed',
+          (error) => error
+        )
+      );
 
-export const removeFolder = ({bucket_name, folder, recursive}) => (dispatch) => {
-  deleteFolder(
-    CONFIG.project_name, bucket_name, folder.folder_path, recursive
-  )
-    .then(({folders}) => dispatch(removeFolders(folders)))
-    .catch(
-      response => response.then(
-        ({error}) => {
+export const removeFolder =
+  ({bucket_name, folder, recursive}) =>
+  (dispatch) => {
+    deleteFolder(
+      CONFIG.project_name,
+      bucket_name,
+      folder.folder_path,
+      recursive
+    )
+      .then(({folders}) => dispatch(removeFolders(folders)))
+      .catch((response) =>
+        response.then(({error}) => {
           if (error == 'Folder is not empty') {
-            if (!confirm(`"${folder.folder_path}" is not empty. Are you sure you want to remove the folder and its contents?`)) return;
+            if (
+              !confirm(
+                `"${folder.folder_path}" is not empty. Are you sure you want to remove the folder and its contents?`
+              )
+            )
+              return;
             removeFolder({bucket_name, folder, recursive: true})(dispatch);
             return;
           }
-          errorMessage(dispatch, 'warning', 'Folder removal failed', error => error)(error);
-        }
-      )
-    );
-};
+          errorMessage(
+            dispatch,
+            'warning',
+            'Folder removal failed',
+            (error) => error
+          )(error);
+        })
+      );
+  };
 
+export const protectFolder =
+  ({bucket_name, folder}) =>
+  (dispatch) => {
+    postProtectFolder(CONFIG.project_name, bucket_name, folder.folder_path)
+      .then(({folders}) => dispatch(addFolders(folders)))
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder protection failed',
+          (error) => error
+        )
+      );
+  };
 
-export const protectFolder = ({bucket_name, folder}) => (dispatch) => {
-  postProtectFolder(
-    CONFIG.project_name, bucket_name, folder.folder_path
-  )
-    .then(({folders}) => dispatch(addFolders(folders)))
-    .catch(
-      errorMessage(dispatch, 'warning', 'Folder protection failed', error => error)
-    );
-};
+export const unprotectFolder =
+  ({bucket_name, folder}) =>
+  (dispatch) => {
+    if (!confirm(`Are you sure you want to unprotect ${folder.folder_path}?`))
+      return;
 
-export const unprotectFolder = ({bucket_name, folder}) => (dispatch) => {
-  if (!confirm(`Are you sure you want to unprotect ${folder.folder_path}?`)) return;
+    postUnprotectFolder(CONFIG.project_name, bucket_name, folder.folder_path)
+      .then(({folders}) => dispatch(addFolders(folders)))
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder unprotection failed',
+          (error) => error
+        )
+      );
+  };
 
-  postUnprotectFolder(
-    CONFIG.project_name, bucket_name, folder.folder_path
-  )
-    .then(({folders}) => dispatch(addFolders(folders)))
-    .catch(
-      errorMessage(dispatch, 'warning', 'Folder unprotection failed', error => error)
-    );
-};
+export const renameFolder =
+  ({bucket_name, folder, new_folder_path, new_bucket_name, current_folder}) =>
+  (dispatch) => {
+    postRenameFolder(
+      CONFIG.project_name,
+      bucket_name,
+      folder.folder_path,
+      new_folder_path,
+      new_bucket_name
+    )
+      .then(({folders}) => {
+        dispatch(removeFolders([folder]));
+        dispatch(
+          addFolders(
+            selectFoldersInCurrentFolder({folders, bucket_name, current_folder})
+          )
+        );
+      })
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder renaming failed',
+          (error) => error
+        )
+      );
+  };
 
-export const renameFolder = ({bucket_name, folder, new_folder_path, new_bucket_name, current_folder}) => (dispatch) => {
-  postRenameFolder(
-    CONFIG.project_name, bucket_name, folder.folder_path, new_folder_path, new_bucket_name
-  )
-    .then(({folders}) => {
-      dispatch(removeFolders([folder]));
-      dispatch(addFolders(selectFoldersInCurrentFolder({folders, bucket_name, current_folder})));
-    })
-    .catch(
-      errorMessage(dispatch, 'warning', 'Folder renaming failed', error => error)
-    );
-};
+export const copyFolder =
+  ({bucket_name, folder, new_parent_folder, new_bucket_name}) =>
+  (dispatch) => {
+    postCopyFolder(
+      CONFIG.project_name,
+      bucket_name,
+      folder.folder_path,
+      new_parent_folder,
+      new_bucket_name
+    )
+      .then(({folders}) => {
+        console.log('folders', folders);
+      })
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder copy failed',
+          (error) => error
+        )
+      );
+  };
 
-export const touchFolder = ({bucket_name, folder}) => (dispatch) => {
-  getTouchFolder(
-    CONFIG.project_name, bucket_name, folder.folder_path
-  )
-    .then(({folders}) => {
-      dispatch(removeFolders([folder]));
-      dispatch(addFolders(folders));
-    })
-    .catch(
-      errorMessage(dispatch, 'warning', 'Folder touching failed', error => error)
-    );
-};
-
+export const touchFolder =
+  ({bucket_name, folder}) =>
+  (dispatch) => {
+    getTouchFolder(CONFIG.project_name, bucket_name, folder.folder_path)
+      .then(({folders}) => {
+        dispatch(removeFolders([folder]));
+        dispatch(addFolders(folders));
+      })
+      .catch(
+        errorMessage(
+          dispatch,
+          'warning',
+          'Folder touching failed',
+          (error) => error
+        )
+      );
+  };

--- a/metis/lib/client/jsx/api/folders_api.jsx
+++ b/metis/lib/client/jsx/api/folders_api.jsx
@@ -1,4 +1,4 @@
-import { json_get, json_delete, json_post } from 'etna-js/utils/fetch';
+import {json_get, json_delete, json_post} from 'etna-js/utils/fetch';
 
 export const postCreateFolder = (project_name, bucket_name, folder_name) =>
   json_post(`/${project_name}/folder/create/${bucket_name}/${folder_name}`);
@@ -9,18 +9,54 @@ export const postProtectFolder = (project_name, bucket_name, folder_name) =>
 export const postUnprotectFolder = (project_name, bucket_name, folder_name) =>
   json_post(`/${project_name}/folder/unprotect/${bucket_name}/${folder_name}`);
 
-export const postRenameFolder = (project_name, bucket_name, folder_name, new_folder_path, new_bucket_name=null) => {
+export const postRenameFolder = (
+  project_name,
+  bucket_name,
+  folder_name,
+  new_folder_path,
+  new_bucket_name = null
+) => {
   let payload = {
     new_folder_path
   };
 
   if (new_bucket_name) payload.new_bucket_name = new_bucket_name;
 
-  return json_post(`/${project_name}/folder/rename/${bucket_name}/${folder_name}`, payload);
+  return json_post(
+    `/${project_name}/folder/rename/${bucket_name}/${folder_name}`,
+    payload
+  );
 };
 
-export const deleteFolder = (project_name, bucket_name, folder_name, recursive) =>
-json_delete(`/${project_name}/folder/remove/${bucket_name}/${folder_name}`, recursive ? {recursive: true } : {});
+export const deleteFolder = (
+  project_name,
+  bucket_name,
+  folder_name,
+  recursive
+) =>
+  json_delete(
+    `/${project_name}/folder/remove/${bucket_name}/${folder_name}`,
+    recursive ? {recursive: true} : {}
+  );
 
 export const getTouchFolder = (project_name, bucket_name, folder_name) =>
   json_get(`/${project_name}/folder/touch/${bucket_name}/${folder_name}`);
+
+export const postCopyFolder = (
+  project_name,
+  bucket_name,
+  folder_name,
+  new_parent_folder,
+  new_bucket_name = null
+) => {
+  let payload = {
+    new_parent_folder
+  };
+
+  if (new_bucket_name) payload.new_bucket_name = new_bucket_name;
+
+  return json_post(
+    `/${project_name}/folder/copy/${bucket_name}/${folder_name}`,
+    payload
+  );
+};

--- a/metis/lib/client/jsx/components/dialogs/copy-folder-dialog.tsx
+++ b/metis/lib/client/jsx/components/dialogs/copy-folder-dialog.tsx
@@ -1,0 +1,54 @@
+import React, {useState, useCallback} from 'react';
+
+import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
+
+import ConfigRow from './config-row';
+
+const CopyFolderDialog = ({
+  currentBucketName,
+  onSubmit
+}: {
+  currentBucketName: string;
+  onSubmit: (bucketName: string, folderPath: string) => void;
+}) => {
+  const [bucketName, setBucketName] = useState(currentBucketName);
+  const [parentFolderPath, setParentFolderPath] = useState('');
+  const invoke = useActionInvoker();
+
+  const submit = useCallback(() => {
+    onSubmit(bucketName, parentFolderPath);
+    invoke({type: 'DISMISS_DIALOG'});
+  }, [bucketName, parentFolderPath, invoke, onSubmit]);
+
+  return (
+    <div className='copy-folder-dialog'>
+      <div className='title'>Copy folder</div>
+      <ConfigRow label='Bucket name'>
+        <input
+          type='text'
+          placeholder='E.g. bucket_name'
+          value={bucketName}
+          onChange={(e) => setBucketName(e.target.value)}
+        />
+      </ConfigRow>
+      <ConfigRow label='Parent folder (blank for root)'>
+        <input
+          type='text'
+          placeholder='E.g. root/child'
+          value={parentFolderPath}
+          onChange={(e) => setParentFolderPath(e.target.value)}
+        />
+      </ConfigRow>
+      <div className='submit'>
+        <span
+          className={`button ${bucketName ? '' : 'disabled'}`}
+          onClick={submit}
+        >
+          Copy
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default CopyFolderDialog;

--- a/metis/lib/client/jsx/components/list/folder-control.tsx
+++ b/metis/lib/client/jsx/components/list/folder-control.tsx
@@ -38,15 +38,14 @@ const FolderControl = ({
           'Invalid name -- cannot change the folder path'
         )
       );
-    }
- else if (new_folder_name) {
-invoke({
+    } else if (new_folder_name) {
+      invoke({
         type: 'RENAME_FOLDER',
         folder,
         new_folder_path: filePath(current_folder, new_folder_name),
         bucket_name
       });
-}
+    }
   }, [folder, current_folder, bucket_name, invoke]);
 
   const removeFolder = useCallback(() => {
@@ -71,6 +70,19 @@ invoke({
     [folder, bucket_name, current_folder, invoke]
   );
 
+  const copyFolder = useCallback(
+    (newBucketName: string, parentFolderPath: string) => {
+      invoke({
+        type: 'COPY_FOLDER',
+        folder,
+        new_parent_folder: '' === parentFolderPath ? '/' : parentFolderPath,
+        new_bucket_name: newBucketName,
+        bucket_name
+      });
+    },
+    [folder, bucket_name, invoke]
+  );
+
   const moveFolderDialog = useCallback(() => {
     let dialog = {
       type: 'move-folder',
@@ -82,6 +94,18 @@ invoke({
       dialog
     });
   }, [moveFolder, bucket_name, invoke]);
+
+  const copyFolderDialog = useCallback(() => {
+    let dialog = {
+      type: 'copy-folder',
+      onSubmit: copyFolder,
+      currentBucketName: bucket_name
+    };
+    invoke({
+      type: 'SHOW_DIALOG',
+      dialog
+    });
+  }, [copyFolder, bucket_name, invoke]);
 
   let items: UiControlItem[] = folder.read_only
     ? [
@@ -116,6 +140,11 @@ invoke({
           label: 'Move folder',
           callback: moveFolderDialog,
           role: 'editor'
+        },
+        {
+          label: 'Copy folder',
+          callback: copyFolderDialog,
+          role: 'administrator'
         }
       ];
   return <MenuControl items={items} />;

--- a/metis/lib/client/jsx/components/modal-dialog.jsx
+++ b/metis/lib/client/jsx/components/modal-dialog.jsx
@@ -8,6 +8,7 @@ import UploadDialog from './dialogs/upload-dialog';
 import MoveFolder from './dialogs/move-folder-dialog';
 import MoveFile from './dialogs/move-file-dialog';
 import FileProperties from './dialogs/file-properties-dialog';
+import CopyFolder from './dialogs/copy-folder-dialog';
 
 const DIALOGS = {
   ConfigureBucket,
@@ -15,7 +16,8 @@ const DIALOGS = {
   UploadDialog,
   MoveFolder,
   MoveFile,
-  FileProperties
+  FileProperties,
+  CopyFolder
 };
 
 const ModalDialog = ({dialog, dismissDialog}) => {

--- a/metis/lib/client/scss/dialog.scss
+++ b/metis/lib/client/scss/dialog.scss
@@ -47,7 +47,6 @@
       }
     }
 
-
     .upload-dialog {
       width: 300px;
       font-family: $base-font;
@@ -67,7 +66,8 @@
     .config-dialog,
     .move-folder-dialog,
     .move-file-dialog,
-    .file-properties-dialog {
+    .file-properties-dialog,
+    .copy-folder-dialog {
       width: 300px;
       font-family: $base-font;
       padding: 5px;
@@ -77,7 +77,7 @@
       }
       .errors {
         display: block;
-        background: rgba(255,0,0,0.1);
+        background: rgba(255, 0, 0, 0.1);
         color: darkred;
         font-size: 0.8em;
         margin: 5px;
@@ -101,12 +101,13 @@
           padding-top: 3px;
           font-size: 0.8em;
           flex: 1 1;
-          select, input {
+          select,
+          input {
             border: 0px;
             border-bottom: $medium-rule;
           }
           input {
-            font-size: 1.0em;
+            font-size: 1em;
             width: 95%;
           }
         }
@@ -120,7 +121,6 @@
           color: #222;
           padding: 3px;
           font-size: 0.8em;
-
         }
       }
 
@@ -163,7 +163,6 @@
           }
         }
       }
-
 
       .ingest-selector {
         margin-bottom: 1rem;

--- a/metis/lib/folder_copy_revision.rb
+++ b/metis/lib/folder_copy_revision.rb
@@ -1,0 +1,51 @@
+require_relative 'folder_revision'
+
+class Metis
+  class FolderCopyRevision < FolderRevision
+    def revise!
+      raise 'Invalid revision, cannot revise!' unless valid?
+      raise 'Cannot revise without a user' unless @user
+
+      # Have to fetch the actual source folder. What gets
+      #   set in the revision's source.folder attribute
+      #   is the parent folder, which
+      #   we don't need at this point.
+      source_folder = Metis::Folder.from_path(
+        @source.bucket, full_folder_path(@source)).last
+
+      source_folder.copy(
+        new_parent_folder: @dest.folder,
+        new_bucket: @dest.bucket,
+        user: @user)
+
+      return source_folder
+    end
+
+    def validate
+      super
+      validate_non_recursive_copy
+    end
+
+    private
+
+    def validate_non_recursive_copy
+      return unless dest_path_inside_source
+
+      @errors << "Cannot copy folder into itself: \"#{@source.mpath.path}\""
+    end
+
+    def dest_path_inside_source
+      # Copying from root-to-root is okay
+      return false if @source.folder.nil? && @dest.folder.nil?
+
+      # Copying from some subfolder to root is okay
+      return false if @dest.folder.nil?
+      # Not okay where the source folder is a root folder and is the dest folder
+      return @dest.folder.folder_name == @source.mpath.file_name && @dest.folder.folder.nil? if @source.folder.nil?
+
+      # Should return `true` if source is a folder, and it
+      #   lies anywhere on the path of @dest.folder up to root
+      @dest.folder.parent_folders.include?(@source.folder)
+    end
+  end
+end

--- a/metis/lib/folder_copy_revision.rb
+++ b/metis/lib/folder_copy_revision.rb
@@ -30,6 +30,8 @@ class Metis
     private
 
     def validate_new_parent_folder
+      return if @source.bucket != @dest.bucket
+
       # Not okay if the source folder is a root folder and the dest is
       #   a root folder, too (i.e. dest.folder == nil), so would be
       #   copying into itself.

--- a/metis/lib/folder_copy_revision.rb
+++ b/metis/lib/folder_copy_revision.rb
@@ -33,7 +33,7 @@ class Metis
       # Not okay if the source folder is a root folder and the dest is
       #   a root folder, too (i.e. dest.folder == nil), so would be
       #   copying into itself.
-      return unless @source.folder.folder_id == nil && @dest.folder == nil
+      return unless @source.folder != nil && @source.folder.folder_id == nil && @dest.folder == nil
 
       @errors << "Parent folder is the same as current: \"#{@source.mpath.path}\""
     end

--- a/metis/lib/folder_copy_revision.rb
+++ b/metis/lib/folder_copy_revision.rb
@@ -24,9 +24,19 @@ class Metis
     def validate
       super
       validate_non_recursive_copy
+      validate_new_parent_folder
     end
 
     private
+
+    def validate_new_parent_folder
+      # Not okay if the source folder is a root folder and the dest is
+      #   a root folder, too (i.e. dest.folder == nil), so would be
+      #   copying into itself.
+      return unless @source.folder.folder_id == nil && @dest.folder == nil
+
+      @errors << "Parent folder is the same as current: \"#{@source.mpath.path}\""
+    end
 
     def validate_non_recursive_copy
       return unless dest_path_inside_source
@@ -38,10 +48,12 @@ class Metis
       # Copying from root-to-root is okay
       return false if @source.folder.nil? && @dest.folder.nil?
 
-      # Copying from some subfolder to root is okay
+      # Otherwise, copying from some subfolder to root is okay
       return false if @dest.folder.nil?
       # Not okay where the source folder is a root folder and is the dest folder
       return @dest.folder.folder_name == @source.mpath.file_name && @dest.folder.folder.nil? if @source.folder.nil?
+
+      return true if @source.folder == @dest.folder
 
       # Should return `true` if source is a folder, and it
       #   lies anywhere on the path of @dest.folder up to root

--- a/metis/lib/models/folder.rb
+++ b/metis/lib/models/folder.rb
@@ -186,6 +186,7 @@ class Metis
 
     def copy(new_parent_folder: nil, new_bucket: nil, user:)
       raise CopyError.new("Cannot copy into child folder.") if new_parent_folder && child_folders.include?(new_parent_folder)
+      raise CopyError.new("Cannot copy into itself.") if new_parent_folder && new_parent_folder == self
 
       new_folder = Metis::Folder.create(
         folder_name: folder_name,

--- a/metis/lib/models/folder.rb
+++ b/metis/lib/models/folder.rb
@@ -9,6 +9,9 @@ class Metis
 
     one_to_many :files
 
+    class CopyError < Exception
+    end
+
     def self.mkdir_p(bucket, folder_path, project_name, author)
       existing_folders = Metis::Folder.from_path(bucket, folder_path, allow_partial_match: true)
       folder_names = folder_path.split(%r!/!)
@@ -168,7 +171,7 @@ class Metis
 
       new_params[:author] = Metis::File.author(user) if user
 
-      update(**new_params)      
+      update(**new_params)
 
       # Need to recursively update all sub-folders and files
       files.each { |file|
@@ -179,6 +182,26 @@ class Metis
       }
 
       refresh
+    end
+
+    def copy(new_parent_folder: nil, new_bucket: nil, user:)
+      raise CopyError.new("Cannot copy into child folder.") if new_parent_folder && child_folders.include?(new_parent_folder)
+
+      new_folder = Metis::Folder.create(
+        folder_name: folder_name,
+        bucket_id: new_bucket.nil? ? bucket.id : new_bucket.id,
+        folder_id: new_parent_folder&.id,
+        project_name: project_name,
+        author: Metis::File.author(user),
+      )
+
+      # Need to recursively update all sub-folders and files
+      files.each { |file|
+        copy_file(new_folder, file, user)
+      }
+      folders.each { |folder|
+        folder.copy(new_parent_folder: new_folder, new_bucket: new_bucket, user: user)
+      }
     end
 
     def remove_contents!
@@ -217,6 +240,40 @@ class Metis
       my_hash.delete(:folder_path) if !with_path
 
       return my_hash
+    end
+
+    private
+
+    def copy_file(new_folder, file, user)
+      revision = Metis::CopyRevision.new({
+        source: Metis::Path.path_from_parts(
+          project_name,
+          bucket.name,
+          ::File.join(folder_path, file.file_name)
+        ),
+        dest: Metis::Path.path_from_parts(
+          project_name,
+          new_folder.bucket.name,
+          ::File.join(new_folder.folder_path, file.file_name)
+        ),
+        user: user
+      })
+
+      revision.set_bucket(revision.source, [bucket])
+      revision.set_bucket(revision.dest, [new_folder.bucket])
+
+      revision.set_folder(
+        revision.source,
+        [self])
+      revision.set_folder(
+        revision.dest,
+        [new_folder])
+
+      revision.validate
+
+      raise Etna::BadRequest, revision.errors.join("\n") unless revision.valid?
+
+      revision.revise!
     end
   end
 end

--- a/metis/lib/path.rb
+++ b/metis/lib/path.rb
@@ -24,6 +24,23 @@ class Metis
       !x
       end
 
+      def self.root_folder_path_match
+        # Assumes Metis root folder paths are in the form
+        #    metis://<project>/<bucket>
+        # Splitting the above produces
+        #   ["metis", "", "<project>", "<bucket>"]
+
+        @root_folder_path_match ||= %r!
+        \A
+          metis:\/\/
+          (?<project_name>(\w+))
+          /
+          (?<bucket_name>(\w+))
+          /?
+        \z
+      !x
+      end
+
       def self.remove_double_slashes(path)
         return ::File.join(path.split("/")) unless path.start_with?("metis://")
 
@@ -35,11 +52,13 @@ class Metis
       end
 
       def project_name
-        valid? ? Metis::Path.filepath_match.match(@path)[:project_name] : nil
+        valid? ?
+          path_regex[:project_name] :
+          nil
       end
 
       def bucket_name
-        valid? ? Metis::Path.filepath_match.match(@path)[:bucket_name] : nil
+        valid? ? path_regex[:bucket_name] : nil
       end
 
       def bucket_matches?(bucket)
@@ -47,7 +66,7 @@ class Metis
       end
 
       def folder_matches?(folder)
-        folder.folder_path.join('/') == folder_path &&
+        ::File.join(folder.folder_path) == folder_path &&
         folder.project_name == project_name
       end
 
@@ -57,7 +76,9 @@ class Metis
       end
 
       def file_path
-        valid? ? Metis::Path.filepath_match.match(@path)[:file_path] : nil
+        valid? && matches_filepath? ?
+          Metis::Path.filepath_match.match(@path)[:file_path] :
+          nil
       end
 
       def file_name
@@ -66,7 +87,21 @@ class Metis
       end
 
       def valid?
+        matches_filepath? || matches_root_folder_path?
+      end
+
+      def matches_filepath?
         !!Metis::Path.filepath_match.match(@path)
+      end
+
+      def matches_root_folder_path?
+        !!Metis::Path.root_folder_path_match.match(@path)
+      end
+
+      def path_regex
+        matches_filepath? ?
+          Metis::Path.filepath_match.match(@path) :
+          Metis::Path.root_folder_path_match.match(@path)
       end
     end
   end

--- a/metis/lib/server.rb
+++ b/metis/lib/server.rb
@@ -51,6 +51,7 @@ class Metis
     post '/:project_name/folder/protect/:bucket_name/*folder_path', action: 'folder#protect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/unprotect/:bucket_name/*folder_path', action: 'folder#unprotect', auth: { user: { is_admin?: :project_name } }
     post '/:project_name/folder/rename/:bucket_name/*folder_path', action: 'folder#rename', auth: { user: { can_edit?: :project_name } }
+    post '/:project_name/folder/copy/:bucket_name/*folder_path', action: 'folder#copy', auth: { user: { can_edit?: :project_name } }
 
     # file operations
     delete '/:project_name/file/remove/:bucket_name/*file_path', action: 'file#remove', auth: { user: { can_edit?: :project_name } }

--- a/metis/spec/folder_copy_revision_spec.rb
+++ b/metis/spec/folder_copy_revision_spec.rb
@@ -219,6 +219,24 @@ describe Metis::FolderCopyRevision do
       )
   end
 
+  it 'adds error message if trying to copy into current parent folder' do
+    revision = Metis::FolderCopyRevision.new({
+        source: 'metis://athena/files/wisdom',
+        dest: 'metis://athena/files/',
+        user: @user
+    })
+
+    revision.source.bucket = default_bucket('athena')
+    revision.source.folder = @wisdom_folder
+    revision.dest.bucket = default_bucket('athena')
+    expect(revision.errors).to eq(nil)
+    revision.validate
+    expect(revision.errors.length).to eq(1)
+    expect(revision.errors[0]).to eq(
+        "Parent folder is the same as current: \"metis://athena/files/wisdom\""
+    )
+end
+
   context 'recursive renaming' do
       context 'is okay' do
           it 'copying from subfolder to root' do

--- a/metis/spec/folder_copy_revision_spec.rb
+++ b/metis/spec/folder_copy_revision_spec.rb
@@ -1,0 +1,600 @@
+describe Metis::FolderCopyRevision do
+
+  def app
+    OUTER_APP
+  end
+
+  before(:each) do
+    default_bucket('athena')
+
+    @user = Etna::User.new({
+      name: 'Athena',
+      email: 'athena@olympus.org',
+      perm: 'a:athena'
+    })
+
+    @wisdom_folder = create_folder('athena', 'wisdom')
+    stubs.create_folder('athena', 'files', 'wisdom')
+  end
+
+  after(:each) do
+    stubs.clear
+
+    expect(stubs.contents(:athena)).to be_empty
+  end
+
+  it 'creates a Metis::PathWithObjects as the dest parameter' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/wisdom',
+          user: @user
+      })
+      expect(revision.dest.instance_of? Metis::PathWithObjects).to eq(true)
+  end
+
+  it 'adds error message if user cannot access the dest bucket' do
+      sundry_bucket = create( :bucket, project_name: 'athena', name: 'sundry', access: 'viewer', owner: 'metis' )
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/sundry/wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid bucket \"sundry\" in project \"athena\". Check the bucket name and your permissions."
+      )
+  end
+
+  it 'does not add error message if user can access the dest bucket' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/wisdom_2',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'adds error message if the dest path is invalid' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: "metis://athena/files/learn\nwisdom",
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"metis://athena/files/learn\nwisdom\""
+      )
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'does not add error message if the dest path is valid' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/learn-wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+
+      blueprints_folder = create_folder('athena', 'blueprints')
+      stubs.create_folder('athena', 'files', 'blueprints')
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/blueprints/drawing_wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.dest.folder = blueprints_folder
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'returns the source and dest bucket_names in an array' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/helmet',
+          dest: 'metis://athena/files/wisdom',
+          user: @user
+      })
+      expect(revision.bucket_names).
+          to eq(['files', 'files'])
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/helmet',
+          dest: nil,
+          user: @user
+      })
+      expect(revision.bucket_names).
+          to eq(['files'])
+  end
+
+  it 'adds error message if dest bucket is read-only' do
+      contents_folder = create_folder('athena', 'contents', read_only: true)
+      stubs.create_folder('athena', 'files', 'contents')
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/contents/wisdom',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.dest.folder = contents_folder
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Folder \"contents\" is read-only"
+      )
+  end
+
+  it 'adds error message if dest file exists' do
+      @wisdom2_file = create_file('athena', 'wisdom2.txt', WISDOM*2)
+      stubs.create_file('athena', 'files', 'wisdom2.txt', WISDOM*2)
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/wisdom2.txt',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Cannot overwrite existing file: \"metis://athena/files/wisdom2.txt\""
+      )
+  end
+
+  it 'reports multiple errors from validation' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/helmet',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+
+      expect(revision.errors.length).to eq(2)
+
+      expect(revision.errors[0]).to eq(
+          "Folder not found: \"metis://athena/files/helmet\""
+      )
+      expect(revision.errors[1]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'adds error message if trying to copy over an existing folder' do
+      wisdom_folder = create_folder('athena', 'wisdom_jr')
+      stubs.create_folder('athena', 'files', 'wisdom_jr')
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/wisdom_jr',
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Cannot copy over existing folder: \"metis://athena/files/wisdom_jr\""
+      )
+  end
+
+  context 'recursive renaming' do
+      context 'is okay' do
+          it 'copying from subfolder to root' do
+              wisdom2_folder = create_folder('athena', 'wisdom2', folder: @wisdom_folder)
+              stubs.create_folder('athena', 'files/wisdom', 'wisdom2')
+
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom/wisdom2',
+                  dest: 'metis://athena/files/wisdom3',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.source.folder = @wisdom_folder
+              revision.dest.bucket = default_bucket('athena')
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(0)
+          end
+
+          it 'copying from subfolder to similarly-named subfolder' do
+              wisdom_dup_folder = create_folder('athena', 'wisdom', folder: @wisdom_folder)
+              stubs.create_folder('athena', 'files/wisdom', 'wisdom')
+              wisdom2_folder = create_folder('athena', 'wisdom2', folder: wisdom_dup_folder)
+              stubs.create_folder('athena', 'files/wisdom/wisdom', 'wisdom2')
+
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom/wisdom/wisdom2',
+                  dest: 'metis://athena/files/wisdom/wisdom2',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.source.folder = wisdom_dup_folder
+              revision.dest.bucket = default_bucket('athena')
+              revision.dest.folder = @wisdom_folder
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(0)
+          end
+
+          it 'copying from root to root' do
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom',
+                  dest: 'metis://athena/files/wisdom2',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.dest.bucket = default_bucket('athena')
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(0)
+          end
+      end
+
+      context 'adds error' do
+          it 'if trying to copy into itself at root level' do
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom',
+                  dest: 'metis://athena/files/wisdom/wisdom',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.dest.bucket = default_bucket('athena')
+              revision.dest.folder = @wisdom_folder
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(1)
+              expect(revision.errors[0]).to eq(
+                  "Cannot copy folder into itself: \"metis://athena/files/wisdom\""
+              )
+          end
+
+          it 'if trying to copy anywhere into its children path' do
+              wisdom_dup_folder = create_folder('athena', 'wisdom', folder: @wisdom_folder)
+              stubs.create_folder('athena', 'files/wisdom', 'wisdom')
+              wisdom2_folder = create_folder('athena', 'wisdom2', folder: wisdom_dup_folder)
+              stubs.create_folder('athena', 'files/wisdom/wisdom', 'wisdom2')
+
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom/wisdom',
+                  dest: 'metis://athena/files/wisdom/wisdom/wisdom2/cyclic-wisdom',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.dest.bucket = default_bucket('athena')
+              revision.dest.folder = @wisdom_folder
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(1)
+              expect(revision.errors[0]).to eq(
+                  "Cannot copy folder into itself: \"metis://athena/files/wisdom/wisdom\""
+              )
+          end
+
+          it 'if trying to copy into itself not at root level' do
+              wisdom2_folder = create_folder('athena', 'wisdom2', folder: @wisdom_folder)
+              stubs.create_folder('athena', 'files/wisdom', 'wisdom2')
+
+              revision = Metis::FolderCopyRevision.new({
+                  source: 'metis://athena/files/wisdom/wisdom2',
+                  dest: 'metis://athena/files/wisdom/wisdom2/wisdom2',
+                  user: @user
+              })
+
+              revision.source.bucket = default_bucket('athena')
+              revision.source.folder = @wisdom_folder
+              revision.dest.bucket = default_bucket('athena')
+              revision.dest.folder = wisdom2_folder
+              expect(revision.errors).to eq(nil)
+              revision.validate
+              expect(revision.errors.length).to eq(1)
+              expect(revision.errors[0]).to eq(
+                  "Cannot copy folder into itself: \"metis://athena/files/wisdom/wisdom2\""
+              )
+          end
+      end
+  end
+
+  it 'executes the revision' do
+      learn_wisdom_folder = create_folder('athena', 'learn-wisdom')
+      stubs.create_folder('athena', 'files', 'learn-wisdom')
+      expect(learn_wisdom_folder.folders.length).to eq(0)
+
+      expect(Metis::Folder.count).to eq(2)
+      expect(Metis::Folder.first.author).to eq('metis|Metis')
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/learn-wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.dest.folder = learn_wisdom_folder
+      revision.validate
+      revision.revise!
+      expect(Metis::Folder.count).to eq(3)
+      learn_wisdom_folder.refresh
+      expect(learn_wisdom_folder.folders.length).to eq(1)
+  end
+
+  it 'executes the revision to a new bucket' do
+      new_bucket_name = 'new_bucket'
+      stubs.create_bucket(new_bucket_name, 'files')
+      new_bucket = create( :bucket, project_name: new_bucket_name, name: 'files', owner: 'metis', access: 'viewer')
+
+      expect(new_bucket.folders.length).to eq(0)
+      expect(Metis::Folder.count).to eq(1)
+      expect(Metis::Folder.first.author).to eq('metis|Metis')
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: "metis://#{new_bucket_name}/files",
+          user: @user
+      })
+
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = new_bucket
+      revision.validate
+      revision.revise!
+      new_bucket.refresh
+      expect(Metis::Folder.count).to eq(2)
+      expect(new_bucket.folders.length).to eq(1)
+  end
+
+  it 'throws exception if you try to revise without setting user' do
+      expect(Metis::Folder.count).to eq(1)
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/learn-wisdom'
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      revision.validate
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::Folder.count).to eq(1)
+  end
+
+  it 'adds error message if source bucket is invalid' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/war/helmet',
+          dest: 'metis://athena/files/wisdom',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(2)
+      expect(revision.errors).to eq([
+          "Invalid bucket \"war\" in project \"athena\". Check the bucket name and your permissions.",
+          "Cannot copy over existing folder: \"metis://athena/files/wisdom\""
+      ])
+  end
+
+  it 'adds error message if source folder does not exist' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom_jr',
+          dest: 'metis://athena/files/wisdom_sr',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Folder not found: \"metis://athena/files/wisdom_jr\""
+      )
+  end
+
+  it 'adds error message if the source path is invalid' do
+      revision = Metis::FolderCopyRevision.new({
+          source: "metis://athena/files/build\nhelmet",
+          dest: "metis://athena/magma/instructables",
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"metis://athena/files/build\nhelmet\""
+      )
+
+      revision = Metis::FolderCopyRevision.new({
+          source: nil,
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(2)
+      expect(revision.errors[0]).to eq(
+          "Invalid path: \"\""
+      )
+      expect(revision.errors[1]).to eq(
+          "Invalid path: \"\""
+      )
+  end
+
+  it 'does not add error message if the source path is valid' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/backup_wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'adds error message if user cannot access the source bucket' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/magma/wisdom',
+          dest: 'metis://athena/files/wisdom',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(2)
+      expect(revision.errors[0]).to eq(
+          "Invalid bucket \"magma\" in project \"athena\". Check the bucket name and your permissions."
+      )
+  end
+
+  it 'does not add error message if user can access the source bucket' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/wisdom_jr',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors).to eq([])
+  end
+
+  it 'will not execute the revision if not valid' do
+      expect(Metis::Folder.count).to eq(1)
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: nil,
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      revision.validate
+      expect(revision.errors.length).to eq(1)
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::Folder.count).to eq(1)
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/files/backup_wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      expect {
+          revision.revise!
+      }.to raise_error(StandardError)
+
+      expect(Metis::Folder.count).to eq(1)
+  end
+
+  it 'is invalid if validate not run' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/wisdom',
+          dest: 'metis://athena/backup_files/wisdom',
+          user: @user
+      })
+      revision.source.bucket = default_bucket('athena')
+      revision.dest.bucket = default_bucket('athena')
+      expect(revision.errors).to eq(nil)
+      expect(revision.valid?).to eq(false)
+  end
+
+  it 'returns the dest and source paths in an array' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/helmet',
+          dest: 'metis://athena/magma/wisdom'
+      })
+      expect(revision.mpaths.length).to eq(2)
+      expect(revision.mpaths[0].path).
+          to eq('metis://athena/files/helmet')
+      expect(revision.mpaths[1].path).
+          to eq('metis://athena/magma/wisdom')
+
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/files/helmet',
+          dest: nil
+      })
+      expect(revision.mpaths.length).to eq(1)
+      expect(revision.mpaths[0].path).
+          to eq('metis://athena/files/helmet')
+  end
+
+  it 'returns a hash representation' do
+      revision = Metis::FolderCopyRevision.new({
+          source: 'metis://athena/magma/wisdom',
+          dest: 'metis://athena/files/wisdom',
+          user: @user
+      })
+      revision.dest.bucket = default_bucket('athena')
+
+      expect(revision.to_hash).to eq({
+          source: 'metis://athena/magma/wisdom',
+          dest: 'metis://athena/files/wisdom',
+          errors: nil
+      })
+
+      revision.validate
+
+      expect(revision.to_hash).to eq({
+          source: 'metis://athena/magma/wisdom',
+          dest: 'metis://athena/files/wisdom',
+          errors: [
+              "Invalid bucket \"magma\" in project \"athena\". Check the bucket name and your permissions.",
+              "Cannot copy over existing folder: \"metis://athena/files/wisdom\""],
+      })
+  end
+end

--- a/metis/spec/folder_copy_revision_spec.rb
+++ b/metis/spec/folder_copy_revision_spec.rb
@@ -237,6 +237,23 @@ describe Metis::FolderCopyRevision do
     )
   end
 
+  it 'works for copying into same parent in different bucket' do
+    new_bucket = create( :bucket, project_name: 'athena', name: 'backups', owner: 'metis', access: 'viewer')
+
+    revision = Metis::FolderCopyRevision.new({
+        source: 'metis://athena/files/wisdom',
+        dest: 'metis://athena/backups/',
+        user: @user
+    })
+
+    revision.source.bucket = default_bucket('athena')
+    revision.source.folder = @wisdom_folder
+    revision.dest.bucket = new_bucket
+    expect(revision.errors).to eq(nil)
+    revision.validate
+    expect(revision.errors.length).to eq(0)
+  end
+
   it 'adds error message if trying to copy into same parent directory' do
     revision = Metis::FolderCopyRevision.new({
         source: 'metis://athena/files/wisdom',

--- a/metis/spec/folder_copy_revision_spec.rb
+++ b/metis/spec/folder_copy_revision_spec.rb
@@ -235,7 +235,25 @@ describe Metis::FolderCopyRevision do
     expect(revision.errors[0]).to eq(
         "Parent folder is the same as current: \"metis://athena/files/wisdom\""
     )
-end
+  end
+
+  it 'adds error message if trying to copy into same parent directory' do
+    revision = Metis::FolderCopyRevision.new({
+        source: 'metis://athena/files/wisdom',
+        dest: 'metis://athena/files/',
+        user: @user
+    })
+
+    revision.source.bucket = default_bucket('athena')
+    revision.source.folder = @wisdom_folder
+    revision.dest.bucket = default_bucket('athena')
+    expect(revision.errors).to eq(nil)
+    revision.validate
+    expect(revision.errors.length).to eq(1)
+    expect(revision.errors[0]).to eq(
+        "Parent folder is the same as current: \"metis://athena/files/wisdom\""
+    )
+  end
 
   context 'recursive renaming' do
       context 'is okay' do
@@ -245,12 +263,12 @@ end
 
               revision = Metis::FolderCopyRevision.new({
                   source: 'metis://athena/files/wisdom/wisdom2',
-                  dest: 'metis://athena/files/wisdom3',
+                  dest: 'metis://athena/files/',
                   user: @user
               })
 
               revision.source.bucket = default_bucket('athena')
-              revision.source.folder = @wisdom_folder
+              revision.source.folder = wisdom2_folder
               revision.dest.bucket = default_bucket('athena')
               expect(revision.errors).to eq(nil)
               revision.validate

--- a/metis/spec/folder_spec.rb
+++ b/metis/spec/folder_spec.rb
@@ -1120,6 +1120,19 @@ describe FolderController do
         expect(Metis::Folder.count).to eq(5)
       end
 
+      it 'throws exception if try to copy to itself' do
+        expect(Metis::Folder.count).to eq(5)
+
+        expect {
+          @blueprints_folder.copy(
+            new_parent_folder: @blueprints_folder,
+            user: @user
+          )
+        }.to raise_error(Metis::Folder::CopyError)
+
+        expect(Metis::Folder.count).to eq(5)
+      end
+
       it 'works when source is at root of bucket' do
         expect(Metis::Folder.count).to eq(5)
         expect(@greenprints_folder.folders.length).to eq(0)
@@ -1290,6 +1303,22 @@ describe FolderController do
         copy_folder(
           ::File.join(@blueprints_folder.folder_path),
           ::File.join(@sketches_folder.folder_path))
+
+        expect(last_response.status).to eq(422)
+        expect(json_body[:errors]).to match_array([
+          "Cannot copy folder into itself: \"metis://athena/files/blueprints\""
+        ])
+
+        expect(Metis::Folder.count).to eq(5)
+      end
+
+      it 'throws exception if try to copy to self' do
+        expect(Metis::Folder.count).to eq(5)
+
+        token_header(:editor)
+        copy_folder(
+          ::File.join(@blueprints_folder.folder_path),
+          ::File.join(@blueprints_folder.folder_path))
 
         expect(last_response.status).to eq(422)
         expect(json_body[:errors]).to match_array([


### PR DESCRIPTION
This PR adds the ability to copy an entire folder, recursively, including subfolders and files. The UI widget is limited to administrators .... I think I will need it to organize the GNE data, and it might be useful for others :shrug: 

In the folder dropdown menu, there is a new item to "Copy folder", where you can specify the target bucket and parent folder path:

![Screenshot from 2022-11-29 09-41-30](https://user-images.githubusercontent.com/4930129/204592435-b4aace14-1d43-4800-a3b2-3f9016fe87c2.png)
![Screenshot from 2022-11-29 09-41-43](https://user-images.githubusercontent.com/4930129/204592460-ab8c3a4a-06ef-44b8-a4fd-91bcafade1f4.png)

You should not be able to cause recursive copies, or copy back into the same folder (i.e. replace yourself).
