### PR TITLE
also render the "sample" button for identifier attributes

### DIFF
--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -243,6 +243,13 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
     );
   }, [executeAction, model_name, removeLink, attribute]);
 
+  const showSampleButton = useMemo(() => {
+    if (!attribute?.attribute_type) return false;
+
+    const allowedTypes = ['string', 'identifier'];
+    return allowedTypes.includes(attribute.attribute_type);
+  }, [attribute]);
+
   if (!attribute) return null;
 
   return (
@@ -257,7 +264,7 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
               handleRemoveLink={handleRemoveLink}
             />
           )}
-          {attribute.attribute_type == 'string' && (
+          {showSampleButton && (
             <Tooltip title='Show data sample'>
               <Button
                 onClick={showSample}

--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -8,7 +8,6 @@ import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
-import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
 import {requestAnswer} from 'etna-js/actions/magma_actions';
 import {useModal} from 'etna-js/components/ModalDialogContainer';
@@ -61,9 +60,7 @@ const useStyles = makeStyles((theme) => ({
   },
   content: {
     height: 'calc(100% - 64px)',
-    overflowY: 'auto',
-    display: 'flex',
-    flexDirection: 'column'
+    overflowY: 'auto'
   },
   type: {
     color: 'gray'
@@ -71,16 +68,13 @@ const useStyles = makeStyles((theme) => ({
   value: {
     color: '#131',
     borderBottom: '1px solid rgba(34, 139, 34, 0.1)',
+    maxHeight: '90px',
     wordWrap: 'break-word',
     width: '0px',
     overflowY: 'auto'
   },
   button: {
     margin: '0.5rem'
-  },
-  sampleContainer: {
-    flexGrow: 1,
-    overflowY: 'auto'
   }
 }));
 
@@ -311,7 +305,7 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
               </Grid>
             ))}
           {sample && (
-            <Grid container className={classes.sampleContainer}>
+            <Grid container>
               <Grid item xs={3} className={classes.type}>
                 sample
               </Grid>

--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -81,24 +81,6 @@ const useStyles = makeStyles((theme) => ({
   sampleContainer: {
     flexGrow: 1,
     overflowY: 'auto'
-  },
-  sampleList: {
-    display: 'flex',
-    flexDirection: 'column'
-  },
-  sampleListColumns: {
-    columnCount: 3,
-    columnWidth: '150px',
-    paddingBottom: '3px'
-  },
-  listItem: {
-    display: 'inline-block',
-    width: '100%',
-    paddingTop: '3px',
-    borderBottom: 'thin-rule(0.1)',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden'
   }
 }));
 
@@ -219,26 +201,6 @@ const ManageAttributeActions = ({
   );
 };
 
-const ListItem = ({text}) => {
-  const classes = useStyles();
-  console.log('text', text);
-  return <div className={classes.listItem}>{text}</div>;
-};
-
-const SampleList = ({sample}) => {
-  const classes = useStyles();
-  console.log('sample', sample);
-  return (
-    <div className={classes.sampleList}>
-      <div className={classes.sampleListColumns}>
-        {sample.map((item, index) => {
-          return <ListItem key={index} text={item} />;
-        })}
-      </div>
-    </div>
-  );
-};
-
 const AttributeReport = ({attribute, model_name, isAdminUser}) => {
   const dispatch = useDispatch();
   const [sample, setSample] = useState(null);
@@ -351,14 +313,10 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
           {sample && (
             <Grid container className={classes.sampleContainer}>
               <Grid item xs={3} className={classes.type}>
-                sample (distinct values)
+                sample
               </Grid>
               <Grid item xs={9} className={classes.value}>
-                {sample.length > 0 ? (
-                  <SampleList sample={sample} />
-                ) : (
-                  <i>No values</i>
-                )}
+                {sample.length > 0 ? JSON.stringify(sample) : <i>No values</i>}
               </Grid>
             </Grid>
           )}

--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -81,6 +81,24 @@ const useStyles = makeStyles((theme) => ({
   sampleContainer: {
     flexGrow: 1,
     overflowY: 'auto'
+  },
+  sampleList: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  sampleListColumns: {
+    columnCount: 3,
+    columnWidth: '150px',
+    paddingBottom: '3px'
+  },
+  listItem: {
+    display: 'inline-block',
+    width: '100%',
+    paddingTop: '3px',
+    borderBottom: 'thin-rule(0.1)',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden'
   }
 }));
 
@@ -201,6 +219,26 @@ const ManageAttributeActions = ({
   );
 };
 
+const ListItem = ({text}) => {
+  const classes = useStyles();
+  console.log('text', text);
+  return <div className={classes.listItem}>{text}</div>;
+};
+
+const SampleList = ({sample}) => {
+  const classes = useStyles();
+  console.log('sample', sample);
+  return (
+    <div className={classes.sampleList}>
+      <div className={classes.sampleListColumns}>
+        {sample.map((item, index) => {
+          return <ListItem key={index} text={item} />;
+        })}
+      </div>
+    </div>
+  );
+};
+
 const AttributeReport = ({attribute, model_name, isAdminUser}) => {
   const dispatch = useDispatch();
   const [sample, setSample] = useState(null);
@@ -313,10 +351,14 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
           {sample && (
             <Grid container className={classes.sampleContainer}>
               <Grid item xs={3} className={classes.type}>
-                sample
+                sample (distinct values)
               </Grid>
               <Grid item xs={9} className={classes.value}>
-                {sample.length > 0 ? JSON.stringify(sample) : <i>No values</i>}
+                {sample.length > 0 ? (
+                  <SampleList sample={sample} />
+                ) : (
+                  <i>No values</i>
+                )}
               </Grid>
             </Grid>
           )}

--- a/timur/lib/client/jsx/components/model_map/attribute_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/attribute_report.jsx
@@ -8,6 +8,7 @@ import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
+import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
 import {requestAnswer} from 'etna-js/actions/magma_actions';
 import {useModal} from 'etna-js/components/ModalDialogContainer';
@@ -60,7 +61,9 @@ const useStyles = makeStyles((theme) => ({
   },
   content: {
     height: 'calc(100% - 64px)',
-    overflowY: 'auto'
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column'
   },
   type: {
     color: 'gray'
@@ -68,13 +71,16 @@ const useStyles = makeStyles((theme) => ({
   value: {
     color: '#131',
     borderBottom: '1px solid rgba(34, 139, 34, 0.1)',
-    maxHeight: '90px',
     wordWrap: 'break-word',
     width: '0px',
     overflowY: 'auto'
   },
   button: {
     margin: '0.5rem'
+  },
+  sampleContainer: {
+    flexGrow: 1,
+    overflowY: 'auto'
   }
 }));
 
@@ -305,7 +311,7 @@ const AttributeReport = ({attribute, model_name, isAdminUser}) => {
               </Grid>
             ))}
           {sample && (
-            <Grid container>
+            <Grid container className={classes.sampleContainer}>
               <Grid item xs={3} className={classes.type}>
                 sample
               </Grid>

--- a/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
@@ -31,7 +31,38 @@ exports[`AttributeReport renders 1`] = `
             "width": "auto",
           }
         }
-      />
+      >
+        <button
+          aria-describedby={null}
+          className="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button-7 MuiButton-textSecondary MuiButton-textSizeSmall MuiButton-sizeSmall"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          title="Show data sample"
+          type="button"
+        >
+          <span
+            className="MuiButton-label"
+          >
+            Sample
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
     </div>
     <div
       className="MuiCardContent-root makeStyles-content-4"
@@ -476,7 +507,23 @@ exports[`AttributeReport renders without model action buttons for admin user, no
         <div
           class="MuiGrid-root MuiGrid-container"
           style="width: auto; flex: 1; align-items: end; justify-content: right;"
-        />
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-button-7 MuiButton-textSecondary MuiButton-textSizeSmall MuiButton-sizeSmall"
+            tabindex="0"
+            title="Show data sample"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              Sample
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
       </div>
       <div
         class="MuiCardContent-root makeStyles-content-4"

--- a/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
@@ -8,16 +8,16 @@ exports[`AttributeReport renders 1`] = `
     className="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <div
-      className="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+      className="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
     >
       <h6
-        className="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
       >
         Attribute
       </h6>
        
       <h6
-        className="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
       >
         name
       </h6>
@@ -109,16 +109,16 @@ exports[`AttributeReport renders with remove attribute buttons for admin user, r
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           species
         </h6>
@@ -275,16 +275,16 @@ exports[`AttributeReport renders with remove link button for admin user, collect
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           monster
         </h6>
@@ -383,16 +383,16 @@ exports[`AttributeReport renders with remove link button for admin user, link at
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           habitat
         </h6>
@@ -491,16 +491,16 @@ exports[`AttributeReport renders without model action buttons for admin user, no
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           name
         </h6>
@@ -571,16 +571,16 @@ exports[`AttributeReport renders without model action buttons for editor user 1`
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           species
         </h6>

--- a/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
@@ -8,16 +8,16 @@ exports[`AttributeReport renders 1`] = `
     className="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <div
-      className="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+      className="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
     >
       <h6
-        className="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
       >
         Attribute
       </h6>
        
       <h6
-        className="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
       >
         name
       </h6>
@@ -109,16 +109,16 @@ exports[`AttributeReport renders with remove attribute buttons for admin user, r
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           species
         </h6>
@@ -275,16 +275,16 @@ exports[`AttributeReport renders with remove link button for admin user, collect
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           monster
         </h6>
@@ -383,16 +383,16 @@ exports[`AttributeReport renders with remove link button for admin user, link at
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           habitat
         </h6>
@@ -491,16 +491,16 @@ exports[`AttributeReport renders without model action buttons for admin user, no
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           name
         </h6>
@@ -571,16 +571,16 @@ exports[`AttributeReport renders without model action buttons for editor user 1`
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
         >
           species
         </h6>

--- a/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
@@ -8,16 +8,16 @@ exports[`AttributeReport renders 1`] = `
     className="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <div
-      className="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+      className="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
     >
       <h6
-        className="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
       >
         Attribute
       </h6>
        
       <h6
-        className="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
       >
         name
       </h6>
@@ -109,16 +109,16 @@ exports[`AttributeReport renders with remove attribute buttons for admin user, r
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
         >
           species
         </h6>
@@ -275,16 +275,16 @@ exports[`AttributeReport renders with remove link button for admin user, collect
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
         >
           monster
         </h6>
@@ -383,16 +383,16 @@ exports[`AttributeReport renders with remove link button for admin user, link at
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
         >
           habitat
         </h6>
@@ -491,16 +491,16 @@ exports[`AttributeReport renders without model action buttons for admin user, no
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
         >
           name
         </h6>
@@ -571,16 +571,16 @@ exports[`AttributeReport renders without model action buttons for editor user 1`
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-8 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-9 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-10 MuiTypography-h6"
         >
           species
         </h6>

--- a/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/attribute_report.test.js.snap
@@ -8,16 +8,16 @@ exports[`AttributeReport renders 1`] = `
     className="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <div
-      className="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+      className="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
     >
       <h6
-        className="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
       >
         Attribute
       </h6>
        
       <h6
-        className="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+        className="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
       >
         name
       </h6>
@@ -109,16 +109,16 @@ exports[`AttributeReport renders with remove attribute buttons for admin user, r
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
         >
           species
         </h6>
@@ -275,16 +275,16 @@ exports[`AttributeReport renders with remove link button for admin user, collect
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
         >
           monster
         </h6>
@@ -383,16 +383,16 @@ exports[`AttributeReport renders with remove link button for admin user, link at
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
         >
           habitat
         </h6>
@@ -491,16 +491,16 @@ exports[`AttributeReport renders without model action buttons for admin user, no
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
         >
           name
         </h6>
@@ -571,16 +571,16 @@ exports[`AttributeReport renders without model action buttons for editor user 1`
       class="MuiPaper-root MuiCard-root makeStyles-attribute_card-3 MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiGrid-root makeStyles-heading-9 undefined MuiGrid-container"
+        class="MuiGrid-root makeStyles-heading-12 undefined MuiGrid-container"
       >
         <h6
-          class="MuiTypography-root makeStyles-name-10 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-name-13 MuiTypography-h6"
         >
           Attribute
         </h6>
          
         <h6
-          class="MuiTypography-root makeStyles-title-11 MuiTypography-h6"
+          class="MuiTypography-root makeStyles-title-14 MuiTypography-h6"
         >
           species
         </h6>


### PR DESCRIPTION
This PR closes #1176.

@dtm2451 , is this what you had in mind? It looks like the other "sample" results, just listed at the bottom of the pane:

![Screenshot from 2023-01-30 16-35-42](https://user-images.githubusercontent.com/4930129/215600556-8c2ccc3f-dc41-4329-852b-6272c3a7a539.png)

I think there was also a comment about making that box larger so you could see more data, but I don't recall -- might have just been a verbal comment at the meeting?