### PR TITLE
does not refetch count when equals to 0; [close #1162]

### DIFF
--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -498,7 +498,7 @@ const ModelReport = ({
   }, [model_name, models]);
 
   useEffect(() => {
-    if (counts[model_name]?.count) {
+    if (counts[model_name]?.count >= 0) {
       setCanReparent(counts[model_name].count <= 0);
     } else {
       getAnswer([model_name, '::count'], (count) => {


### PR DESCRIPTION
This PR sets the logic check to account for 0 record count, so it won't continuously refetch the model count data.