### PR TITLE
project-specific existence check

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -452,8 +452,8 @@ class MetisClient < Client
     raise MetisClient::Error, "Could not copy file #{file_path} to #{proposed_file_path}\n#{error(response)}" unless response.code == "200"
   end
 
-  def exists(md5s)
-    response = json_post("/api/exists", md5s: md5s)
+  def exists(md5s, project_name=nil)
+    response = json_post("/api/exists", {md5s: md5s, project_name: project_name}.compact)
 
     return json_body(response)
   end
@@ -1330,6 +1330,10 @@ EOT
         opts.on("-f", "--file FILE", "Use FILE as the pattern to find and write checksum files") do |file|
           options[:file] = file
         end
+
+        opts.on("-p", "--project-name PROJECT_NAME", "Restrict search to specified project") do |n|
+          options[:project_name] = n
+        end
       end
     end
 
@@ -1358,7 +1362,7 @@ EOT
       remaining_size = 0
       unless files.empty?
         # check with metis
-        response = @shell.client.exists(file_md5s.values)
+        response = @shell.client.exists(file_md5s.values, options[:project_name])
 
         # remove all found files
         found = ::Set.new(response[:found])
@@ -1403,6 +1407,10 @@ EOT
         opts.on("-l", "--list", "List unarchived files") do |n|
           options[:list] = true
         end
+
+        opts.on("-p", "--project-name PROJECT_NAME", "Restrict search to specified project") do |n|
+          options[:project_name] = n
+        end
       end
     end
 
@@ -1425,7 +1433,7 @@ EOT
         puts "Computing md5s - #{progress_bar(1)} - #{files.length} of #{files.length}\n"
 
         # check with metis
-        response = @shell.client.exists(file_md5s.values)
+        response = @shell.client.exists(file_md5s.values, options[:project_name])
 
         # count found files
         found = ::Set.new(response[:found])

--- a/metis/lib/server/controllers/data_block_controller.rb
+++ b/metis/lib/server/controllers/data_block_controller.rb
@@ -3,7 +3,14 @@ class DataBlockController < Metis::Controller
     raise Etna::BadRequest, "Improper md5!" unless @params[:md5s].all? do |md5|
       md5 =~ /^[a-f0-9]{32}$/i
     end
-    found = Metis::DataBlock.where(md5_hash: @params[:md5s]).select_map(:md5_hash)
+    if @params[:project_name]
+      found = Metis::DataBlock.where(md5_hash: @params[:md5s]).join(
+        Metis::File.where(project_name: @params[:project_name]),
+        data_block_id: :id
+      ).select_map(:md5_hash)
+    else
+      found = Metis::DataBlock.where(md5_hash: @params[:md5s]).select_map(:md5_hash)
+    end
     success_json(found: found, missing: @params[:md5s] - found)
   end
 end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -751,6 +751,10 @@ describe MetisShell do
   end
 
   describe MetisShell::Nuke do
+    after(:each) do
+      FileUtils.rm('md5checksum.txt', force: true)
+    end
+
     it 'nukes a local directory except for missing files' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
 
@@ -790,9 +794,30 @@ describe MetisShell do
 
       FileUtils.rm_r('athena-copy')
     end
+
+    it 'only looks within the specified project' do
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
+      stubs.create_file('athena', 'armor', 'helmet.jpg', HELMET)
+      folly_file = create_file('ate', 'folly.txt', WISDOM.reverse, bucket: bucket)
+      stubs.create_file('ate', 'files', 'folly.txt', WISDOM.reverse)
+
+      stubs.send(:stub_file,'athena-copy/new/wisdom-copy.txt', WISDOM)
+      stubs.send(:stub_file,'athena-copy/new/helmet-copy.txt', HELMET)
+      stubs.send(:stub_file,'athena-copy/old/folly-copy.txt', WISDOM.reverse)
+
+      expect_output("metis://athena", "nuke", "--project-name", "athena", "athena-copy") { /Deleted 1 of 3 files, 0 of 2 folders./ }
+
+      FileUtils.rm_r('athena-copy')
+    end
   end
 
   describe MetisShell::Validate do
+    after(:each) do
+      FileUtils.rm('md5checksum.txt', force: true)
+    end
+
     it 'validates a local directory for missing files' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
 
@@ -806,6 +831,23 @@ describe MetisShell do
       stubs.send(:stub_file,'athena-copy/old/folly-copy.txt', WISDOM.reverse)
 
       expect_output("metis://athena", "validate", "athena-copy") { /Found 2 of 3 files on Metis/ }
+
+      FileUtils.rm_r('athena-copy')
+    end
+
+    it 'only looks within the specified project' do
+      bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+
+      helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
+      stubs.create_file('athena', 'armor', 'helmet.jpg', HELMET)
+      folly_file = create_file('ate', 'folly.txt', WISDOM.reverse, bucket: bucket)
+      stubs.create_file('ate', 'files', 'folly.txt', WISDOM.reverse)
+
+      stubs.send(:stub_file,'athena-copy/new/wisdom-copy.txt', WISDOM)
+      stubs.send(:stub_file,'athena-copy/new/helmet-copy.txt', HELMET)
+      stubs.send(:stub_file,'athena-copy/old/folly-copy.txt', WISDOM.reverse)
+
+      expect_output("metis://athena", "validate", "--project-name", "athena", "athena-copy") { /Found 1 of 3 files on Metis/ }
 
       FileUtils.rm_r('athena-copy')
     end

--- a/metis/spec/client_spec.rb
+++ b/metis/spec/client_spec.rb
@@ -820,23 +820,28 @@ describe MetisShell do
 
     it 'validates a local directory for missing files' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      bucket2 = create( :bucket, project_name: 'ate', name: 'busted_armor', access: 'editor', owner: 'metis')
 
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
       stubs.create_file('athena', 'armor', 'helmet.jpg', HELMET)
       wisdom_file = create_file('athena', 'wisdom.txt', WISDOM, bucket: bucket)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+      broken_helmet_file = create_file('ate', 'broken_helmet.jpg', HELMET.reverse, bucket: bucket2)
+      stubs.create_file('ate', 'broken_armor', 'helmet.jpg', HELMET)
 
       stubs.send(:stub_file,'athena-copy/new/wisdom-copy.txt', WISDOM)
       stubs.send(:stub_file,'athena-copy/new/helmet-copy.txt', HELMET)
       stubs.send(:stub_file,'athena-copy/old/folly-copy.txt', WISDOM.reverse)
+      stubs.send(:stub_file,'athena-copy/old/broken-helmet-copy.txt', HELMET.reverse)
 
-      expect_output("metis://athena", "validate", "athena-copy") { /Found 2 of 3 files on Metis/ }
+      expect_output("metis://athena", "validate", "athena-copy") { /Found 3 of 4 files on Metis/ }
 
       FileUtils.rm_r('athena-copy')
     end
 
     it 'only looks within the specified project' do
       bucket = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
+      bucket2 = create( :bucket, project_name: 'athena', name: 'armor', access: 'editor', owner: 'metis')
 
       helmet_file = create_file('athena', 'helmet.jpg', HELMET, bucket: bucket)
       stubs.create_file('athena', 'armor', 'helmet.jpg', HELMET)

--- a/metis/spec/data_block_spec.rb
+++ b/metis/spec/data_block_spec.rb
@@ -291,18 +291,22 @@ describe DataBlockController do
     it 'checks for the existence of data blocks by md5' do
       wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
       stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+      folly_file = create_file('ate', 'folly.txt', WISDOM.reverse)
+      stubs.create_file('ate', 'files', 'folly.txt', WISDOM.reverse)
 
       wisdom_md5 = Digest::MD5.hexdigest(WISDOM)
       folly_md5 = Digest::MD5.hexdigest(WISDOM.reverse)
+      helmet_md5 = Digest::MD5.hexdigest(HELMET)
 
       token_header(:viewer)
       json_post('/api/exists', md5s: [
         wisdom_md5,
-        folly_md5
+        folly_md5,
+        helmet_md5
       ])
 
       expect(last_response.status).to eq(200)
-      expect(json_body).to eq(found: [wisdom_md5], missing: [folly_md5])
+      expect(json_body).to eq(found: [wisdom_md5, folly_md5], missing: [helmet_md5])
     end
 
     it 'finds data blocks only for a specified project' do

--- a/metis/spec/data_block_spec.rb
+++ b/metis/spec/data_block_spec.rb
@@ -304,5 +304,24 @@ describe DataBlockController do
       expect(last_response.status).to eq(200)
       expect(json_body).to eq(found: [wisdom_md5], missing: [folly_md5])
     end
+
+    it 'finds data blocks only for a specified project' do
+      wisdom_file = create_file('athena', 'wisdom.txt', WISDOM)
+      stubs.create_file('athena', 'files', 'wisdom.txt', WISDOM)
+      folly_file = create_file('ate', 'folly.txt', WISDOM.reverse)
+      stubs.create_file('ate', 'files', 'folly.txt', WISDOM.reverse)
+
+      wisdom_md5 = Digest::MD5.hexdigest(WISDOM)
+      folly_md5 = Digest::MD5.hexdigest(WISDOM.reverse)
+
+      token_header(:viewer)
+      json_post('/api/exists', md5s: [
+        wisdom_md5,
+        folly_md5
+      ], project_name: 'athena')
+
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(found: [wisdom_md5], missing: [folly_md5])
+    end
   end
 end


### PR DESCRIPTION
Adds a --project-name flag to nuke and validate, and the corresponding "exists" endpoint on Metis, to allow those commands to only check (or remove) files that are linked into some project. Doesn't know anything about folder structure or buckets, just that the file is somewhere in the project's metis collection. A file that exists, but in a separate project (e.g. triage) will be treated as if it does not exist in Metis.