### PR TITLE
Use hold_file to healthcheck

### DIFF
--- a/magma/bin/healthcheck
+++ b/magma/bin/healthcheck
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+HOLD_FILE=$(grep hold_file config.yml | awk '{ print $2 }')
+
+if [ -f "$HOLD_FILE" ];
+then
+    hold_time=$(cat $HOLD_FILE)
+    curr_time=$(date -u --iso-8601=sec)
+
+    if [[ $curr_time < $hold_time ]];
+    then
+    	exit 0
+    fi
+fi
+
+curl -f -X OPTIONS http://localhost:3000 || exit 1

--- a/magma/config.yml.template
+++ b/magma/config.yml.template
@@ -19,6 +19,8 @@
     :download_expiration: 1440
     :upload_expiration: 720
   :server_pidfile: tmp/pids/puma.pid
+# :hold_file: tmp/puma.hold
+# :hold_interval: 10
   :token_algo: RS256
   :token_name: JANUS_DEV_TOKEN
   :rsa_public: |

--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -57,7 +57,7 @@ class Magma
     return unless config(:hold_file)
 
     ::File.open(config(:hold_file),"w") do |f|
-      f.puts (Time.now + config(:hold_interval) || 10).utc.to_datetime.iso8601
+      f.puts (Time.now + (config(:hold_interval) || 10)).utc.to_datetime.iso8601
     end
   end
 

--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -45,6 +45,28 @@ class Magma
     @db.pool.connection_validation_timeout = -1
   end
 
+  def restart_server
+    return if test?
+
+    write_hold_file
+
+    Process.kill("USR2", server_pid)
+  end
+
+  def write_hold_file
+    return unless config(:hold_file)
+
+    ::File.open(config(:hold_file),"w") do |f|
+      f.puts (Time.now + config(:hold_interval) || 10).utc.to_datetime.iso8601
+    end
+  end
+
+  def remove_hold_file
+    return unless config(:hold_file)
+
+    ::File.unlink(config(:hold_file))
+  end
+
   def load_models(validate = true)
     setup_db
     setup_sequel
@@ -53,6 +75,8 @@ class Magma
     load_db_projects
 
     validate_models if validate
+
+    remove_hold_file
   end
 
   def load_db_projects

--- a/magma/lib/magma/actions/model_update_actions.rb
+++ b/magma/lib/magma/actions/model_update_actions.rb
@@ -135,8 +135,7 @@ class Magma
     end
 
     def restart_server
-      return if Magma.instance.test?
-      Process.kill("USR2", Magma.instance.server_pid)
+      Magma.instance.restart_server
     end
 
     def validate_project


### PR DESCRIPTION
This PR attempts to solve issues with Magma becoming unstable during "create project" workflows initiated from Janus.

The issue breaks down like this:
1. When creating a new project via the Janus UI, you may select a "template project". Janus's `add_project` endpoint will start a thread to copy the template project's models and attributes into the new project. This runs the `ModelSynchronizationWorkflow`, which is somewhat spammy towards magma's `update_model` API; it does not attempt to batch update actions, so copying a large number of models and attributes results in many individual requests to the `update_model` API in quick succession.
2. When `update_model` is called, after digesting its actions it calls `ModelUpdateActions.restart_server`, which ultimately sends the signal `USR2` to the server (puma) pid. Puma, on responding to USR2, will restart its workers (https://github.com/puma/puma/blob/master/docs/signals.md). Importantly, this will kill any outstanding requests. 
3. Meanwhile, the swarm runs a healthcheck every 10s, which consists of running `curl -X OPTIONS http://localhost:3000` inside the container. Since Puma does not actually kill the process, this curl can be picked up while puma is restarting, and will wait for Puma to startup to receive its OPTIONS response.
4. While the curl is waiting, if Puma receives another USR2 signal, it will restart again. At this point it will drop the curl instead of answering it, resulting in the healthcheck failing. Docker swarm immediately kills the container and restarts it, which takes some time.

We believe that this is happening because, while the server is restarting, it will continue to queue requests - from the healthcheck curl, but also from the model synchronization workflow on janus, which is still trying to copy model attributes.  When Puma restarts, it answers the restart request first, resulting in a failed curl.

This solution attempts to circumvent the issue by preventing the healthcheck from sending a curl request while Magma is restarting. To do this, the `restart_server` method drops a hold file containing a timestamp with the expiration of the hold. The healthcheck, if it finds this hold file to be not-expired, will exit with a 0 status without invoking curl. Otherwise, it will curl as usual.

It is still possible that the health check could occur simultaneously with an update_model action, causing it to be dropped, but there is a narrow window where this can occur - the health check must have started, but not finished, before an update_model action completed. This is not a very likely event; the main problem is the two events are forced into concurrency by the restart latency. Therefore, we hope that this can mitigate the bulk of the issue.

Separately, we should try to batch the ModelSynchronizationWorkflow better, so it does not create as many magma restarts. Even with this fix, puma will restart dozens (hundreds?) of times to copy a template.