### PR TITLE
clean Makefile-mac clutter mistakenly added in last PR

### DIFF
--- a/Makefile-mac
+++ b/Makefile-mac
@@ -45,11 +45,6 @@ build-dev-archimedes-images:
 	 cd archimedes-r-base && docker build . -t archimedes-r-base # takes a really long time!
 	 cd docker/archimedes-node-base && docker build . -t archimedes-node-base
 
-build-dev-deployer-images:
-	# Deployer
-	echo "Building deployer images..."
-	cd docker/deployer-base && docker build . -t deployer-base
-
 ### Project level targets ###
 
 # Note: the project level docker-compose files use relative paths so it is important to execute commands from within

--- a/Makefile-mac
+++ b/Makefile-mac
@@ -18,7 +18,6 @@ build-dev-etna-images:
 	cd bash_mocker &&  docker build . -t bash_mocker
 	cd development-certs && docker build . -t development-certs
 	cd docker/development-psql && docker build . -t development-psql
-	# Is this needed? cd docker/deployer_base && docker build . -t deployer-base
 
 	# Apache
 	echo "Building apache images..."


### PR DESCRIPTION
Removes the unnecessary 'build-dev-deployer-images' build target that I'd added in my last PR

Also removes the comment about whether deployer building is needed, though we could revert.