### PR TITLE
make aspera client ls return boolean if exception thrown...

### DIFF
--- a/etna/lib/etna/filesystem.rb
+++ b/etna/lib/etna/filesystem.rb
@@ -172,6 +172,8 @@ module Etna
 
       def exist?(src)
         !run_ascli_cmd("ls", src).nil?
+      rescue Exception => e
+        false
       end
 
       def mv(src, dest)


### PR DESCRIPTION
The new `exists?` check in the Materialize workflow was causing the GNE transfer to throw an exception, since the Aspera client cannot execute `ls`. So we should return `false` in that case, since we do not know if the file exists on the target system or not.

I'm pushing this out to production, since this affects the GNE transfer ... will have to figure out how to rollback the cursor without re-starting the entire transfer... but I think files that were uploaded today not have actually transferred, given the code path in the materialize workflow.