### PR TITLE
Minor fixed for the Makefile-mac build path

### DIFF
--- a/Makefile-mac
+++ b/Makefile-mac
@@ -43,7 +43,12 @@ build-dev-archimedes-images:
 	 echo "Building archimedes images..."
 	 cd docker/archimedes-base && docker build . -t archimedes-base
 	 cd archimedes-r-base && docker build . -t archimedes-r-base # takes a really long time!
-	 cd docker/archimedes-node-base && docker . build -t archimedes-node-base
+	 cd docker/archimedes-node-base && docker build . -t archimedes-node-base
+
+build-dev-deployer-images:
+	# Deployer
+	echo "Building deployer images..."
+	cd docker/deployer-base && docker build . -t deployer-base
 
 ### Project level targets ###
 


### PR DESCRIPTION
- Fixes a typo where `build .` was incorrectly ordered `. build`
- Also adds a target for the deployer-base image.  Likely, this is not necessary for using make targets within this file, but it was useful for me when I was mixing the build calls from this file with then using `make up` from the "base" Makefile.