### PR TITLE
remove CI staging actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -35,4 +34,3 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
-          git push origin HEAD:staging --force

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -35,4 +33,3 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
-          git push origin HEAD:production-build --force

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.SYNC_ACCESS_TOKEN }}
       - name: docker login
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -35,4 +33,3 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C etna release
           make -j 4 release
-          git push origin HEAD:staging-build --force


### PR DESCRIPTION
Per question in Slack, since we currently do not deploy the staging containers, I propose removing that step from our CI / CD workflow. So to push to `production`, we would execute a PR to merge `master` into `production` directly (instead of `staging` into `production`). This will save about an hour, hour and a half in the deploy process.

This PR would be a trial run, basically it should merge cleanly into `master`, there should be no follow-on `staging` CI step, and then merging `master` into `production` should trigger production deploys (with no app changes).