### PR TITLE
use symbolized version of column name

### DIFF
--- a/magma/lib/magma/query/predicate/model.rb
+++ b/magma/lib/magma/query/predicate/model.rb
@@ -224,7 +224,7 @@ class Magma
         end
       end
 
-      Sequel[alias_name][attribute.column_name]
+      Sequel[alias_name][attribute.column_name.to_sym]
     end
 
     def constraint


### PR DESCRIPTION
Small PR to make sure that the column name is returned as a symbol for a model, which helps remove duplicate column requests when constructing the question SQL.