### PR TITLE
Metis_client find

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -386,6 +386,13 @@ class MetisClient < Client
     return json_body(response)[:buckets]
   end
 
+  def find(project_name, bucket_name, params)
+    response = json_post("/#{project_name}/find/#{bucket_name}", params: params)
+    raise MetisClient::Error, "Find failed" unless response.code == "200"
+
+    return json_body(response)
+  end
+
   def list_folder(project_name,folder_path)
     response = get_request( "/#{project_name}/list/#{encode_path(folder_path || '')}" )
 
@@ -826,6 +833,59 @@ EOT
         return [ rows, cols, col_widths ]
       end
       return [ entries.size, 1, entries.map{0} ]
+    end
+  end
+
+  class Find < Command
+    usage "find [<attribute op value>+]"
+
+    def parse(args)
+      parse_opts(args) do |opts|
+        opts.on("-t", "--type <file|folder>", "Restricts find by type") do |type|
+          options[:type] = type
+        end
+      end
+    end
+
+    PARAMS={
+      created_at: [ '<', '>', '>=', '<=', '=' ],
+      updated_at: [ '<', '>', '>=', '<=', '=' ],
+      name: [ '=~', '=' ]
+    }
+
+    PARAM_REGEX=Regexp.new(
+      "(?:#{
+        PARAMS.map do |name, ops|
+          %Q{(#{name})(#{ops.join('|')})(\\S+)}
+        end.join('|')
+      })"
+    )
+
+    def run(*args)
+      raise ShellError, 'No bucket is selected' if !@shell.bucket_name
+
+      params = args.map do |arg|
+        name, op, value = PARAM_REGEX.match(arg).captures.compact
+
+        raise ShellError, "Poorly formed find parameter '#{arg}'" unless name
+
+        {
+          attribute: name,
+          predicate: op,
+          value: value,
+          type: options[:type]
+        }.compact
+      end
+
+      results = @shell.client.find(@shell.project_name, @shell.bucket_name, params)
+
+      found = (results[:files] + results[:folders]).sort_by {|f| f[:file_path] || f[:folder_path] }
+
+      if found.empty?
+        puts "No results."
+      else
+        puts found.map{|f| f[:file_path] || (f[:folder_path] + "/") }.join("\n")
+      end
     end
   end
 
@@ -1297,6 +1357,8 @@ EOT
         ::File.basename(file) == options[:file]
       end
 
+      files = files.select {|f| ::File.exists?(f) }
+
       puts "Found #{files.count} files in #{folders.count} folders, total size #{byte_format(files.map{|f| ::File.size(f)}.sum)}."
 
       md5files.each do |md5file|
@@ -1708,6 +1770,12 @@ EOT
     @client ||= MetisClient.new(@host, @token, logger)
   end
 
+  def bucket_name
+    return nil unless @cwd
+
+    @cwd.split('/').first
+  end
+
   def relative_path(file_path=nil)
     path = case file_path
     when '.', nil then @cwd
@@ -1896,7 +1964,6 @@ def start
 
   MetisConfig.instance.config(config)
   MetisShell.new(ARGV[0], *ARGV[1..-1]).run
-  puts
 end
 
 start unless test_env?

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -864,6 +864,8 @@ EOT
     def run(*args)
       raise ShellError, 'No bucket is selected' if !@shell.bucket_name
 
+      raise ShellError, 'Invalid type specified' unless [ nil, 'file', 'folder' ].include?(options[:type])
+
       params = args.map do |arg|
         name, op, value = PARAM_REGEX.match(arg).captures.compact
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1335,6 +1335,10 @@ EOT
       end
     end
 
+    def is_valid_checksum?(checksum)
+      checksum =~ /^[a-f0-9]{32}$/i
+    end
+
     def md5_cache
       @md5_cache ||= {}
     end
@@ -1345,7 +1349,7 @@ EOT
       File.readlines(md5file, encoding: "UTF-8").each do |line|
         checksum, file_name = line.chomp.split(/\s+/, 2)
         full_path = clean_path(::File.join( md5dir, file_name ))
-        next unless ::File.exists?(full_path)
+        next unless ::File.exists?(full_path) && is_valid_checksum?(checksum)
 
         md5_cache[full_path] = checksum
       end
@@ -1376,7 +1380,14 @@ EOT
 
           next if ::File.basename(file) == options[:file] || md5_cache[file]
 
-          md5_cache[file] = %x{ md5sum #{Shellwords.escape(file)} }.split(' ')[0]
+          checksum = %x{ md5sum #{Shellwords.escape(file)} }.split(' ')[0]
+
+          unless is_valid_checksum?(checksum)
+            puts "Could not compute md5sum for #{file}"
+            next
+          end
+
+          md5_cache[file] = checksum
         end
         puts "Computing md5s - #{progress_bar(1)} - #{files.length} of #{files.length}      "
       rescue Exception => e

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -45,7 +45,7 @@ end
 
 def byte_format(bytes)
   if bytes > 1024*1024*1024*1024
-    bytes = "#{(bytes / 1024/1024/1024).round(2)}T"
+    bytes = "#{(bytes / 1024/1024/1024/1024).round(2)}T"
   elsif bytes > 1024*1024*1024
     bytes = "#{(bytes / 1024/1024/1024).round(2)}G"
   elsif bytes > 1024*1024

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -388,6 +388,7 @@ class MetisClient < Client
 
   def find(project_name, bucket_name, params)
     response = json_post("/#{project_name}/find/#{bucket_name}", params: params)
+
     raise MetisClient::Error, "Find failed" unless response.code == "200"
 
     return json_body(response)
@@ -862,12 +863,10 @@ EOT
     )
 
     def run(*args)
-      raise ShellError, 'No bucket is selected' if !@shell.bucket_name
-
       raise ShellError, 'Invalid type specified' unless [ nil, 'file', 'folder' ].include?(options[:type])
 
       params = args.map do |arg|
-        name, op, value = PARAM_REGEX.match(arg).captures.compact
+        name, op, value = PARAM_REGEX.match(arg)&.captures&.compact
 
         raise ShellError, "Poorly formed find parameter '#{arg}'" unless name
 
@@ -879,15 +878,37 @@ EOT
         }.compact
       end
 
-      results = @shell.client.find(@shell.project_name, @shell.bucket_name, params)
-
-      found = (results[:files] + results[:folders]).sort_by {|f| f[:file_path] || f[:folder_path] }
-
-      if found.empty?
-        puts "No results."
+      if !@shell.bucket_name
+        buckets = @shell.client.list_buckets(@shell.project_name)
+        found = false
+        buckets.each do |bucket|
+          results = find_in_bucket(bucket[:bucket_name], params)
+          unless results.empty?
+            found = true
+            puts "#{bucket[:bucket_name]}:"
+            puts results.join("\n")
+          end
+        end
+        unless found
+          puts "No results."
+        end
       else
-        puts found.map{|f| f[:file_path] || (f[:folder_path] + "/") }.join("\n")
+        results = find_in_bucket(@shell.bucket_name, params)
+        if results.empty?
+          puts "No results."
+        else
+          puts "#{@shell.bucket_name}:"
+          puts results.join("\n")
+        end
       end
+    end
+
+    def find_in_bucket(bucket_name, params)
+      results = @shell.client.find(@shell.project_name, bucket_name, params)
+
+      return (results[:files] + results[:folders]).map do |f|
+        f[:file_path] || (f[:folder_path] + "/")
+      end.sort
     end
   end
 

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1523,6 +1523,7 @@ EOT
       files = files.select {|f| ::File.exists?(f) && !is_checksum_file?(f) }
 
       archived_files_count = 0
+      archived_files = []
       unarchived_files = []
       unarchived_size = 0
 
@@ -1536,6 +1537,7 @@ EOT
         file_md5s.each do |file, md5|
           next if is_checksum_file?(file)
           if found.include?(md5)
+            archived_files << file
             archived_files_count += 1
           else
             unarchived_files << file

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1549,6 +1549,8 @@ EOT
       if options[:list] && !unarchived_files.empty?
         puts "\nMissing files:"
         puts unarchived_files
+        puts "Archived files:"
+        puts archived_files
       end
     end
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1368,16 +1368,23 @@ EOT
       end
 
       # compute md5sums
-      files.each.with_index do |file,i|
-        file = clean_path(file)
+      begin
+        files.each.with_index do |file,i|
+          file = clean_path(file)
 
-        print "Computing md5s - #{progress_bar(i.to_f / files.length)} - #{i} of #{files.length}      \r"
+          print "Computing md5s - #{progress_bar(i.to_f / files.length)} - #{i} of #{files.length}      \r"
 
-        next if ::File.basename(file) == options[:file] || md5_cache[file]
+          next if ::File.basename(file) == options[:file] || md5_cache[file]
 
-        md5_cache[file] = %x{ md5sum #{Shellwords.escape(file)} }.split(' ')[0]
+          md5_cache[file] = %x{ md5sum #{Shellwords.escape(file)} }.split(' ')[0]
+        end
+        puts "Computing md5s - #{progress_bar(1)} - #{files.length} of #{files.length}      "
+      rescue Exception => e
+        puts
+        puts e.message
+        puts e.backtrace
+        puts "Aborting checksum computation, writing partial #{options[:file]}"
       end
-      puts "Computing md5s - #{progress_bar(1)} - #{files.length} of #{files.length}      "
 
       output =  md5_cache.map do |file_name, checksum|
         "#{checksum}  #{Pathname.new(file_name).relative_path_from(Pathname.new(local_directory))}"


### PR DESCRIPTION
This adds a "find" command to metis_client, which lets you use the metis find API to search within a bucket using SQL globs (i.e., using `%` as a wildcard) amongst other things (you can also filter on updated_at and created_at). A pan-bucket version might be nice, but this should go a long way to making it easier to locate data on Metis.

Also fixes a bunch of issues with validate.