### PR TITLE
etna materialize

### DIFF
--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.46'
+  spec.version           = '0.1.47'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -248,13 +248,14 @@ class EtnaApp
 
       string_flags << "--project-name"
       string_flags << "--log-file"
+      string_flags << "--log-level"
+      string_flags << "--concurrency"
 
-      def logger
-        @logger ||= @logger = Etna::Logger.new(@log_file, 0, 1048576)
-      end
 
-      def execute(project_name:, log_file:'/dev/stdout')
-        @log_file = log_file
+      def execute(project_name:, log_file:'/dev/stdout', log_level: ::Logger::INFO, concurrency: 1)
+        logger = Etna::Logger.new(log_file, 0, 1048576)
+
+        logger.level = log_level
 
         workflow = Etna::Clients::Magma::MaterializeDataWorkflow.new(
             model_attributes_mask: model_attribute_pairs(project_name),
@@ -265,7 +266,7 @@ class EtnaApp
             logger: logger,
             project_name: project_name,
             model_name: 'project', filesystem: filesystem,
-            concurrency: 1)
+            concurrency: concurrency.to_i)
 
         workflow.materialize_all(project_name)
         logger.info("Done")

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -245,11 +245,17 @@ class EtnaApp
 
     class Materialize < Etna::Command
       include WithEtnaClients
-      include WithLogger
 
       string_flags << "--project-name"
+      string_flags << "--log-file"
 
-      def execute(project_name:)
+      def logger
+        @logger ||= @logger = Etna::Logger.new(@log_file, 0, 1048576)
+      end
+
+      def execute(project_name:, log_file:'/dev/stdout')
+        @log_file = log_file
+
         workflow = Etna::Clients::Magma::MaterializeDataWorkflow.new(
             model_attributes_mask: model_attribute_pairs(project_name),
             record_names: 'all',
@@ -261,7 +267,7 @@ class EtnaApp
             model_name: 'project', filesystem: filesystem,
             concurrency: 1)
 
-        workflow.materialize_all("Upload")
+        workflow.materialize_all(project_name)
         logger.info("Done")
       end
 

--- a/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
@@ -108,6 +108,7 @@ module Etna
             end
 
             dest_file = File.join(dest_dir, metadata_file_name(record_name: record[template.identifier], record_model_name: template.name, ext: "_#{attr_name}_#{idx}#{File.extname(filename)}"))
+            filesystem.mkdir_p(File.dirname(dest_file))
             sync_metis_data_workflow.copy_file(dest: dest_file, url: url, stub: stub_files)
             record_to_serialize[attr_name] << {file: dest_file, original_filename: filename}
           end

--- a/etna/lib/etna/clients/metis/workflows/sync_metis_data_workflow.rb
+++ b/etna/lib/etna/clients/metis/workflows/sync_metis_data_workflow.rb
@@ -94,6 +94,18 @@ module Etna
                 if start_time == end_time
                   next
                 end
+
+                rate = upload_amount / (end_time - start_time)
+
+                if rate / last_rate > 1.3 || rate / last_rate < 0.7
+                  logger&.debug("Uploading #{Etna::Formatting.as_size(rate)} per second, #{Etna::Formatting.as_size(remaining)} remaining")
+
+                  if rate == 0
+                    last_rate = 0.0001
+                  else
+                    last_rate = rate
+                  end
+                end
               end
             end
           end

--- a/etna/lib/etna/command.rb
+++ b/etna/lib/etna/command.rb
@@ -136,7 +136,7 @@ module Etna
             "<#{name}>..."
           when :keyrest
             "[flags...]"
-          when :key
+          when :key, :keyreq
             flag = "--#{name.to_s.gsub('_', '-')}"
             if self.class.boolean_flags.include?(flag)
               "[#{flag}]"

--- a/etna/lib/etna/filesystem.rb
+++ b/etna/lib/etna/filesystem.rb
@@ -14,45 +14,48 @@ module Etna
       ::File.open(dest, opts, &block)
     end
 
+    class Error < StandardError
+    end
+
     def ls(dir)
-      raise "ls not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "ls not supported by #{self.class.name}" unless self.class == Filesystem
       ::Dir.entries(dir).select { |p| !p.start_with?('.') }.map do |path|
         ::File.file?(::File.join(dir, path)) ? [:file, path] : [:dir, path]
       end
     end
 
     def with_readable(src, opts = 'r', &block)
-      raise "with_readable not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "with_readable not supported by #{self.class.name}" unless self.class == Filesystem
       ::File.open(src, opts, &block)
     end
 
     def mkdir_p(dir)
-      raise "mkdir_p not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "mkdir_p not supported by #{self.class.name}" unless self.class == Filesystem
       ::FileUtils.mkdir_p(dir)
     end
 
     def rm_rf(dir)
-      raise "rm_rf not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "rm_rf not supported by #{self.class.name}" unless self.class == Filesystem
       ::FileUtils.rm_rf(dir)
     end
 
     def tmpdir
-      raise "tmpdir not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "tmpdir not supported by #{self.class.name}" unless self.class == Filesystem
       ::Dir.mktmpdir
     end
 
     def exist?(src)
-      raise "exist? not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "exist? not supported by #{self.class.name}" unless self.class == Filesystem
       ::File.exist?(src)
     end
 
     def mv(src, dest)
-      raise "mv not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "mv not supported by #{self.class.name}" unless self.class == Filesystem
       ::FileUtils.mv(src, dest)
     end
 
     def stat(src)
-      raise "stat not supported by #{self.class.name}" unless self.class == Filesystem
+      raise Etna::Filesystem::Error, "stat not supported by #{self.class.name}" unless self.class == Filesystem
       ::File.stat(src)
     end
 


### PR DESCRIPTION
Surprisingly easy delivery of a "materialize" command, which just involves connecting the Materialize workflow to a local Etna::Filesystem. `etna materialize --project-name my_project` results in a local folder `my_project` containing the project data.

If the Filesystem can report size information (i.e. responds to `stat`) sync_metis_data_workflow will skip a file if it exists with the same file size. Does not check hashes. Hopefully this makes resuming/retrying less painful. Records (.json) still get re-downloaded every time.