### PR TITLE
Magma migration jsonb

### DIFF
--- a/magma/db/migrations/014_convert_json_to_jsonb.rb
+++ b/magma/db/migrations/014_convert_json_to_jsonb.rb
@@ -15,7 +15,7 @@ Sequel.migration do
 
     def self.matching_model_attributes
       {}.tap do |table_attributes|
-        Magma.instance.db[:attributes].where(type: json_type_attributes).map do |attribute|
+        Magma.instance.db[:attributes].where(type: json_type_attributes).each do |attribute|
           project_name = attribute[:project_name].to_sym
           model_name = attribute[:model_name].pluralize.to_sym
 

--- a/magma/db/migrations/014_convert_json_to_jsonb.rb
+++ b/magma/db/migrations/014_convert_json_to_jsonb.rb
@@ -1,0 +1,67 @@
+Sequel.migration do
+  class Helper
+
+    def self.convert_attribute_columns(migration, new_type)
+      matching_model_attributes.each do |table_name_tuple, attribute_names|
+        migration.alter_table(Sequel[table_name_tuple.first][table_name_tuple.last]) do
+          attribute_names.each do |attribute_name|
+            set_column_type attribute_name, new_type, using: Sequel.cast(attribute_name, new_type)
+          end
+        end
+      end
+    end
+
+    private
+
+    def self.matching_model_attributes
+      {}.tap do |table_attributes|
+        Magma.instance.db[:attributes].where(type: json_type_attributes).map do |attribute|
+          project_name = attribute[:project_name].to_sym
+          model_name = attribute[:model_name].pluralize.to_sym
+
+          table_tuple = [project_name, model_name]
+
+          table_attributes[table_tuple] = [] unless table_attributes.keys.include?(table_tuple)
+
+          table_attributes[table_tuple] << attribute[:attribute_name].to_sym
+        end
+      end
+    end
+
+    def self.json_type_attributes
+      [ 'file', 'image', 'file_collection', 'matrix' ]
+    end
+  end
+
+  up do
+    new_type = :jsonb
+
+    alter_table(:grammars) do
+      set_column_type :config, new_type, using: Sequel.cast(:config, new_type)
+    end
+    alter_table(:attributes) do
+      set_column_type :validation, new_type, using: Sequel.cast(:validation, new_type)
+    end
+    alter_table(:models) do
+      set_column_type :dictionary, new_type, using: Sequel.cast(:dictionary, new_type)
+    end
+
+    Helper.convert_attribute_columns(self, new_type)
+  end
+
+  down do
+    new_type = :json
+
+    alter_table(:grammars) do
+      set_column_type :config, new_type, using: Sequel.cast(:config, new_type)
+    end
+    alter_table(:attributes) do
+      set_column_type :validation, new_type, using: Sequel.cast(:validation, new_type)
+    end
+    alter_table(:models) do
+      set_column_type :dictionary, new_type, using: Sequel.cast(:dictionary, new_type)
+    end
+
+    Helper.convert_attribute_columns(self, new_type)
+  end
+end

--- a/magma/db/migrations/014_convert_json_to_jsonb.rb
+++ b/magma/db/migrations/014_convert_json_to_jsonb.rb
@@ -16,10 +16,10 @@ Sequel.migration do
     def self.matching_model_attributes
       {}.tap do |table_attributes|
         Magma.instance.db[:attributes].where(type: json_type_attributes).each do |attribute|
-          project_name = attribute[:project_name].to_sym
-          model_name = attribute[:model_name].pluralize.to_sym
+          schema_name = attribute[:project_name].to_sym
+          table_name = attribute[:model_name].pluralize.to_sym
 
-          table_tuple = [project_name, model_name]
+          table_tuple = [schema_name, table_name]
 
           table_attributes[table_tuple] = [] unless table_attributes.keys.include?(table_tuple)
 

--- a/magma/lib/magma/attributes/file_attribute.rb
+++ b/magma/lib/magma/attributes/file_attribute.rb
@@ -4,7 +4,7 @@ require_relative './file_serializer'
 class Magma
   class FileAttribute < Attribute
     def database_type
-      :json
+      :jsonb
     end
 
     def serializer

--- a/magma/lib/magma/attributes/file_collection_attribute.rb
+++ b/magma/lib/magma/attributes/file_collection_attribute.rb
@@ -4,7 +4,7 @@ require_relative './file_serializer'
 class Magma
   class FileCollectionAttribute < Attribute
     def database_type
-      :json
+      :jsonb
     end
 
     def serializer

--- a/magma/lib/magma/attributes/match.rb
+++ b/magma/lib/magma/attributes/match.rb
@@ -1,7 +1,7 @@
 class Magma
   class MatchAttribute < Attribute
     def database_type
-      :json
+      :jsonb
     end
 
     def entry(value, loader)

--- a/magma/lib/magma/attributes/matrix.rb
+++ b/magma/lib/magma/attributes/matrix.rb
@@ -6,7 +6,7 @@ class Magma
   end
   class MatrixAttribute < Attribute
     def database_type
-      :json
+      :jsonb
     end
 
     def entry(value, loader)

--- a/magma/lib/magma/query/predicate/record.rb
+++ b/magma/lib/magma/query/predicate/record.rb
@@ -64,7 +64,7 @@ class Magma
         case attribute
         when Magma::ForeignKeyAttribute, Magma::LinkAttribute
           null_constraint(attribute.foreign_id)
-        when Magma::FileAttribute, Magma::ImageAttribute
+        when Magma::FileAttribute, Magma::ImageAttribute, Magma::FileCollectionAttribute
           or_constraint([
             json_constraint(attribute.column_name.to_sym, "filename", nil),
             # The string "null" appears if someone fetches a ::temp URL
@@ -123,7 +123,7 @@ class Magma
       #   so we provide a convenience method to generate new aliases
       10.times.map{ (97+rand(26)).chr }.join.to_sym
     end
-    
+
     def inner_join_child(attribute)
       Magma::Join.new(
         # left table

--- a/magma/spec/migration_spec.rb
+++ b/magma/spec/migration_spec.rb
@@ -70,7 +70,7 @@ EOT
 EOT
     end
 
-    it 'suggests a creation migration for json attributes' do
+    it 'suggests a creation migration for jsonb attributes' do
       module Labors
         class Olympian < Magma::Model
           match :prayers
@@ -82,7 +82,7 @@ EOT
       primary_key :id
       DateTime :created_at
       DateTime :updated_at
-      json :prayers
+      jsonb :prayers
     end
 EOT
     end
@@ -156,7 +156,7 @@ EOT
       remove_attribute(Labors::Prize, :weight)
     end
 
-    it 'suggests an update migration for json attributes' do
+    it 'suggests an update migration for jsonb attributes' do
       module Labors
         class Prize < Magma::Model
           match :dimensions
@@ -165,7 +165,7 @@ EOT
       migration = Labors::Prize.migration
       expect(migration.to_s).to eq <<EOT.chomp
     alter_table(Sequel[:labors][:prizes]) do
-      add_column :dimensions, :json
+      add_column :dimensions, :jsonb
     end
 EOT
       remove_attribute(Labors::Prize, :dimensions)
@@ -369,7 +369,7 @@ EOT
         migration = Labors::Prize.migration
         expect(migration.to_s).to eq <<EOT.chomp
     alter_table(Sequel[:labors][:prizes]) do
-      set_column_type :#{original_attribute.column_name}, :json, using: 'worth::json'
+      set_column_type :#{original_attribute.column_name}, :jsonb, using: 'worth::jsonb'
     end
 EOT
         Labors::Prize.attributes[:worth] = original_attribute

--- a/magma/spec/query_spec.rb
+++ b/magma/spec/query_spec.rb
@@ -1842,6 +1842,21 @@ describe QueryController do
       expect(json_body[:format]).to eq(['labors::monster#name', 'labors::monster#name'])
     end
 
+    it 'can filter on ::has' do
+      practice = create(:labor, name: 'Practice', project: @project)
+      paper_tiger = create(:monster, name: 'Roar!', stats: nil, labor: practice)
+      paper_dragon = create(:monster, name: 'Whoosh!', stats: 'null', labor: practice)
+
+      query(
+        [ 'monster', ['::has', 'stats'], '::all', '::identifier' ]
+      )
+
+      expect(last_response.status).to eq(200)
+
+      expect(json_body[:answer].map(&:last).sort).to eq([ "Augean Stables", "Lernean Hydra", "Nemean Lion" ])
+      expect(json_body[:format]).to eq(['labors::monster#name', 'labors::monster#name'])
+    end
+
     it 'can match on filename with ::equals' do
       practice = create(:labor, name: 'Practice', project: @project)
       paper_tiger = create(:monster, name: 'Roar!', stats: '{"filename": "::blank", "original_filename": "::blank"}', labor: practice)

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -274,7 +274,7 @@ describe UpdateController do
         hydra = create(:labor, name: 'The Lernean Hydra', year: '0003-01-01', project: @project)
 
         hydra_monster = create(:monster, name: 'Lernean Hydra', labor: hydra)
-        
+
         lion_monster = create(:monster, name: 'Nemean Lion', labor: lion)
 
         expect(hydra_monster.reference_monster).to eq(nil)
@@ -1339,11 +1339,11 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.stats.to_json).to eq({
-        location: "::blank",
-        filename: "::blank",
-        original_filename: "::blank"
-      }.to_json)
+      expect(lion.stats).to eq({
+        "location" => "::blank",
+        "filename" => "::blank",
+        "original_filename" => "::blank"
+      })
 
       expect(last_response.status).to eq(200)
 
@@ -1373,11 +1373,11 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.stats.to_json).to eq({
-        location: nil,
-        filename: nil,
-        original_filename: nil
-      }.to_json)
+      expect(lion.stats).to eq({
+        "location" => nil,
+        "filename" => nil,
+        "original_filename" => nil
+      })
 
       expect(last_response.status).to eq(200)
 
@@ -1406,11 +1406,11 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.stats.to_json).to eq({
-        location: "::blank",
-        filename: "::blank",
-        original_filename: "::blank"
-      }.to_json)
+      expect(lion.stats).to eq({
+        "location" => "::blank",
+        "filename" => "::blank",
+        "original_filename" => "::blank"
+      })
 
       expect(last_response.status).to eq(200)
 
@@ -1476,11 +1476,11 @@ describe UpdateController do
       expect(last_response.status).to eq(200)
 
       lion.refresh
-      expect(lion.stats.to_json).to eq({
-        location: "metis://labors/files/lion-stats.txt",
-        filename: "monster-Nemean Lion-stats.txt",
-        original_filename: "original-file.txt"
-      }.to_json)
+      expect(lion.stats).to eq({
+        "location" => "metis://labors/files/lion-stats.txt",
+        "filename" => "monster-Nemean Lion-stats.txt",
+        "original_filename" => "original-file.txt"
+      })
 
       # but we do get an download url for Metis
       uri = URI.parse(json_document(:monster, 'Nemean Lion')[:stats][:url])
@@ -1589,10 +1589,10 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.selfie.to_json).to eq({
-        location: "::blank",
-        filename: "::blank",
-        original_filename: "::blank"}.to_json)
+      expect(lion.selfie).to eq({
+        "location" => "::blank",
+        "filename" => "::blank",
+        "original_filename" => "::blank"})
 
       expect(last_response.status).to eq(200)
 
@@ -1622,11 +1622,11 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.selfie.to_json).to eq({
-        location: nil,
-        filename: nil,
-        original_filename: nil
-      }.to_json)
+      expect(lion.selfie).to eq({
+        "location" => nil,
+        "filename" => nil,
+        "original_filename" => nil
+      })
 
       expect(last_response.status).to eq(200)
 
@@ -1655,11 +1655,11 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.selfie.to_json).to eq({
-        location: '::blank',
-        filename: '::blank',
-        original_filename: '::blank'
-      }.to_json)
+      expect(lion.selfie).to eq({
+        "location" => '::blank',
+        "filename" => '::blank',
+        "original_filename" => '::blank'
+      })
 
       expect(last_response.status).to eq(200)
 
@@ -1721,10 +1721,10 @@ describe UpdateController do
       )
 
       lion.refresh
-      expect(lion.selfie.to_json).to eq({
-        location: 'metis://labors/files/lion.jpg',
-        filename: 'monster-Nemean Lion-selfie.jpg',
-        original_filename: 'closeup.jpg'}.to_json)
+      expect(lion.selfie).to eq({
+        "location" => 'metis://labors/files/lion.jpg',
+        "filename" => 'monster-Nemean Lion-selfie.jpg',
+        "original_filename" => 'closeup.jpg'})
 
       expect(last_response.status).to eq(200)
 
@@ -1845,11 +1845,11 @@ describe UpdateController do
       )
 
       lion.refresh
-      expect(lion.certificates.to_json).to eq([{
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
-        filename: 'monster-Nemean Lion-certificates-0.txt',
-        original_filename: nil
-      }].to_json)
+      expect(lion.certificates).to eq([{
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
+        "filename" => 'monster-Nemean Lion-certificates-0.txt',
+        "original_filename" => nil
+      }])
 
       expect(last_response.status).to eq(200)
 
@@ -1938,15 +1938,15 @@ describe UpdateController do
       expect(last_response.status).to eq(200)
 
       lion.refresh
-      expect(lion.certificates.to_json).to eq([{
-        location: "metis://labors/magma/monster-Nemean Lion-certificates-1.txt",
-        filename: 'monster-Nemean Lion-certificates-0.txt',
-        original_filename: 'certificate-1.txt'
+      expect(lion.certificates).to eq([{
+        "location" => "metis://labors/magma/monster-Nemean Lion-certificates-1.txt",
+        "filename" => 'monster-Nemean Lion-certificates-0.txt',
+        "original_filename" => 'certificate-1.txt'
       }, {
-        location: "metis://labors/magma/monster-Nemean Lion-certificates-0.txt",
-        filename: 'monster-Nemean Lion-certificates-1.txt',
-        original_filename: 'certificate-0.txt'
-      }].to_json)
+        "location" => "metis://labors/magma/monster-Nemean Lion-certificates-0.txt",
+        "filename" => 'monster-Nemean Lion-certificates-1.txt',
+        "original_filename" => 'certificate-0.txt'
+      }])
 
       expect(WebMock).to have_requested(:post, "https://metis.test/labors/files/copy").
         with(query: hash_including({
@@ -1988,19 +1988,19 @@ describe UpdateController do
 
       lion.refresh
 
-      expect(lion.certificates.to_json).to eq([{
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
-        filename: 'monster-Nemean Lion-certificates-0.txt',
-        original_filename: 'certificate-0.txt'
+      expect(lion.certificates).to eq([{
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
+        "filename" => 'monster-Nemean Lion-certificates-0.txt',
+        "original_filename" => 'certificate-0.txt'
       }, {
-        location: 'metis://labors/files/CharmSchool.pdf',
-        filename: 'monster-Nemean Lion-certificates-1.pdf',
-        original_filename: 'CharmSchool.pdf'
+        "location" => 'metis://labors/files/CharmSchool.pdf',
+        "filename" => 'monster-Nemean Lion-certificates-1.pdf',
+        "original_filename" => 'CharmSchool.pdf'
       }, {
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
-        filename: 'monster-Nemean Lion-certificates-2.txt',
-        original_filename: 'certificate-1.txt'
-      }].to_json)
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
+        "filename" => 'monster-Nemean Lion-certificates-2.txt',
+        "original_filename" => 'certificate-1.txt'
+      }])
 
       expect(WebMock).to have_requested(:post, "https://metis.test/labors/files/copy").
         with(query: hash_including({
@@ -2039,15 +2039,15 @@ describe UpdateController do
 
       # the field is updated
       lion.refresh
-      expect(lion.certificates.to_json).to eq([{
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
-        filename: 'monster-Nemean Lion-certificates-0.txt',
-        original_filename: nil
+      expect(lion.certificates).to eq([{
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
+        "filename" => 'monster-Nemean Lion-certificates-0.txt',
+        "original_filename" => nil
       }, {
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
-        filename: 'monster-Nemean Lion-certificates-1.txt',
-        original_filename: nil
-      }].to_json)
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
+        "filename" => 'monster-Nemean Lion-certificates-1.txt',
+        "original_filename" => nil
+      }])
 
       expect(last_response.status).to eq(200)
 
@@ -2108,19 +2108,19 @@ describe UpdateController do
       expect(last_response.status).to eq(200)
 
       lion.refresh
-      expect(lion.certificates.to_json).to eq([{
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
-        filename: 'monster-Nemean Lion-certificates-0.txt',
-        original_filename: 'certificate-0.txt'
+      expect(lion.certificates).to eq([{
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-0.txt',
+        "filename" => 'monster-Nemean Lion-certificates-0.txt',
+        "original_filename" => 'certificate-0.txt'
       }, {
-        location: 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
-        filename: 'monster-Nemean Lion-certificates-1.txt',
-        original_filename: 'certificate-1.txt'
+        "location" => 'metis://labors/magma/monster-Nemean Lion-certificates-1.txt',
+        "filename" => 'monster-Nemean Lion-certificates-1.txt',
+        "original_filename" => 'certificate-1.txt'
       }, {
-        location: 'metis://labors/files/new-pirate-certificate.txt',
-        filename: 'monster-Nemean Lion-certificates-3.txt',
-        original_filename: 'new-pirate-certificate.txt'
-      }].to_json)
+        "location" => 'metis://labors/files/new-pirate-certificate.txt',
+        "filename" => 'monster-Nemean Lion-certificates-3.txt',
+        "original_filename" => 'new-pirate-certificate.txt'
+      }])
 
       expect(WebMock).to have_requested(:post, "https://metis.test/labors/files/copy").
         with(query: hash_including({
@@ -2532,7 +2532,7 @@ describe UpdateController do
       Magma.instance.configure(
         :test => @orig_config.dup.update(dateshift_salt: '')
       )
-      
+
       expect(@john_doe.birthday).to eq(nil)
 
       update(
@@ -2560,12 +2560,12 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:wound][:documents][@john_arm.id.to_s.to_sym][:received_date]
         ).not_to eq(iso_date_str('2000-01-01'))
-        
+
         @john_arm.refresh
         expect(@john_arm[:received_date]).not_to eq(nil)
         expect(@john_arm[:received_date].iso8601).not_to eq(iso_date_str('2000-01-01'))
@@ -2726,7 +2726,7 @@ describe UpdateController do
             }
           }
         )
-  
+
         expect(last_response.status).to eq(422)
         expect(@john_arm[:received_date]).to eq(nil)
       end
@@ -2810,9 +2810,9 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
-        
+
         @john_arm.refresh
         expect(@john_arm[:received_date]).to eq(nil)
       end
@@ -2851,12 +2851,12 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][@john_doe.name.to_sym][:birthday]
         ).not_to eq(iso_date_str('2000-01-01'))
-        
+
         @john_doe.refresh
         expect(@john_doe[:birthday]).not_to eq(nil)
         expect(@john_doe[:birthday].iso8601).not_to eq(iso_date_str('2000-01-01'))
@@ -2872,7 +2872,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][:Unicorn][:birthday]
@@ -2911,12 +2911,12 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][@john_doe.name.to_sym][:birthday]
         ).not_to eq(iso_date_str('2000-01-01'))
-        
+
         @john_doe.refresh
         expect(@john_doe[:birthday]).not_to eq(nil)
         expect(@john_doe[:birthday].iso8601).not_to eq(iso_date_str('2000-01-01'))
@@ -2935,7 +2935,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][:Unicorn][:birthday]
@@ -2961,13 +2961,13 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][:Unicorn][:birthday]
         ).not_to eq(iso_date_str('2000-01-01'))
 
-        set_date_shift_root("labor", false) 
+        set_date_shift_root("labor", false)
       end
 
       it 'shifts dates when update contains shifted and not-shifted data' do
@@ -2985,12 +2985,12 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][@john_doe.name.to_sym][:birthday]
         ).not_to eq(iso_date_str('2000-01-01'))
-        
+
         @john_doe.refresh
         expect(@john_doe[:birthday]).not_to eq(nil)
         expect(@john_doe[:birthday].iso8601).not_to eq(iso_date_str('2000-01-01'))
@@ -3014,7 +3014,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][@john_doe.name.to_sym][:birthday]
@@ -3041,12 +3041,12 @@ describe UpdateController do
             dry_run: true
           }
         )
-  
+
         expect(last_response.status).to eq(200)
         expect(
           json_body[:models][:victim][:documents][@john_doe.name.to_sym][:birthday]
         ).not_to eq(iso_date_str('2000-01-01'))
-        
+
         @john_doe.refresh
         expect(@john_doe[:birthday]).to eq(nil)
       end
@@ -3061,7 +3061,7 @@ describe UpdateController do
             }
           }
         )
-  
+
         expect(last_response.status).to eq(422)
         expect(@john_doe[:birthday]).to eq(nil)
       end
@@ -3075,7 +3075,7 @@ describe UpdateController do
             }
           }
         )
-  
+
         expect(last_response.status).to eq(422)
       end
 
@@ -3091,7 +3091,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
 
         @john_doe.refresh
@@ -3114,7 +3114,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
 
         @john_doe.refresh
@@ -3135,7 +3135,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
 
         @john_doe.refresh
@@ -3153,7 +3153,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
         expect(Labors::Victim.count).to eq(4)
       end
@@ -3171,7 +3171,7 @@ describe UpdateController do
           }},
           :privileged_editor
         )
-  
+
         expect(last_response.status).to eq(422)
         expect(Labors::Victim.count).to eq(4)
       end
@@ -3260,7 +3260,7 @@ EOT
     context 'using dry-run flag' do
       it 'censors date shift attribute updates, privileged user' do
         expect(@john_doe[:birthday]).to eq(nil)
-  
+
         update({
           victim: {
             @john_doe.name => {
@@ -3272,15 +3272,15 @@ EOT
             dry_run: true
           }
         )
-  
+
         expect(last_response.status).to eq(200)
-  
+
         output = <<EOT
 WARN:2000-01-01T00:00:00+00:00 8fzmq8 User copreus@twelve-labors.org calling update#action with params {:project_name=>"labors", :revisions=>{:victim=>{:"John Doe"=>{:birthday=>"*"}}}, :dry_run=>"true"}
 EOT
-  
+
         expect(File.read(@log_file)).to eq(output)
-  
+
         @john_doe.refresh
         expect(@john_doe[:birthday]).to eq(nil)
       end


### PR DESCRIPTION
Kind of prepping if we decide to use SQL aggregation for our queries, instead of doing the aggregation in Ruby. 

More refined start of #1166. Would kind of replace those changes.

This would convert our `json` columns to `jsonb`, which are queryable and orderable, so no need to fake-aggregate them via `string_agg`, and would make the implementation cleaner.

Trying to break this into smaller chunks, since #1166 got super messy and convoluted.