### PR TITLE
WIP: Allow make build to work on OSX

### DIFF
--- a/airflow/Makefile
+++ b/airflow/Makefile
@@ -3,6 +3,8 @@ release::
 
 include ../make-base/stubs.mk
 include ../make-base/docker-compose.mk
+include ../make-base/utils.mk
+
 app_service_name:=airflow_ui
 
 baseTag:=$(shell basename "$$(pwd)")
@@ -15,5 +17,5 @@ run-image-test::
 black:
 	docker run -u 0:0 -v $(pwd)/opt/providers:/opt/airflow/providers --rm $(baseTag) bash -c '$$@' -- black /opt/airflow/providers/etna
 
-pdoc: $(shell readlink -m $(shell dirname $(firstword $(MAKEFILE_LIST))))/image-release.marker
+pdoc: $(call readlink_m $(shell dirname $(firstword $(MAKEFILE_LIST))))/image-release.marker
 	docker run -u 0:0 -v $(pwd)/opt/providers:/opt/airflow/providers --rm $(baseTag) bash -c '$$@' -- pdoc -o /opt/airflow/providers/etna/docs etna

--- a/docker/build_support/build_image
+++ b/docker/build_support/build_image
@@ -32,12 +32,22 @@ if [[ "$1" == "-h" ]]; then
   exit 1
 fi
 
+OS=$(uname -s)
+
+# Set the appropriate readlink command based on the operating system
+# Note: use this only for the -m flag
+if [[ "$OS" == "Darwin" ]]; then
+  READLINK_M="greadlink -m"
+else
+  READLINK_M="readlink -m"
+fi
+
 #- Builds the given Dockerfile into an image,
 #-   first by constructing a build directory that links together the shortest
 #-   common parent directories of given dependencies, then running the given Dockerfile
 #-   in that context.  It also injects metadata related to the release sha at the time
 #-   the image is built.
-Dockerfile=$(readlink -m $1)
+Dockerfile=$($READLINK_M $1)
 
 baseTag=$(basename "$(dirname "$(realpath $Dockerfile)")")
 monoetnaSha=$(git rev-parse HEAD)
@@ -55,7 +65,7 @@ if [[ -z "$Dockerfile" ]]; then
 fi
 
 buildDir="$(mktemp -d)"
-sourceDockerDir="$(readlink -m $(dirname $Dockerfile))"
+sourceDockerDir="$($READLINK_M $(dirname $Dockerfile))"
 rsync -a $sourceDockerDir/ $buildDir/
 
 # Docker can 'leak' intermediate build images from different runs, unfortunately, even with --rm and --force-rm.

--- a/docker/build_support/find-updated-sources
+++ b/docker/build_support/find-updated-sources
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 set -e
 
+echo 'find-updated-sources'
+
 prog=$0
 error() {
    echo "Whoops!  Looks like $0:$2 failed."
@@ -26,7 +28,15 @@ YELLOW='\033[1;33m'
 CYAN='\033[1;36m'
 NC='\033[0m'
 
-dir=$(readlink -m $1)
+# Set the appropriate readlink command based on the operating system
+# Note: use this only for the -m flag
+if [ "$(uname -s)" = "Darwin" ]; then
+  READLINK_M="greadlink -m"
+else
+  READLINK_M="readlink -m"
+fi
+
+dir=$($READLINK_M $1)
 touchTarget=$2
 find=find
 if type -p gfind; then

--- a/docker/build_support/find-updated-sources
+++ b/docker/build_support/find-updated-sources
@@ -1,8 +1,6 @@
 #! /usr/bin/env bash
 set -e
 
-echo 'find-updated-sources'
-
 prog=$0
 error() {
    echo "Whoops!  Looks like $0:$2 failed."

--- a/make-base/utils.mk
+++ b/make-base/utils.mk
@@ -1,9 +1,13 @@
 .PHONY: always
 
+map = $(foreach a,$(2),$(call $(1),$(a)))
+readlink_m = $(shell $(if $(findstring Darwin,$(shell uname -s)),greadlink,readlink) -m $(1))
+dirname = $(shell dirname $(1))
+
 # Function that find project directories by a file that must exist inside of it
 define find_projects_containing
 $(sort \
-	$(call map,readlink, \
+	$(call map,readlink_m, \
 		$(filter-out $(shell dirname $(firstword $(wildcard $(addsuffix /monoetna,.. ../.. ../../..))))/%, \
 			$(wildcard \
 				$(addsuffix /*/$(1),. .. ../.. ../../..) \
@@ -23,9 +27,6 @@ endef
 define find_project_file
 $(addsuffix /$(2),$(call find_project_containing,$(1),$(2)))
 endef
-map = $(foreach a,$(2),$(call $(1),$(a)))
-readlink = $(shell $(if $(findstring Darwin,$(shell uname -s)),greadlink,readlink) -m $(1))
-dirname = $(shell dirname $(1))
 
 define find_updated_sources
 $(shell $(call find_project_file,build_support,find-updated-sources) $(1))
@@ -90,20 +91,12 @@ $(1)/image-release.marker: $(1)/image-test.marker
 
 endef
 
-
-# This must be defined outside any define blocks
-ifeq ($(shell uname -s),Darwin)
-    readlink_m = greadlink -m
-else
-    readlink_m = readlink -m
-endif
-
 define image_target_here
-$(call image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
-$(call test_image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
-$(call release_image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
-release-build:: $(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST))))/image.marker
-release-test:: $(shell dirname $$( $(readlink_m)  $(firstword $(MAKEFILE_LIST))))/image-test.marker
-release:: $(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST))))/image-release.marker
+$(call image_target1,$(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST)))))
+$(call test_image_target1,$(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST)))))
+$(call release_image_target1,$(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST)))))
+release-build:: $(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST))))/image.marker
+release-test:: $(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST))))/image-test.marker
+release:: $(shell dirname $(call readlink_m, $(firstword $(MAKEFILE_LIST))))/image-release.marker
 run-image-test::
 endef

--- a/make-base/utils.mk
+++ b/make-base/utils.mk
@@ -23,9 +23,8 @@ endef
 define find_project_file
 $(addsuffix /$(2),$(call find_project_containing,$(1),$(2)))
 endef
-
 map = $(foreach a,$(2),$(call $(1),$(a)))
-readlink = $(shell readlink -m $(1))
+readlink = $(shell $(if $(findstring Darwin,$(shell uname -s)),greadlink,readlink) -m $(1))
 dirname = $(shell dirname $(1))
 
 define find_updated_sources
@@ -91,12 +90,20 @@ $(1)/image-release.marker: $(1)/image-test.marker
 
 endef
 
+
+# This must be defined outside any define blocks
+ifeq ($(shell uname -s),Darwin)
+    readlink_m = greadlink -m
+else
+    readlink_m = readlink -m
+endif
+
 define image_target_here
-$(call image_target1,$(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST)))))
-$(call test_image_target1,$(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST)))))
-$(call release_image_target1,$(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST)))))
-release-build:: $(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST))))/image.marker
-release-test:: $(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST))))/image-test.marker
-release:: $(shell dirname $$(readlink -m $(firstword $(MAKEFILE_LIST))))/image-release.marker
+$(call image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
+$(call test_image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
+$(call release_image_target1,$(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST)))))
+release-build:: $(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST))))/image.marker
+release-test:: $(shell dirname $$( $(readlink_m)  $(firstword $(MAKEFILE_LIST))))/image-test.marker
+release:: $(shell dirname $$( $(readlink_m) $(firstword $(MAKEFILE_LIST))))/image-release.marker
 run-image-test::
 endef


### PR DESCRIPTION
## readlink

### Problem

On the linux, the GNU utility `readlink` supports a `-m` parameter . The `readlink` command on mac does not support this parameter.

You can install `coreutils` on mac in order to acquire this feature, however the utility is named  `greadlink` (note the `g` for GNU)  in order to avoid naming conflicts with the native `readlink`. The makefiles have historically been supported for developement on linux, therefore many `make` commands will fail if they try and use the native `readlink`. 

### Solution

Add conditionals to use `greadlink` when the OS is mac in makefiles and other supporting build scripts. 

## Incompatible architectures

### Problem 

Trying to build docker images on Mac when the intended target platform is `linux/amd64` causes many docker issues

For more information: https://stackoverflow.com/questions/65612411/forcing-docker-to-use-linux-amd64-platform-by-default-on-macos

### Solutions 

Whatever shell you use to run `make -C magma up`, set the following environment variables:

**bash**  

`export DOCKER_DEFAULT_PLATFORM=linux/amd64`

**fish** 🐟 

`set -xU DOCKER_DEFAULT_PLATFORM linux/amd64`

Note: is is important that you set this env var globally (notice the `U`) !

#### Other (potential) issues 

You may also need to set the following env vars:

**bash** 

`export DOCKER_BUILDKIT=0`
`export COMPOSE_DOCKER_CLI_BUILD=0`

**fish** 🐟 

`set -xU DOCKER_BUILDKIT false`
`set -xU COMPOSE_DOCKER_CLI_BUILD false`

https://github.com/docker/compose/issues/8449
https://stackoverflow.com/questions/66662820/m1-docker-preview-and-keycloak-images-platform-linux-amd64-does-not-match-th


### Other approaches

- using buildx
- adding this key to compose files: platform: linux/amd64

### specs and versions

Docker can be quite finicky when it comes to OS specs and docker settings, so this solution was tested on:

- Apple M2 Pro
- Ventura 13.2

And the `docker version` :

```
Client:
 Cloud integration: v1.0.31
 Version:           23.0.5
 API version:       1.42
 Go version:        go1.19.8
 Git commit:        bc4487a
 Built:             Wed Apr 26 16:12:52 2023
 OS/Arch:           darwin/arm64
 Context:           default

Server: Docker Desktop 4.19.0 (106363)
 Engine:
  Version:          23.0.5
  API version:      1.42 (minimum version 1.12)
  Go version:       go1.19.8
  Git commit:       94d3ad6
  Built:            Wed Apr 26 16:17:14 2023
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.6.20
  GitCommit:        2806fc1057397dbaeefbea0e4e17bddfbd388f38
 runc:
  Version:          1.1.5
  GitCommit:        v1.1.5-0-gf19387a
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
  ```
  
  I've also attached some docker-desktop screenshots of various settings:

<img width="737" alt="Screenshot 2023-05-10 at 3 02 01 PM" src="https://github.com/mountetna/monoetna/assets/6462800/e14bd782-2c0d-42da-83ea-f258a770d057">

<img width="752" alt="Screenshot 2023-05-10 at 3 02 44 PM" src="https://github.com/mountetna/monoetna/assets/6462800/58fc7d0d-4e45-420d-9867-05abefddb621">

<img width="821" alt="Screenshot 2023-05-10 at 3 02 12 PM" src="https://github.com/mountetna/monoetna/assets/6462800/b5436530-930b-4074-98ed-64761ddd21b7">

<img width="760" alt="Screenshot 2023-05-10 at 3 03 05 PM" src="https://github.com/mountetna/monoetna/assets/6462800/248240fc-2d85-46ee-bde9-2a2f14edfacf">

