### PR TITLE
Magma query join collection data

### DIFF
--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -41,6 +41,7 @@ class Magma
     @db = Sequel.connect(config(:db))
     @db.extension :connection_validator
     @db.extension :pg_json
+    @db.extension :string_agg
     Sequel.extension :pg_json_ops
     @db.pool.connection_validation_timeout = -1
   end

--- a/magma/lib/magma/attribute.rb
+++ b/magma/lib/magma/attribute.rb
@@ -101,6 +101,10 @@ class Magma
       Magma::ValidationObject.build(validation&.symbolize_keys)
     end
 
+    def predicate_class
+      Magma::RecordPredicate
+    end
+
     def json_template
       {
         name: attribute_name,
@@ -242,6 +246,7 @@ class Magma
   end
 end
 
+require_relative 'attributes/column_attribute'
 require_relative 'attributes/link'
 require_relative 'attributes/child'
 require_relative 'attributes/collection'

--- a/magma/lib/magma/attributes/boolean_attribute.rb
+++ b/magma/lib/magma/attributes/boolean_attribute.rb
@@ -1,7 +1,11 @@
 class Magma
-  class BooleanAttribute < Attribute
+  class BooleanAttribute < ColumnAttribute
     def database_type
       TrueClass
+    end
+
+    def predicate_class
+      Magma::BooleanPredicate
     end
   end
 end

--- a/magma/lib/magma/attributes/column_attribute.rb
+++ b/magma/lib/magma/attributes/column_attribute.rb
@@ -1,0 +1,4 @@
+class Magma
+  class ColumnAttribute < Attribute
+  end
+end

--- a/magma/lib/magma/attributes/date_time_attribute.rb
+++ b/magma/lib/magma/attributes/date_time_attribute.rb
@@ -1,5 +1,5 @@
 class Magma
-  class DateTimeAttribute < Attribute
+  class DateTimeAttribute < ColumnAttribute
     def database_type
       DateTime
     end
@@ -10,6 +10,10 @@ class Magma
 
     def revision_to_payload(record_name, new_value, loader)
       [ name, new_value ]
+    end
+
+    def predicate_class
+      Magma::DateTimePredicate
     end
   end
 end

--- a/magma/lib/magma/attributes/file_attribute.rb
+++ b/magma/lib/magma/attributes/file_attribute.rb
@@ -2,9 +2,13 @@ require_relative './file_copier'
 require_relative './file_serializer'
 
 class Magma
-  class FileAttribute < Attribute
+  class FileAttribute < ColumnAttribute
     def database_type
       :json
+    end
+
+    def predicate_class
+      Magma::FilePredicate
     end
 
     def serializer

--- a/magma/lib/magma/attributes/file_collection_attribute.rb
+++ b/magma/lib/magma/attributes/file_collection_attribute.rb
@@ -2,9 +2,13 @@ require_relative './file_copier'
 require_relative './file_serializer'
 
 class Magma
-  class FileCollectionAttribute < Attribute
+  class FileCollectionAttribute < ColumnAttribute
     def database_type
       :json
+    end
+
+    def predicate_class
+      Magma::FileCollectionPredicate
     end
 
     def serializer

--- a/magma/lib/magma/attributes/float_attribute.rb
+++ b/magma/lib/magma/attributes/float_attribute.rb
@@ -1,11 +1,15 @@
 class Magma
-  class FloatAttribute < Attribute
+  class FloatAttribute < ColumnAttribute
     def database_type
       Float
     end
 
     def revision_to_loader(record_name, new_value)
       [ name, new_value.to_f ]
+    end
+
+    def predicate_class
+      Magma::NumberPredicate
     end
   end
 end

--- a/magma/lib/magma/attributes/integer_attribute.rb
+++ b/magma/lib/magma/attributes/integer_attribute.rb
@@ -1,11 +1,15 @@
 class Magma
-  class IntegerAttribute < Attribute
+  class IntegerAttribute < ColumnAttribute
     def database_type
       Integer
     end
 
     def revision_to_loader(record_name, new_value)
       [ name, new_value.to_i ]
+    end
+
+    def predicate_class
+      Magma::NumberPredicate
     end
   end
 end

--- a/magma/lib/magma/attributes/matrix.rb
+++ b/magma/lib/magma/attributes/matrix.rb
@@ -4,9 +4,13 @@ require 'json'
 class Magma
   class MatrixJsonError < StandardError
   end
-  class MatrixAttribute < Attribute
+  class MatrixAttribute < ColumnAttribute
     def database_type
       :json
+    end
+
+    def predicate_class
+      Magma::MatrixPredicate
     end
 
     def entry(value, loader)

--- a/magma/lib/magma/attributes/string_attribute.rb
+++ b/magma/lib/magma/attributes/string_attribute.rb
@@ -1,7 +1,11 @@
 class Magma
-  class StringAttribute < Attribute
+  class StringAttribute < ColumnAttribute
     def database_type
       String
+    end
+
+    def predicate_class
+      Magma::StringPredicate
     end
   end
 end

--- a/magma/lib/magma/query/predicate.rb
+++ b/magma/lib/magma/query/predicate.rb
@@ -85,6 +85,14 @@ EOT
       end
     end
 
+    def group_by
+      if @verb && @verb.gives?(:group_by)
+        [ @verb.do(:group_by) ].compact
+      else
+        []
+      end
+    end
+
     def subquery_config
       if @verb && @verb.gives?(:subquery_config)
         @verb.do(:subquery_config)
@@ -332,7 +340,7 @@ EOT
       )
     end
 
-    def is_numeric_constraint column_name      
+    def is_numeric_constraint column_name
       Magma::Constraint.new(
         alias_name,
         Sequel.qualify(alias_name, column_name) => Regexp.new(/^\d+(\.\d+)?$/)
@@ -396,6 +404,8 @@ require_relative 'predicate/subquery_config'
 require_relative 'predicate/subquery_filter'
 require_relative 'predicate/subquery_operator'
 require_relative 'predicate/subquery_utils'
+require_relative 'predicate/collection'
+require_relative 'predicate/aggregated_record'
 require_relative 'subquery_inner'
 require_relative 'subquery_outer'
 require_relative 'subquery_constraint'

--- a/magma/lib/magma/query/predicate/aggregated_record.rb
+++ b/magma/lib/magma/query/predicate/aggregated_record.rb
@@ -1,0 +1,65 @@
+class Magma
+  class AggregatedRecordPredicate < Magma::Predicate
+    attr_reader :model
+
+    def initialize question, model, alias_name, *query_args
+      super(question)
+      @model = model
+      @alias_name = alias_name
+      require 'pry'
+      binding.pry
+      process_args(query_args)
+    end
+
+    verb '::identifier' do
+      child :record_child
+
+      select_columns do
+        [ column_name ]
+      end
+    end
+
+    verb :attribute_name do
+      child :record_child
+
+      join :attribute_join
+
+      select_columns do
+        [ column_name ]
+      end
+    end
+
+    def to_hash
+      super.merge(
+        model: model
+      )
+    end
+
+    def select
+      [
+        Sequel.function(:json_agg, Sequel[@alias_name][column_name(@arguments[0])]).distinct.as(column_name_alias)
+      ]
+    end
+
+    private
+
+    def record_child
+      RecordPredicate.new(@question, @model, @alias_name, *@query_args)
+    end
+
+    def column_name(attribute = @model.identity)
+      if attribute.is_a?(String) || attribute.is_a?(Symbol)
+        attribute = @model.attributes[attribute.to_sym]
+        if attribute.nil?
+          attribute = @model.identity
+        end
+      end
+
+      attribute.column_name.to_sym
+    end
+
+    def column_name_alias
+      "#{@alias_name}_#{column_name(@arguments[0])}_aggregated"
+    end
+  end
+end

--- a/magma/lib/magma/query/predicate/collection.rb
+++ b/magma/lib/magma/query/predicate/collection.rb
@@ -1,0 +1,52 @@
+class Magma
+  class CollectionPredicate < Magma::Predicate
+  # This object should just return the list of aggregated values
+  #   for a collection.
+    attr_reader :model
+
+    def initialize question, model, *query_args
+      super(question)
+      @model = model
+      require 'pry'
+      binding.pry
+      process_args(query_args)
+    end
+
+    verb '::all' do
+      child :record_child
+
+      extract do |table, return_identity|
+        require 'pry'
+        binding.pry
+        table.map do |identifier,rows|
+          next unless identifier
+          [ identifier, rows ]
+        end.compact
+      end
+    end
+
+    verb '::first' do
+      child :record_child
+
+      extract do |table, return_identity|
+        require 'pry'
+        binding.pry
+        table.group_by do |row|
+          row[identity]
+        end.first&.last
+      end
+    end
+
+    def to_hash
+      super.merge(
+        model: model
+      )
+    end
+
+    private
+
+    def record_child
+      RecordPredicate.new(@question, @model, alias_name, *@query_args)
+    end
+  end
+end

--- a/magma/lib/magma/query/predicate/column.rb
+++ b/magma/lib/magma/query/predicate/column.rb
@@ -68,7 +68,8 @@ class Magma
     def is_collection_column?
       collection_column_types = [
         Magma::ChildAttribute,
-        Magma::ForeignKeyAttribute
+        Magma::ForeignKeyAttribute,
+        Magma::LinkAttribute
       ]
 
       collection_column_types.include?(@attribute_obj.class)

--- a/magma/lib/magma/query/predicate/column.rb
+++ b/magma/lib/magma/query/predicate/column.rb
@@ -2,11 +2,12 @@ class Magma
   class ColumnPredicate < Magma::Predicate
     # This Predicate returns an actual attribute value of some kind - a number, integer, etc.,
     # or else a test on that value (number > 2, etc.)
+    attr_reader :upstream_aggregation
+
     def initialize question, model, alias_name, attribute, *query_args
       super(question)
       @model = model
       @alias_name = alias_name
-      @upstream_aggregation = false
       set_attribute(attribute)
       process_args(query_args)
     end
@@ -16,28 +17,9 @@ class Magma
     end
 
     def self.from_record_predicate_and_attribute(record_predicate, attribute)
-      case attribute
-      when :id
-        predicate_class = Magma::NumberPredicate
-      when Magma::FileAttribute, Magma::ImageAttribute
-        predicate_class = Magma::FilePredicate
-      when Magma::FileCollectionAttribute
-        predicate_class = Magma::FileCollectionPredicate
-      when Magma::MatchAttribute
-        predicate_class = Magma::MatchPredicate
-      when Magma::MatrixAttribute
-        predicate_class = Magma::MatrixPredicate
-      when Magma::StringAttribute
-        predicate_class = Magma::StringPredicate
-      when Magma::IntegerAttribute, Magma::FloatAttribute
-        predicate_class = Magma::NumberPredicate
-      when Magma::DateTimeAttribute, Magma::ShiftedDateTimeAttribute
-        predicate_class = Magma::DateTimePredicate
-      when Magma::BooleanAttribute
-        predicate_class = Magma::BooleanPredicate
-      else
-        invalid_argument! attribute.name
-      end
+      predicate_class = :id == attribute ?
+        Magma::NumberPredicate :
+        attribute.predicate_class
 
       return predicate_class.new(
         record_predicate.question,
@@ -54,10 +36,6 @@ class Magma
       @column_name = attribute.column_name.to_sym
     end
 
-    def set_upstream_aggregation(upstream_aggregation)
-      @upstream_aggregation = upstream_aggregation
-    end
-
     def extract table, identity
       if @verb && @verb.gives?(:extract)
         @verb.do(:extract, table, identity)
@@ -71,8 +49,7 @@ class Magma
     end
 
     def select
-      require 'pry'
-      binding.pry if @upstream_aggregation
+      binding.pry if @attribute_name == "::identifier"
       @arguments.empty? ?
         is_aggregated_attribute? ?
           [ Sequel.function(aggregate_function, column_to_aggregate).distinct.as(aggregated_column_name) ] :
@@ -97,44 +74,6 @@ class Magma
       is_json_column? ?
         Sequel[alias_name][@column_name].cast_string(:text) :
         Sequel[alias_name][@column_name]
-    end
-
-    def root_model_column?
-      @question.model == @model
-    end
-
-    def aggregate_function
-      is_json_column? ? :string_agg : :json_agg
-    end
-
-    def is_collection_column?
-      collection_column_types = [
-        Magma::ChildAttribute,
-        Magma::ForeignKeyAttribute,
-        Magma::LinkAttribute
-      ]
-
-      collection_column_types.include?(@attribute_obj.class)
-    end
-
-    def is_json_column?
-      # Postgres cannot group_by JSON columns, so we apply a
-      #   string_agg on them, instead.
-      json_column_types = [
-        Magma::FileAttribute,
-        Magma::ImageAttribute,
-        Magma::FileCollectionAttribute
-      ]
-
-      json_column_types.include?(@attribute_obj.class)
-    end
-
-    def is_aggregated_attribute?
-      !root_model_column? || is_json_column? || is_collection_column? || @upstream_aggregation
-    end
-
-    def aggregated_column_name
-      "#{alias_name}_#{@attribute_name}_aggregated"
     end
   end
 end

--- a/magma/lib/magma/query/predicate/file.rb
+++ b/magma/lib/magma/query/predicate/file.rb
@@ -88,7 +88,7 @@ class Magma
     end
 
     def select
-      [ Sequel[alias_name][@column_name].as(column_name) ]
+      [ Sequel.string_agg(Sequel[alias_name][@column_name].cast_string(:text), ',').distinct.as(column_name) ]
     end
   end
 end

--- a/magma/lib/magma/query/predicate/file_collection.rb
+++ b/magma/lib/magma/query/predicate/file_collection.rb
@@ -69,7 +69,7 @@ class Magma
     end
 
     def select
-      [ Sequel[alias_name][@column_name].as(column_name) ]
+      [ Sequel.string_agg(Sequel[alias_name][@column_name].cast_string(:text), ',').distinct.as(column_name) ]
     end
   end
 end

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -88,6 +88,15 @@ class Magma
           [ identifier, child_extract(rows, identity) ]
         end.compact
       end
+
+      # group_by do
+      #   identity unless is_
+      # end
+
+      select_columns do
+        []
+      end
+
       format do
         [
           default_format,
@@ -212,7 +221,8 @@ class Magma
       if @verb && @verb.gives?(:select_columns)
         @verb.do(:select_columns)
       else
-        [ column_name.as(identity) ]
+        []
+        # [ column_name.as(identity) ]
       end
     end
 
@@ -224,7 +234,7 @@ class Magma
         end
       end
 
-      Sequel[alias_name][attribute.column_name]
+      Sequel[alias_name][attribute.column_name.to_sym]
     end
 
     def constraint

--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -89,10 +89,6 @@ class Magma
         end.compact
       end
 
-      # group_by do
-      #   identity unless is_
-      # end
-
       select_columns do
         []
       end

--- a/magma/lib/magma/query/predicate/record.rb
+++ b/magma/lib/magma/query/predicate/record.rb
@@ -284,6 +284,8 @@ class Magma
       when :id
         return Magma::NumberPredicate.new(@question, @model, alias_name, attribute, *@query_args)
       when Magma::ChildAttribute, Magma::ForeignKeyAttribute
+        require 'pry'
+        binding.pry if ["reference_monster", "reference_monster_id", "monster_group"].include?(attribute.attribute_name)
         return Magma::RecordPredicate.new(@question, attribute.link_model, nil, *@query_args)
       when Magma::TableAttribute, Magma::CollectionAttribute
         return Magma::ModelPredicate.new(@question, attribute.link_model, *@query_args)

--- a/magma/lib/magma/query/predicate/table.rb
+++ b/magma/lib/magma/query/predicate/table.rb
@@ -6,8 +6,11 @@ class Magma
       super(question)
       @model = model
       @alias_name = alias_name
+      require 'pry'
+      binding.pry
       raise ArgumentError, 'No columns were requested!' if columns.empty?
       @column_predicates = columns.map do |column_query|
+        binding.pry if column_query.first == 'monster_group'
         # now, we merely map this to a record predicate. Handy!
         RecordPredicate.new(@question, @model, @alias_name, *column_query)
       end

--- a/magma/lib/magma/query/predicate/table.rb
+++ b/magma/lib/magma/query/predicate/table.rb
@@ -57,8 +57,16 @@ class Magma
     end
 
     def select
+      require 'pry'
+      binding.pry
       @column_predicates.map do |pred|
         pred.flatten.map(&:select).inject(&:+)
+      end.inject(&:+)
+    end
+
+    def group_by
+      @column_predicates.map do |pred|
+        pred.flatten.map(&:group_by).inject(&:+)
       end.inject(&:+)
     end
   end

--- a/magma/lib/magma/query/verb.rb
+++ b/magma/lib/magma/query/verb.rb
@@ -132,5 +132,22 @@ class Magma
         raise "Cannot determine select_columns for #{@predicate}"
       end
     end
+
+    def group_by(arg=nil, &block)
+      @group_by = block_given? ? block : arg
+    end
+
+    def get_group_by
+      case @group_by
+      when Symbol
+        @predicate.send @group_by
+      when Proc
+        @predicate.instance_exec(&@group_by)
+      when Class
+        @predicate.send :terminal, @group_by
+      else
+        raise "Cannot determine group_by predicate for #{@predicate}"
+      end
+    end
   end
 end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -1340,6 +1340,10 @@ describe RetrieveController do
       )
 
       expect(json_body[:models][:monster][:documents].keys).to eq(names.map(&:to_sym))
+      require 'pry'
+      binding.pry
+      expect(json_body[:models][:monster][:documents][:monster7][:victim]).to match_array(["victim13", "victim14"])
+      expect(json_body[:models][:monster][:documents][:monster7][:labor]).to eq("Nemean Lion")
     end
 
     it 'returns a count of total records for page 1' do


### PR DESCRIPTION
So this PR is a start at trying to reduce the impact of join-explosions on Magma queries, especially ones that should be simple, such as fetching a project record and its attributes (i.e. #937). Currently, the generated SQL seems redundant in many cases (duplicated columns, duplicated JOINS), which may be contributing to the explosion. This PR tries to reduce those redundancies, too.

The overall idea is to use Postgres's built-in aggregation functions to reduce one-to-many relationships to a single row / column value, instead of generating unique rows for each combination of the parent-child join results and then aggregating in Ruby (which can lead to exponential row growth, when you talk about many of these one-to-many relationships in a single query). In theory, you could get a SQL query result like the following, with just one row per unique `monster.name` record (note how the `victim names` are in a single column value, instead of creating two records that we later have to run `group_by` on, in Ruby, to aggregate):

```
=> [{:cavabtjtpk_created_at=>2022-12-19 18:15:30.409824 +0000,
  :cavabtjtpk_updated_at=>2022-12-19 18:15:30.409824 +0000,
  :cavabtjtpk_species=>nil,
  :zmubuiwost_name_aggregated=>["Nemean Lion"],
  :cavabtjtpk_name=>"monster7",
  :qjavmribcs_name_aggregated=>["victim13", "victim14"],
  :dwssgzatvq_aspect_id_aggregated=>[nil],
  :cavabtjtpk_stats=>nil,
  :cavabtjtpk_selfie=>nil,
  :leqvnobusi_name_aggregated=>[nil],
  :cavabtjtpk_restricted=>nil,
  :dzcxsfaxxf_name_aggregated=>[nil],
  :cavabtjtpk_certificates=>nil},
 {:cavabtjtpk_created_at=>2022-12-19 18:15:30.410253 +0000,
  :cavabtjtpk_updated_at=>2022-12-19 18:15:30.410253 +0000,
  :cavabtjtpk_species=>nil,
  :zmubuiwost_name_aggregated=>["Nemean Lion"],
  :cavabtjtpk_name=>"monster8",
  :qjavmribcs_name_aggregated=>["victim15", "victim16"],
  :dwssgzatvq_aspect_id_aggregated=>[nil],
  :cavabtjtpk_stats=>nil,
  :cavabtjtpk_selfie=>nil,
  :leqvnobusi_name_aggregated=>[nil],
  :cavabtjtpk_restricted=>nil,
  :dzcxsfaxxf_name_aggregated=>[nil],
  :cavabtjtpk_certificates=>nil},
 {:cavabtjtpk_created_at=>2022-12-19 18:15:30.410647 +0000,
  :cavabtjtpk_updated_at=>2022-12-19 18:15:30.410647 +0000,
  :cavabtjtpk_species=>nil,
  :zmubuiwost_name_aggregated=>["Nemean Lion"],
  :cavabtjtpk_name=>"monster9",
  :qjavmribcs_name_aggregated=>["victim17", "victim18"],
  :dwssgzatvq_aspect_id_aggregated=>[nil],
  :cavabtjtpk_stats=>nil,
  :cavabtjtpk_selfie=>nil,
  :leqvnobusi_name_aggregated=>[nil],
  :cavabtjtpk_restricted=>nil,
  :dzcxsfaxxf_name_aggregated=>[nil],
  :cavabtjtpk_certificates=>nil}]
```

(This was generated by the following, hand-cleaned up SQL query):

```

SELECT
    "cavabtjtpk"."created_at" AS "cavabtjtpk_created_at",
    "cavabtjtpk"."updated_at" AS "cavabtjtpk_updated_at",
    "cavabtjtpk"."species" AS "cavabtjtpk_species",
    json_agg(DISTINCT "zmubuiwost"."name") AS "zmubuiwost_name_aggregated",
    "cavabtjtpk"."name" AS "cavabtjtpk_name",
    json_agg(DISTINCT "qjavmribcs"."name") AS "qjavmribcs_name_aggregated",
    json_agg(DISTINCT "dwssgzatvq"."aspect_id") AS "dwssgzatvq_aspect_id_aggregated",
    string_agg(DISTINCT CAST("cavabtjtpk"."stats" AS text), ',') AS "cavabtjtpk_stats",
    string_agg(DISTINCT CAST("cavabtjtpk"."selfie" AS text), ',') AS "cavabtjtpk_selfie",
    json_agg(DISTINCT "leqvnobusi"."name") AS "leqvnobusi_name_aggregated",
    "cavabtjtpk"."restricted" AS "cavabtjtpk_restricted",
    json_agg(DISTINCT "dzcxsfaxxf"."name") AS "dzcxsfaxxf_name_aggregated",
    string_agg(DISTINCT CAST("cavabtjtpk"."certificates" AS text), ',') AS "cavabtjtpk_certificates"
FROM "labors"."monsters" AS "cavabtjtpk"
    LEFT OUTER JOIN "labors"."labors" AS "edhrdnlwos"
        ON ("cavabtjtpk"."labor_id" = "edhrdnlwos"."id")
    LEFT OUTER JOIN "labors"."labors" AS "zmubuiwost"
        ON ("cavabtjtpk"."labor_id" = "zmubuiwost"."id")
    LEFT OUTER JOIN "labors"."victims" AS "qjavmribcs"
        ON (("cavabtjtpk"."id" = "qjavmribcs"."monster_id") AND ("qjavmribcs"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."monsters" AS "piboariosf"
        ON (("qjavmribcs"."monster_id" = "piboariosf"."id") AND ("piboariosf"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."aspects" AS "dwssgzatvq"
        ON ("cavabtjtpk"."id" = "dwssgzatvq"."monster_id")
    LEFT OUTER JOIN "labors"."monsters" AS "eakceakrmu"
        ON (("dwssgzatvq"."monster_id" = "eakceakrmu"."id") AND ("eakceakrmu"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."monsters" AS "leqvnobusi"
        ON ("cavabtjtpk"."reference_monster_id" = "leqvnobusi"."id")
    LEFT OUTER JOIN "labors"."habitats" AS "dzcxsfaxxf"
        ON ("cavabtjtpk"."habitat_id" = "dzcxsfaxxf"."id")
WHERE (("cavabtjtpk"."restricted" IS NOT TRUE)
    AND ("cavabtjtpk"."labor_id" IS NOT NULL)
    AND ("edhrdnlwos"."project_id" IS NOT NULL) 
    AND (((TRUE AND (TRUE OR FALSE)) 
    AND ("cavabtjtpk"."name" >= 'monster7' OR ("cavabtjtpk"."reference_monster_id" IS NOT NULL OR FALSE)))))
GROUP BY "cavabtjtpk_created_at", 
    "cavabtjtpk_updated_at", 
    "cavabtjtpk_species",
    "cavabtjtpk_name", 
    "cavabtjtpk_restricted" 
ORDER BY "cavabtjtpk"."name"
```

Taken from the below query, I had to remove the join / select for `reference_monster_id` on table `ibregzzgsb`, plus the `order_by` of `reference_monster_id`. So ... where to cut in the code, to achieve the same effects? There is where I am a bit stuck, so documenting this for now. Would love to pair with @graft when we're both back in the office.

Here is what I've gotten the query to automatically build to. Also have not figured out how to change the `extract` statements to look in the `_aggregated` columns, though I also suspect it may just automatically work if I remove that suffix from the column name, as long as everything else is cleaned up correctly (no duplicate `SELECT` columns):

Retrieve request that generated the query (from `retrieve_spec.rb`, line 1330):

```
      retrieve(
        project_name: 'labors',
        model_name: 'monster',
        record_names: 'all',
        attribute_names: 'all',
        order: 'reference_monster',
        page: 3,
        page_size: 3
      )
```

```
SELECT
    "cavabtjtpk"."created_at" AS "cavabtjtpk_created_at",
    "cavabtjtpk"."updated_at" AS "cavabtjtpk_updated_at",
    "cavabtjtpk"."species" AS "cavabtjtpk_species",
    "ibregzzgsb"."name" AS "ibregzzgsb_name",  <-- This seems to be generated from the Magma::ForeignKey JOIN condition in RecordPredicate.rb. I can't get this to aggregate? Seems duplicated, so ideally would remove it.
    json_agg(DISTINCT "zmubuiwost"."name") AS "zmubuiwost_name_aggregated",
    "cavabtjtpk"."name" AS "cavabtjtpk_name",
    json_agg(DISTINCT "qjavmribcs"."name") AS "qjavmribcs_name_aggregated",
    json_agg(DISTINCT "dwssgzatvq"."aspect_id") AS "dwssgzatvq_aspect_id_aggregated",
    string_agg(DISTINCT CAST("cavabtjtpk"."stats" AS text), ',') AS "cavabtjtpk_stats",
    string_agg(DISTINCT CAST("cavabtjtpk"."selfie" AS text), ',') AS "cavabtjtpk_selfie",
    json_agg(DISTINCT "leqvnobusi"."name") AS "leqvnobusi_name_aggregated",  <-- This is some duplicate version of the reference_monster data, but correctly aggregated??
    "cavabtjtpk"."restricted" AS "cavabtjtpk_restricted",
    json_agg(DISTINCT "dzcxsfaxxf"."name") AS "dzcxsfaxxf_name_aggregated",
    string_agg(DISTINCT CAST("cavabtjtpk"."certificates" AS text), ',') AS "cavabtjtpk_certificates"
FROM "labors"."monsters" AS "cavabtjtpk"
    LEFT OUTER JOIN "labors"."labors" AS "edhrdnlwos"
        ON ("cavabtjtpk"."labor_id" = "edhrdnlwos"."id")
    LEFT OUTER JOIN "labors"."monsters" AS "ibregzzgsb" <-- I feel like we should remove this JOIN
        ON (("cavabtjtpk"."id" = "ibregzzgsb"."reference_monster_id") AND ("ibregzzgsb"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."labors" AS "zmubuiwost"
        ON ("cavabtjtpk"."labor_id" = "zmubuiwost"."id")
    LEFT OUTER JOIN "labors"."victims" AS "qjavmribcs"
        ON (("cavabtjtpk"."id" = "qjavmribcs"."monster_id") AND ("qjavmribcs"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."monsters" AS "piboariosf"
        ON (("qjavmribcs"."monster_id" = "piboariosf"."id") AND ("piboariosf"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."aspects" AS "dwssgzatvq"
        ON ("cavabtjtpk"."id" = "dwssgzatvq"."monster_id")
    LEFT OUTER JOIN "labors"."monsters" AS "eakceakrmu"
        ON (("dwssgzatvq"."monster_id" = "eakceakrmu"."id") AND ("eakceakrmu"."restricted" IS NOT TRUE))
    LEFT OUTER JOIN "labors"."monsters" AS "leqvnobusi"
        ON ("cavabtjtpk"."reference_monster_id" = "leqvnobusi"."id")  <-- This seems like it should also have a restricted IS NOT TRUE clause based on the ibregzzgsb JOIN above, but does not??
    LEFT OUTER JOIN "labors"."habitats" AS "dzcxsfaxxf"
        ON ("cavabtjtpk"."habitat_id" = "dzcxsfaxxf"."id")
WHERE (("cavabtjtpk"."restricted" IS NOT TRUE)
    AND ("cavabtjtpk"."labor_id" IS NOT NULL)
    AND ("edhrdnlwos"."project_id" IS NOT NULL) 
    AND (((TRUE AND (TRUE OR FALSE)) 
    AND ("cavabtjtpk"."name" >= 'monster7' OR ("cavabtjtpk"."reference_monster_id" IS NOT NULL OR FALSE)))))
GROUP BY "cavabtjtpk_created_at", 
    "cavabtjtpk_updated_at", 
    "cavabtjtpk_species",
    "cavabtjtpk_name", 
    "cavabtjtpk_restricted" 
ORDER BY "cavabtjtpk"."reference_monster_id", <-- Somehow this order-by needs to also be aggregated or in the group_by clause, not sure where to inject that, yet, since theoretically the user could do something like order by some json_aggregated column...? :facepalm: I think ideally this becomes the aliased column name, and then we avoid this issue, because we won't have SELECT statements for any aggregated data, but could sort by them (maybe?).
    "cavabtjtpk"."name"
```

Open questions:

- [ ] Where to cut to remove the extra join and select statement? Suspect in `RecordAttribute#attribute_join` somewhere, for `Magma::ForeignKeyAttribute` case.
- [ ] How to add in the `restricted is not true` to the generated SQL for the remaining `reference_monster` join?
- [ ] How to handle `order_by` of aggregated columns?
- [ ] Update the `extract` statements to handle aggregated column aliases,