### PR TITLE
fix for missing models in Metis Linker

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -183,7 +183,7 @@ def MetisLinker():
         buckets = [
             config.bucket_key
             for config in configs
-            for model, model_config in config.config["models"].items()
+            for model, model_config in config.config.get("models",{}).items()
             for script in model_config["scripts"]
         ]
                 

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -140,8 +140,8 @@ class MetisLoaderConfig(EtlConfigResponse):
     schedule_interval=timedelta(minutes=60),
     start_date=datetime(2023, 4, 12),
     default_args={
-        'depends_on_past': True,
-        'wait_for_downstream': True
+        'depends_on_past': False,
+        'wait_for_downstream': False
     }
 )
 def MetisLinker():


### PR DESCRIPTION
We noticed that if someone tries to run an empty config the metis linker barfs, a simple fix to change this.

Also changes `wait_for_downstream` and `depends_on_past` to be False, so failed tasks will not block subsequent runs (I think it will still wait for completion, i.e. it won't run two jobs at once). This might result in missed failures in the logs but seems better than having to scoop out failed tasks all the time. Individual config errors should still triage to the polyphemus logs.