### PR TITLE
fix map for too many boxes

### DIFF
--- a/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
@@ -55,7 +55,7 @@ const ModelMapGraphic = ({
             key={model_name}
             center={node.center}
             size={node.size}
-            numSiblings={ layout.grid[node.depth].length }
+            numSiblings={ layout.grid[node.depth] ? layout.grid[node.depth].length : 0 }
             selected={
               selected_models ? selected_models.includes(model_name) : false
             }

--- a/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
@@ -55,6 +55,7 @@ const ModelMapGraphic = ({
             key={model_name}
             center={node.center}
             size={node.size}
+            numSiblings={ layout.grid[node.depth].length }
             selected={
               selected_models ? selected_models.includes(model_name) : false
             }

--- a/timur/lib/client/jsx/components/model_map/model_node.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_node.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-const ModelNode = ({model_name, center, size, selected, handler, disabled}) =>
+const ModelNode = ({model_name, center, size, selected, handler, disabled, numSiblings}) =>
+
   center ? (
     <div
       className={`model_node ${selected ? 'selected' : ''} ${
         disabled ? 'disabled' : ''
       }`}
-      style={{top: center.y, left: center.x}}
+      style={{top: center.y, left: center.x, '--model-width': `${600 / (numSiblings + 1) - 15}px` }}
       onClick={() => {
         if (!disabled) handler(model_name);
       }}

--- a/timur/lib/client/jsx/components/model_map/tree_layout.jsx
+++ b/timur/lib/client/jsx/components/model_map/tree_layout.jsx
@@ -65,7 +65,7 @@ class LayoutNode {
     let maxpos = grid[this.depth].length;
     let maxdepth = grid.length;
     this.center = {
-      x: (this.pos / (maxpos + 1)) * this.layout.width,
+      x: (this.pos/(maxpos + 1)) * this.layout.width,
       y: (this.depth / maxdepth) * this.layout.height
     };
     this.size = 40;
@@ -86,6 +86,8 @@ class TreeLayout {
     }
 
     let grid = [];
+
+    this.grid = grid;
 
     let {project} = this.nodes;
 

--- a/timur/lib/client/scss/model_map.scss
+++ b/timur/lib/client/scss/model_map.scss
@@ -18,6 +18,10 @@ svg#map {
   font-family: $body_font;
   font-size: 0.75em;
 
+  max-width: var(--model-width);
+  overflow: hidden;
+  text-overflow: ellipsis;
+
   border-radius: 3px;
   border: 2px solid #aaa;
   background: #f2f2f2;
@@ -32,6 +36,9 @@ svg#map {
   transform: translate(-50%, -50%);
   &:hover {
     background: #cec;
+    max-width: unset;
+    overflow: unset;
+    z-index: 1000;
   }
 }
 

--- a/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
@@ -572,6 +572,7 @@ exports[`ModelMap renders an incomplete graph 1`] = `
       onClick={[Function]}
       style={
         Object {
+          "--model-width": "285px",
           "left": 300,
           "top": 300,
         }
@@ -1512,19 +1513,19 @@ exports[`ModelMap renders with reparent model action buttons for admin user, no-
       </svg>
       <div
         class="model_node  "
-        style="top: 300px; left: 300px;"
+        style="top: 300px; left: 300px; --model-width: 285px;"
       >
         labor
       </div>
       <div
         class="model_node selected "
-        style="top: 450px; left: 300px;"
+        style="top: 450px; left: 300px; --model-width: 285px;"
       >
         monster
       </div>
       <div
         class="model_node  "
-        style="top: 150px; left: 300px;"
+        style="top: 150px; left: 300px; --model-width: 285px;"
       >
         project
       </div>

--- a/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
+++ b/timur/test/javascript/components/__snapshots__/model_map.test.js.snap
@@ -81,6 +81,7 @@ exports[`ModelMap renders 1`] = `
       onClick={[Function]}
       style={
         Object {
+          "--model-width": "285px",
           "left": 300,
           "top": 300,
         }
@@ -93,6 +94,7 @@ exports[`ModelMap renders 1`] = `
       onClick={[Function]}
       style={
         Object {
+          "--model-width": "285px",
           "left": 300,
           "top": 450,
         }
@@ -105,6 +107,7 @@ exports[`ModelMap renders 1`] = `
       onClick={[Function]}
       style={
         Object {
+          "--model-width": "285px",
           "left": 300,
           "top": 150,
         }
@@ -1046,19 +1049,19 @@ exports[`ModelMap renders with model action buttons for admin user (no reparent 
       </svg>
       <div
         class="model_node  "
-        style="top: 300px; left: 300px;"
+        style="top: 300px; left: 300px; --model-width: 285px;"
       >
         labor
       </div>
       <div
         class="model_node  "
-        style="top: 450px; left: 300px;"
+        style="top: 450px; left: 300px; --model-width: 285px;"
       >
         monster
       </div>
       <div
         class="model_node selected "
-        style="top: 150px; left: 300px;"
+        style="top: 150px; left: 300px; --model-width: 285px;"
       >
         project
       </div>
@@ -2129,19 +2132,19 @@ exports[`ModelMap renders without model action buttons for editor user 1`] = `
       </svg>
       <div
         class="model_node  "
-        style="top: 300px; left: 300px;"
+        style="top: 300px; left: 300px; --model-width: 285px;"
       >
         labor
       </div>
       <div
         class="model_node  "
-        style="top: 450px; left: 300px;"
+        style="top: 450px; left: 300px; --model-width: 285px;"
       >
         monster
       </div>
       <div
         class="model_node selected "
-        style="top: 150px; left: 300px;"
+        style="top: 150px; left: 300px; --model-width: 285px;"
       >
         project
       </div>

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -40,7 +40,25 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
               <div
                 class="cm-line"
               >
-                user_columns: ["monster.name","prize.name","labor.contributions"]
+                user_columns: [
+                <span
+                  class="ͼe"
+                >
+                  "monster.name"
+                </span>
+                ,
+                <span
+                  class="ͼe"
+                >
+                  "prize.name"
+                </span>
+                ,
+                <span
+                  class="ͼe"
+                >
+                  "labor.contributions"
+                </span>
+                ]
               </div>
             </div>
           </div>

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -40,25 +40,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
               <div
                 class="cm-line"
               >
-                user_columns: [
-                <span
-                  class="ͼe"
-                >
-                  "monster.name"
-                </span>
-                ,
-                <span
-                  class="ͼe"
-                >
-                  "prize.name"
-                </span>
-                ,
-                <span
-                  class="ͼe"
-                >
-                  "labor.contributions"
-                </span>
-                ]
+                user_columns: ["monster.name","prize.name","labor.contributions"]
               </div>
             </div>
           </div>


### PR DESCRIPTION
Sometimes if there are too many boxes in a row on the map they overlap. This uses a max-width to make sure that doesn't happen.