### PR TITLE
Timur delete model bug; close #1174, close #1182

### DIFF
--- a/etna/packages/etna-js/components/ModalDialogContainer.jsx
+++ b/etna/packages/etna-js/components/ModalDialogContainer.jsx
@@ -17,7 +17,6 @@ export function ModalDialogContainer({children}) {
 
   let modal = null;
   if (component) {
-    console.log('opts', opts, closeOnClickBackdrop());
     modal = (
       <div
         className='etna-modal-window'

--- a/etna/packages/etna-js/components/ModalDialogContainer.jsx
+++ b/etna/packages/etna-js/components/ModalDialogContainer.jsx
@@ -1,34 +1,49 @@
-import React, { useState, createContext, useContext, useCallback } from 'react';
+import React, {useState, createContext, useContext, useCallback} from 'react';
 require('./ModalDialog.css');
 
 const ModalDialogContext = createContext({});
 
-export function ModalDialogContainer({ children }) {
+export function ModalDialogContainer({children}) {
   const [modalState, setModalState] = useState({});
   const dismissModal = useCallback(() => setModalState({}), [setModalState]);
-  const modalContextValue = { modalState, setModalState, dismissModal };
-  const { component } = modalState;
+  const modalContextValue = {modalState, setModalState, dismissModal};
+  const {component, opts} = modalState;
+
+  function closeOnClickBackdrop() {
+    return opts.hasOwnProperty('closeOnClickBackdrop')
+      ? !!opts.closeOnClickBackdrop
+      : true;
+  }
 
   let modal = null;
   if (component) {
-    modal = <div className='etna-modal-window' onClick={dismissModal}>
-      <div onClick={(e) => e.stopPropagation()}>
-        { component }
+    console.log('opts', opts, closeOnClickBackdrop());
+    modal = (
+      <div
+        className='etna-modal-window'
+        onClick={() => (closeOnClickBackdrop() ? dismissModal() : null)}
+      >
+        <div onClick={(e) => e.stopPropagation()}>{component}</div>
       </div>
-    </div>;
+    );
   }
 
-  return <ModalDialogContext.Provider value={modalContextValue}>
-    {children}
-    {modal}
-  </ModalDialogContext.Provider>
+  return (
+    <ModalDialogContext.Provider value={modalContextValue}>
+      {children}
+      {modal}
+    </ModalDialogContext.Provider>
+  );
 }
 
 export function useModal() {
   const {setModalState, dismissModal} = useContext(ModalDialogContext);
-  const openModal = useCallback(function openModal(component) {
-    setModalState({component});
-  }, [setModalState])
+  const openModal = useCallback(
+    function openModal(component, opts = {}) {
+      setModalState({component, opts});
+    },
+    [setModalState]
+  );
 
   return {openModal, dismissModal};
 }

--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -144,7 +144,9 @@ const ManageModelActions = ({
           className={classes.addBtn}
           startIcon={<AddIcon />}
           onClick={() => {
-            openModal(<AddAttributeModal onSave={handleAddAttribute} />);
+            openModal(<AddAttributeModal onSave={handleAddAttribute} />, {
+              closeOnClickBackdrop: false
+            });
           }}
         >
           Attribute
@@ -155,7 +157,9 @@ const ManageModelActions = ({
           className={classes.addBtn}
           startIcon={<LinkIcon />}
           onClick={() => {
-            openModal(<AddLinkModal onSave={handleAddLink} />);
+            openModal(<AddLinkModal onSave={handleAddLink} />, {
+              closeOnClickBackdrop: false
+            });
           }}
         >
           Link
@@ -167,7 +171,10 @@ const ManageModelActions = ({
           startIcon={<LibraryAddIcon />}
           onClick={() => {
             openModal(
-              <AddModelModal modelName={modelName} onSave={handleAddModel} />
+              <AddModelModal modelName={modelName} onSave={handleAddModel} />,
+              {
+                closeOnClickBackdrop: false
+              }
             );
           }}
         >
@@ -184,7 +191,10 @@ const ManageModelActions = ({
                 <ReparentModelModal
                   modelName={modelName}
                   onSave={handleReparentModel}
-                />
+                />,
+                {
+                  closeOnClickBackdrop: false
+                }
               );
             }}
           >
@@ -202,7 +212,10 @@ const ManageModelActions = ({
                 <RemoveModelModal
                   modelName={modelName}
                   onSave={handleRemoveModel}
-                />
+                />,
+                {
+                  closeOnClickBackdrop: false
+                }
               );
             }}
           >

--- a/timur/lib/client/jsx/components/model_map/use_magma_actions.ts
+++ b/timur/lib/client/jsx/components/model_map/use_magma_actions.ts
@@ -18,6 +18,7 @@ const useMagmaActions = () => {
         })
         .catch((err: any) => {
           invoke(showMessages(err));
+          throw err;
         });
     },
     [invoke, addTemplatesAndDocuments, showMessages]


### PR DESCRIPTION
This PR addresses #1174 and #1182.

* Better handles Magma errors during the model editing processes. Previously if an error were returned, the message would be shown to the user, but the action would incorrectly change the UI state. Now errors do not change UI state, so it should reflect the actual server-side model state.
* Adds an option for our Etna modal component to not close the modal when you click on the backdrop. Turns off that behavior for the model editing modals.