### PR TITLE
BugFix: Vulcan 'Visualization from File' workflow csv read-in

### DIFF
--- a/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
+++ b/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
@@ -15,5 +15,5 @@ if re.search("csv$", file.file_path) is not None:
     separator = ","
 
 with metis.open_file(file) as open_file:
-    df = pandas.read_table(open_file, sep = separator)
+    df = pandas.read_table(open_file, sep=separator, engine="python")
 df.to_json(output_path("data_frame"))

--- a/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
+++ b/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
@@ -2,12 +2,18 @@ from archimedes.functions.dataflow import output_path, input_json
 from archimedes.functions.utils import pandas
 from archimedes.functions.environment import project_name, metis_host, token
 from archimedes.functions.etna import Metis, File, TokenAuth
+from archimedes.functions.utils import re
 
 metis = Metis(TokenAuth(token), metis_host)
 fileInfo = input_json('data_table_file')
 file = File(
     file_path=fileInfo['path'], project_name=project_name, bucket_name=fileInfo['bucket'], download_url = None
 )
+
+separator = "\\t"
+if re.search("csv$", file.file_path) is not None:
+    separator = ","
+
 with metis.open_file(file) as open_file:
-    df = pandas.read_table(open_file)
+    df = pandas.read_table(open_file, sep = separator)
 df.to_json(output_path("data_frame"))


### PR DESCRIPTION
*Minor bug-fix / future-proofing: seems not actually a current bug, but based on different behavior in airflow, also seems likely enough to become one in the future if not protected against

In building the python/airflow data-handling side of the data_frame loader for Polyphemus, I noticed that the `pandas.read_table()` file read-in did not automatically detect and adjust for csv vs tsv files.  Possibly (not confirmed) from a pandas version difference with an adjustment to default behavior.  In any case, implies a need to be explicit about what we want to happen.  This PR does that.

In 'Fetch Data' step of the 'Visualization from File' workflow:
- Adds determination of whether to use `separator` of `","` or `"\\t"` based on the file extension, and passes this along in the read-in, `pandas.read_table(open_file, sep = separator)`