### PR TITLE
use Variable.update instead of Variable.set

### DIFF
--- a/airflow/opt/providers/etna/etna/hooks/box.py
+++ b/airflow/opt/providers/etna/etna/hooks/box.py
@@ -244,7 +244,7 @@ class Box(object):
         """
         Save the cursor to the database.
         """
-        Variable.set(self.variable_key, self.cursor, serialize_json=True)
+        Variable.update(self.variable_key, self.cursor, serialize_json=True)
 
     def remove_file(self, ftps: FTP_TLS, file: FtpEntry):
         """

--- a/airflow/opt/providers/etna/etna/hooks/cat.py
+++ b/airflow/opt/providers/etna/etna/hooks/cat.py
@@ -319,7 +319,7 @@ class Cat(SSHBase):
         latest_cursor = Variable.get(self.variable_key(postfix), default_var={}, deserialize_json=True)
 
         self.cursors[postfix] = {**latest_cursor, **self.cursors[postfix]}
-        Variable.set(self.variable_key(postfix), self.cursors[postfix], serialize_json=True)
+        Variable.update(self.variable_key(postfix), self.cursors[postfix], serialize_json=True)
 
     def variable_key(self, postfix: str):
         """


### PR DESCRIPTION
Getting some errors on the CAT ingest ETL (wonder why we didn't see these before):

```
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/home/airflow/.local/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "variable_key_key"
DETAIL:  Key (key)=(cat_ingest_cursor-c4-cat_ingestion_etl3) already exists.
```

Changing to use [`Variable.update`](https://airflow.apache.org/docs/apache-airflow/2.2.4/_api/airflow/models/variable/index.html#airflow.models.variable.Variable.update) instead of `Variable.set` to try and avoid this problem. Testing in production ... 