### PR TITLE
Fix magma hold file

### DIFF
--- a/magma/bin/healthcheck
+++ b/magma/bin/healthcheck
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-HOLD_FILE=$(grep hold_file config.yml | awk '{ print $2 }')
+HOLD_FILE=$(grep -E "^\s+:hold_file:" config.yml | awk '{ print $2 }')
+HOLD_URL=$(grep -E "^\s+:hold_url:" config.yml | awk '{ print $2 }')
 
 if [ -f "$HOLD_FILE" ];
 then
@@ -9,8 +10,13 @@ then
 
     if [[ $curr_time < $hold_time ]];
     then
-    	exit 0
+        exit 0
     fi
 fi
 
-curl -f -X OPTIONS http://localhost:3000 || exit 1
+if [ "$MAGMA_ENV" == "test" ];
+then
+    exit 1
+fi
+
+curl -f -X OPTIONS ${HOLD_URL:-http://localhost:3000} || exit 1

--- a/magma/config.yml.template
+++ b/magma/config.yml.template
@@ -43,6 +43,8 @@
   :host: https://magma.test
   :log_file: /dev/stdout
   :log_level: error
+  :hold_file: tmp/test.hold
+  :hold_interval: 10
   :hmac_keys:
     :magma: haggis
   :storage:

--- a/magma/lib/magma.rb
+++ b/magma/lib/magma.rb
@@ -64,7 +64,7 @@ class Magma
   def remove_hold_file
     return unless config(:hold_file)
 
-    ::File.unlink(config(:hold_file))
+    ::File.unlink(config(:hold_file)) if ::File.exists?(config(:hold_file))
   end
 
   def load_models(validate = true)

--- a/magma/spec/magma_spec.rb
+++ b/magma/spec/magma_spec.rb
@@ -78,4 +78,22 @@ describe Magma do
       Labors::Monster.attributes.delete(:size)
     end
   end
+
+  context 'hold file' do
+    it 'writes the hold file' do
+      Magma.instance.write_hold_file
+
+      expect(::File.exists?(Magma.instance.config(:hold_file))).to be_truthy
+
+      ::File.unlink(Magma.instance.config(:hold_file))
+    end
+
+    it 'removes the hold file' do
+      Magma.instance.write_hold_file
+
+      Magma.instance.remove_hold_file
+
+      expect(::File.exists?(Magma.instance.config(:hold_file))).to be_falsy
+    end
+  end
 end

--- a/magma/spec/magma_spec.rb
+++ b/magma/spec/magma_spec.rb
@@ -95,5 +95,33 @@ describe Magma do
 
       expect(::File.exists?(Magma.instance.config(:hold_file))).to be_falsy
     end
+
+    it 'passes the healthcheck if hold file exists' do
+      Magma.instance.write_hold_file
+
+      status = system("bin/healthcheck")
+
+      ::File.unlink(Magma.instance.config(:hold_file))
+
+      expect(status).to be_truthy
+    end
+
+    it 'runs the healthcheck if hold file does not exist' do
+      status = system("bin/healthcheck")
+
+      expect(status).to be_falsy
+    end
+
+    it 'runs the healthcheck if hold file is expired' do
+      Timecop.freeze(DateTime.now-Magma.instance.config(:hold_interval)-1)
+      Magma.instance.write_hold_file
+      Timecop.return
+
+      status = system("bin/healthcheck")
+
+      ::File.unlink(Magma.instance.config(:hold_file))
+
+      expect(status).to be_falsy
+    end
   end
 end

--- a/magma/spec/magma_spec.rb
+++ b/magma/spec/magma_spec.rb
@@ -96,7 +96,7 @@ describe Magma do
       expect(::File.exists?(Magma.instance.config(:hold_file))).to be_falsy
     end
 
-    it 'passes the healthcheck if hold file exists' do
+    it 'passes the healthcheck if hold file exists and is not expired' do
       Magma.instance.write_hold_file
 
       status = system("bin/healthcheck")


### PR DESCRIPTION
Currently Magma cannot start up correctly if hold_file is configured, this PR repairs this issue and adds some tests.

To review:
1. start magma up with hold_file defined in config.yml
2. test bin/healthcheck works as expected after calling Magma.instance.write_hold_file