### PR TITLE
fix globbing

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -44,8 +44,8 @@ class MetisLoaderConfig(EtlConfigResponse):
             match = re.escape(match)
             # **/ matches anything including nothing
             match = re.sub(STAR_MAGIC*2+'/', '(?:.*/|)', match)
-            # * matches any non-zero non-slash
-            match = re.sub(STAR_MAGIC, '[^/]+', match)
+            # * matches any non-slash including nothing
+            match = re.sub(STAR_MAGIC, '[^/]*', match)
             # {a,b,c,d} matches a group
             match = re.sub(f"{BRACE1_MAGIC}((?:[^,]+,)+,[^,]+){BRACE2_MAGIC}", lambda m : f"({m[1].replace(',','|')})", match)
             match = re.compile(match)

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -242,7 +242,7 @@ Models: {', '.join(i['response'].models.keys())}
 Committed to Magma: {i['commit']}
 '''
         for model_name, model in i['response'].models.items():
-            summary += f"{model_name} records updated: {len(model.documents)}\n"
+            summary += f"{model_name} records updated: {', '.join(model.documents.keys())}\n"
 
         summary += "==============================="
 

--- a/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
@@ -51,7 +51,7 @@ class TestMetisLinker:
                             {
                                 "type": "file",
                                 "folder_path": "victims",
-                                "file_match": "*.deceased.png",
+                                "file_match": "*.deceased*.png",
                                 "attribute_name": "photo_deceased"
                             }
                         ]


### PR DESCRIPTION
The glob implementation in the MetisLinker improperly matches one or more characters, while the glob in the find api uses SQL %, which may match zero-length characters. This produces a discrepancy in matching, here resolved.