### PR TITLE
Split vulcan ruby tests into separate workflows

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -47,3 +47,22 @@ jobs:
           IMAGES_POSTFIX: :master
         run: |
           make -C ${{ matrix.test-app }} release
+  test_vulcan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: docker login
+        env:
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
+      - name: Run vulcan e2e test suite
+        id: app_first_test_run
+        env:
+          # Runs tests and builds images, but does not push (PUSH_IMAGES not set to 1)
+          IMAGES_PREFIX: etnaagent/
+          IS_CI: 1
+          CI_SECRET: ${{ secrets.CI_SECRET }}
+          IMAGES_POSTFIX: :master
+          RUN_E2E: 1
+        run: |
+          make -C vulcan release

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -65,4 +65,9 @@ jobs:
           IMAGES_POSTFIX: :master
           RUN_E2E: 1
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           make -C vulcan release

--- a/make-base/etna-ruby.mk
+++ b/make-base/etna-ruby.mk
@@ -23,7 +23,7 @@ run-image-test::
 		docker-compose up -d $(app_db_name) || true; \
 		docker run --rm $(EXTRA_DOCKER_ARGS) -e $(app_name_capitalized)_ENV=test \
 				-e APP_NAME=$(app_name) -e RELEASE_TEST=1 -e CI_SECRET=$${CI_SECRET} \
-				-e IS_CI=$${IS_CI} -e WAIT_FOR_DB=1 -e UPDATE_STATE=1 \
+				-e IS_CI=$${IS_CI} -e RUN_E2E=$${RUN_E2E} -e WAIT_FOR_DB=1 -e UPDATE_STATE=1 \
 				--network monoetna_default $(fullTag) \
 				/entrypoints/development.sh rspec; \
 	fi

--- a/vulcan/spec/orchestration_spec.rb
+++ b/vulcan/spec/orchestration_spec.rb
@@ -148,7 +148,7 @@ describe Vulcan::Orchestration do
     end
   end
 
-  describe 'e2e' do
+  describe 'e2e', e2e: true do
     it 'works' do
       expect(orchestration.run_until_done!(storage).length).to eql(0)
       expect(primary_outputs.is_built?(storage)).to eql(false)
@@ -301,7 +301,7 @@ describe Vulcan::Orchestration do
       end
     end
 
-    describe 'node' do
+    describe 'node workflow' do
       let(:figure) {
         create_figure(
           workflow_name: "test_node_workflow.cwl",

--- a/vulcan/spec/spec_helper.rb
+++ b/vulcan/spec/spec_helper.rb
@@ -98,6 +98,13 @@ RSpec.configure do |config|
     #      https://github.com/jeremyevans/sequel/issues/908#issuecomment-61217226
     Vulcan.instance.db.transaction(:rollback=>:always, :auto_savepoint=>true){ example.run }
   end
+
+  if ENV['RUN_E2E']=='1'
+    config.filter_run e2e: true
+  else
+    config.filter_run_excluding e2e: true
+  end
+
 end
 
 def create_figure(params)


### PR DESCRIPTION
Goal: stop the constant test failures of our all our commits owing to hitting github action constraints rather than actually broken code