### PR TITLE
Fix metis linker tail

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -186,22 +186,21 @@ def MetisLinker():
         start, end = get_batch_range(context)
         print(f"Collecting tails in range {str(dict(start=start, end=end))}")
 
-        buckets = [
-            config.bucket_key
-            for config in configs
-            for model, model_config in config.config.get("models",{}).items()
-            for script in model_config["scripts"]
-        ]
+        buckets = dict()
+        for config in configs:
+            ran_at = datetime.fromisoformat(config.ran_at or '2010-01-01')
+            if config.bucket_key not in buckets or buckets[ config.bucket_key ] < ran_at:
+                buckets[ config.bucket_key ] = ran_at
                 
         with hook.metis() as metis:
             tails = dict()
-            for project_name, bucket_name in buckets:
+            for (project_name, bucket_name), ran_at in buckets.items():
                 try:
                     files = metis.tail(
                         project_name=project_name,
                         bucket_name=bucket_name,
                         type='files',
-                        batch_start=start,
+                        batch_start=ran_at,
                         batch_end=end
                     )
                     tails[ (project_name, bucket_name) ] = { 'files': files }

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -189,7 +189,7 @@ def MetisLinker():
         buckets = dict()
         for config in configs:
             ran_at = datetime.fromisoformat(config.ran_at or '2010-01-01')
-            if config.bucket_key not in buckets or buckets[ config.bucket_key ] < ran_at:
+            if config.bucket_key not in buckets or buckets[ config.bucket_key ] > ran_at:
                 buckets[ config.bucket_key ] = ran_at
                 
         with hook.metis() as metis:

--- a/polyphemus/lib/models/etl_config.rb
+++ b/polyphemus/lib/models/etl_config.rb
@@ -32,7 +32,7 @@ class Polyphemus
     end
 
     def self.current
-      return self.reverse(:config_id, :version_number).distinct(:config_id).exclude(run_interval: Polyphemus::EtlConfig::RUN_ARCHIVED)
+      return self.reverse(:config_id, :version_number).distinct(:config_id).from_self.exclude(run_interval: Polyphemus::EtlConfig::RUN_ARCHIVED)
     end
 
     def etl_job_class


### PR DESCRIPTION
This PR makes a small adjustment to the way the metis linker runs which resolves a number of major issues with the workflow. Instead of using the airflow task start/stop times to collect tails from Metis, now instead it uses the Polyphemus etl_config ran_at time to determine the tail window (which is updated at  the end of the linker's run). This has two big benefits: 1) if ran_at is null (i.e., the config has never been run before), the tail will start from 2010-01-01, i.e., all files will be scanned. 2) if ran_at is not null (i.e., the config has run before), the tail will collect any files modified after the last time it ran, rather than the airflow interval, so that the user no longer has to line up the running of the config, the touching of the files, and the timing of the airflow task, avoiding weird races that are hard to reason about. The result is it is much simpler and easier to understand when the config will run across some files, and touching files is only necessary if you want to re-process data; most of the time it will not be required.

This also resolves an issue with removing/archiving loaders, which previously would show up again after reloading when deleted.

To test:
1) Run a new metis loader from polyphemus on some old files without recreating the linker or touching the files.
2) Run a metis loader after uploading new files.
3) Touch files to re-run.
4) Delete a loader and refresh to validate it has been removed.