### PR TITLE
Fix archimedes-r-base build

### DIFF
--- a/archimedes-r-base/Dockerfile
+++ b/archimedes-r-base/Dockerfile
@@ -22,10 +22,15 @@ RUN apt-get update \
 
 WORKDIR /app
 # Add jetpack package manager, enable command line controls, and instll packages based on past package uses.
+RUN R -e 'install.packages("remotes")'
+RUN R -e 'remotes::install_version("renv", version = "0.17.3", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("cli", version = "3.6.1", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("R6", version = "2.5.1", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("rprojroot", version = "2.0.3", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("desc", version = "1.4.2", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("docopt", version = "0.7.1", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("jetpack", version = "0.5.5", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
 COPY DESCRIPTION .
 COPY renv.lock .
 COPY .Rprofile .
-RUN R -e 'install.packages("remotes")'
-RUN R -e 'remotes::install_version("renv", version = "0.17.3", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
-RUN R -e 'remotes::install_version("jetpack", version = "0.5.5", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
 RUN R -e 'jetpack::cli(); jetpack::install()'

--- a/archimedes-r-base/Dockerfile
+++ b/archimedes-r-base/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update \
 
 WORKDIR /app
 # Add jetpack package manager, enable command line controls, and instll packages based on past package uses.
-RUN R -e 'install.packages(c("renv", "jetpack")); jetpack::cli()'
 COPY DESCRIPTION .
 COPY renv.lock .
 COPY .Rprofile .
-RUN jetpack install
+RUN R -e 'install.packages("remotes")'
+RUN R -e 'remotes::install_version("renv", version = "0.17.3", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'remotes::install_version("jetpack", version = "0.5.5", repos = "http://cran.us.r-project.org", upgrade = FALSE)'
+RUN R -e 'jetpack::cli(); jetpack::install()'


### PR DESCRIPTION
The cause of recent archimedes-r-base build errors: seems to stem from 'renv' getting an update on 7/7.  Tracks with recent CI and dev builds that pull from cache until after the renv & jetpack install line of the Dockerfile being fine, whereas failures happen when these packages are not pulled from cache.

The Fix: This PR adds installation of 'remotes' to be able to use its 'install_version' tool, then uses that to lock down versions of renv, all of jetpack's dependencies, and finally jetpack itself, to currently used versions / those expected in the renv.lock.  (Would be nice if R had version control built in better on its own, but :shrug:)

ToDo, future PR: Could be improved to manage versions by parsing the .lock file, where versions of everything except jetpack are tracked, possibly with [yq](https://mikefarah.gitbook.io/yq/).  Just doesn't seem like a quick enough / important enough lift compared to the goal of unblocking our deploy process ASAP!