### PR TITLE
Fix materialize to pull all records

### DIFF
--- a/etna/Gemfile.lock
+++ b/etna/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    etna (0.1.50)
+    etna (0.1.51)
       concurrent-ruby
       curb
       jwt

--- a/etna/etna.gemspec
+++ b/etna/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.50'
+  spec.version           = '0.1.51'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/etna/lib/commands.rb
+++ b/etna/lib/commands.rb
@@ -250,10 +250,10 @@ class EtnaApp
       string_flags << "--log-file"
       string_flags << "--log-level"
       string_flags << "--concurrency"
-      string_flags << "--page_size"
+      string_flags << "--page-size"
+      boolean_flags << "--list-only"
 
-
-      def execute(project_name:, log_file:'/dev/stdout', log_level: ::Logger::INFO, concurrency: 1, page_size: 20)
+      def execute(project_name:, log_file:'/dev/stdout', log_level: ::Logger::INFO, concurrency: 1, page_size: 20, list_only: false)
         logger = Etna::Logger.new(log_file, 0, 1048576)
 
         logger.level = log_level
@@ -267,6 +267,7 @@ class EtnaApp
             logger: logger,
             project_name: project_name,
             model_name: 'project', filesystem: filesystem,
+            list_only: list_only,
             page_size: page_size.to_i,
             concurrency: concurrency.to_i)
 


### PR DESCRIPTION
Previously the model walker would bail out on retrieving if it had seen a { from, model_name } pair before while walking the data tree, where "from" was the name of a linking model (e.g., you saw the "patient" model from the "project" model). I'm not sure why this was written this way, but it seems to have skipped a number of records as a result. This PR repairs the walker so that it only skips on actually previously-seen record names that it is asked to retrieve. This more accurately consumes the tree resulting in a complete materialize.