### PR TITLE
tweak uniq call until after all predicates have been built

### DIFF
--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -155,11 +155,11 @@ class Magma
     end
 
     def built_predicate_select_statements
-      (predicate_collect(:select)).uniq.map do |predicate|
+      (predicate_collect(:select)).map do |predicate|
         predicate.is_a?(Magma::SubselectBase) ?
           predicate.build_with_alias :
           predicate
-      end
+      end.uniq
     end
 
     def order_by_attributes

--- a/magma/lib/magma/query/subselect_base.rb
+++ b/magma/lib/magma/query/subselect_base.rb
@@ -32,6 +32,8 @@ class Magma
     end
 
     def eql?(other)
+      return false unless other.is_a?(Magma::SubselectBase)
+
       subselect_column_alias == other.subselect_column_alias
     end
 


### PR DESCRIPTION
I think moving this `.uniq` call helps remove the flakiness seen in the Magma tests. Unclear why those tests would sometimes fail, since the bugs and failed tests we observe in testing are not reproducible, even with the same seed. So there may still be an underlying issue...