### PR TITLE
expose page_size argument to materialize command

### DIFF
--- a/etna/Gemfile.lock
+++ b/etna/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    etna (0.1.49)
+    etna (0.1.50)
       concurrent-ruby
       curb
       jwt

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.49'
+  spec.version           = '0.1.50'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -250,9 +250,10 @@ class EtnaApp
       string_flags << "--log-file"
       string_flags << "--log-level"
       string_flags << "--concurrency"
+      string_flags << "--page_size"
 
 
-      def execute(project_name:, log_file:'/dev/stdout', log_level: ::Logger::INFO, concurrency: 1)
+      def execute(project_name:, log_file:'/dev/stdout', log_level: ::Logger::INFO, concurrency: 1, page_size: 20)
         logger = Etna::Logger.new(log_file, 0, 1048576)
 
         logger.level = log_level
@@ -266,6 +267,7 @@ class EtnaApp
             logger: logger,
             project_name: project_name,
             model_name: 'project', filesystem: filesystem,
+            page_size: page_size.to_i,
             concurrency: concurrency.to_i)
 
         workflow.materialize_all(project_name)

--- a/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
+++ b/etna/lib/etna/clients/magma/workflows/materialize_magma_record_files_workflow.rb
@@ -9,10 +9,10 @@ module Etna
           :metis_client, :magma_client, :project_name,
           :model_name, :model_filters, :model_attributes_mask,
           :filesystem, :logger, :stub_files, :concurrency,
-          :record_names, keyword_init: true)
+          :page_size, :record_names, keyword_init: true)
 
         def initialize(**kwds)
-          super(**({filesystem: Etna::Filesystem.new, concurrency: 10, record_names: "all"}.update(kwds)))
+          super(**({filesystem: Etna::Filesystem.new, page_size: 20, concurrency: 10, record_names: "all"}.update(kwds)))
         end
 
         def magma_crud
@@ -34,7 +34,7 @@ module Etna
               record_names,
               model_attributes_mask: model_attributes_mask,
               model_filters: model_filters,
-              page_size: 20,
+              page_size: page_size,
           ) do |template, document|
             logger&.info("Materializing #{template.name}##{document[template.identifier]}")
             templates[template.name] = template


### PR DESCRIPTION
For some reason materialize requests to download ipi are dying with a 403, which results from an expired download URL. These URLs are generated by `retrieve` requests to Magma, which happen right now in pages of 20 records. A plausible explanation for how a URL could become stale before it is used might be that the contents of the page take more than a day to download. This requires a page to be > 1 TB, which seems plausible for some of these datasets.

A hopeful solution is to simply shrink the page size to 1, so each record retrieve is fresh. An expiration might STILL result if a single record takes more than a day to download, but that probably isn't going to happen here.