### PR TITLE
Fix polyphemus revision history

### DIFF
--- a/polyphemus/lib/client/jsx/etl/configure-pane.tsx
+++ b/polyphemus/lib/client/jsx/etl/configure-pane.tsx
@@ -149,6 +149,7 @@ const ConfigurePane = ({
                 json_get(`/api/etl/${project_name}/revisions/${config_id}`)
               }
               open={showRevisions}
+              dateField='created_at'
               revisionDoc={(revision) =>
                 JSON.stringify(revision.config, null, 2)
               }

--- a/polyphemus/lib/models/etl_config.rb
+++ b/polyphemus/lib/models/etl_config.rb
@@ -128,7 +128,7 @@ class Polyphemus
     end
 
     def to_revision
-      as_json.slice(:config, :version_number, :comment)
+      as_json.slice(:config, :updated_at, :version_number, :comment)
     end
 
     def valid_config?(config)

--- a/polyphemus/lib/models/etl_config.rb
+++ b/polyphemus/lib/models/etl_config.rb
@@ -128,7 +128,7 @@ class Polyphemus
     end
 
     def to_revision
-      as_json.slice(:config, :updated_at, :version_number, :comment)
+      as_json.slice(:config, :created_at, :version_number, :comment)
     end
 
     def valid_config?(config)


### PR DESCRIPTION
Revisions in polyphemus UI don't work currently because the UI chokes on lack of a date to display. Since "updated_at" was dropped from these histories (in favor of `version_number` and retaining `created_at`) the revisions had no date associated with them. Changed to use `created_at` instead.