### PR TITLE
Add flag api and tests

### DIFF
--- a/magma/lib/magma/flag.rb
+++ b/magma/lib/magma/flag.rb
@@ -31,7 +31,7 @@ class Magma
       none: 'none'
     }
 
-    def self.flag_valid?(flag_name, flag_value)
+    def self.is_registered(flag_name, flag_value)
       # flag_hash: a string, flag_value: a string
       # ensures that a flag has the proper name and the values are defined
       constants.each do |constant|

--- a/magma/lib/magma/flag.rb
+++ b/magma/lib/magma/flag.rb
@@ -1,16 +1,20 @@
 class Magma
   class Flag < Sequel::Model
     # update_or_create is natively implemented in a later version of Sequel - I believe it can also be installed as a plugin
-    def self.update_or_create(project_name, flag_list)
-      flag_list.each do |flag|
-        flag.each do |flag_name, value|
-          existing_flag = self.where(project_name: project_name, flag_name: flag_name.to_s).first
-          if existing_flag
-            existing_flag.update(value: value)
-          else
-            self.create(project_name: project_name, flag_name: flag_name.to_s, value: value)
-          end
-        end
+    def self.update_or_create(update_hash, value_hash)
+      # handles updates, creates and deletes. Deletes when {value: nil}.
+      #
+      # update_key: a hash with two keys: {project_name: , flag_name: }
+      # value: a hash with one key: {value: }
+
+      existing_flag = self.where(update_hash).first
+      if existing_flag
+        # We delete flags set as nil and update the flags otherwise
+        value_hash[:value].nil? ? existing_flag.delete : existing_flag.update(value_hash)
+      else
+        # create a new row, make sure the value is not nil
+        # (this is a rare case when a user tries to delete a row that does not exist)
+        self.create(update_hash.merge(value_hash)) unless value_hash[:value].nil?
       end
     end
   end

--- a/magma/lib/magma/flag.rb
+++ b/magma/lib/magma/flag.rb
@@ -1,5 +1,18 @@
 class Magma
   class Flag < Sequel::Model
+    # update_or_create is natively implemented in a later version of Sequel - I believe it can also be installed as a plugin
+    def self.update_or_create(project_name, flag_list)
+      flag_list.each do |flag|
+        flag.each do |flag_name, value|
+          existing_flag = self.where(project_name: project_name, flag_name: flag_name.to_s).first
+          if existing_flag
+            existing_flag.update(value: value)
+          else
+            self.create(project_name: project_name, flag_name: flag_name.to_s, value: value)
+          end
+        end
+      end
+    end
   end
 
   module Flags

--- a/magma/lib/magma/flag.rb
+++ b/magma/lib/magma/flag.rb
@@ -4,7 +4,7 @@ class Magma
     def self.update_or_create(update_hash, value_hash)
       # handles updates, creates and deletes. Deletes when {value: nil}.
       #
-      # update_key: a hash with two keys: {project_name: , flag_name: }
+      # update_hash: a hash with two keys: {project_name: , flag_name: }
       # value: a hash with one key: {value: }
 
       existing_flag = self.where(update_hash).first
@@ -13,7 +13,7 @@ class Magma
         value_hash[:value].nil? ? existing_flag.delete : existing_flag.update(value_hash)
       else
         # create a new row, make sure the value is not nil
-        # (this is a rare case when a user tries to delete a row that does not exist)
+        # our unless statement is for a rare case when a user tries to delete a row that does not exist
         self.create(update_hash.merge(value_hash)) unless value_hash[:value].nil?
       end
     end
@@ -23,11 +23,23 @@ class Magma
     # All hashes nested under this namespace represent flags that can be used in a production.
     # Each hash should define a 'name' key, that represents the name of the flag and it
     # should also specify all potential values that can be assigned to a flag.
+
     GNOMON_MODE = {
       name: 'gnomon_mode',
       identifier: 'identifier',
       pattern: 'pattern',
       none: 'none'
     }
+
+    def self.flag_valid?(flag_name, flag_value)
+      # flag_hash: a string, flag_value: a string
+      # ensures that a flag has the proper name and the values are defined
+      constants.each do |constant|
+        next unless const_get(constant)[:name] == flag_name && (const_get(constant).has_value?(flag_value) || flag_value.nil?)
+        return true
+      end
+      false
+    end
+
   end
 end

--- a/magma/lib/magma/flag.rb
+++ b/magma/lib/magma/flag.rb
@@ -32,7 +32,6 @@ class Magma
     }
 
     def self.is_registered(flag_name, flag_value)
-      # flag_hash: a string, flag_value: a string
       # ensures that a flag has the proper name and the values are defined
       constants.each do |constant|
         next unless const_get(constant)[:name] == flag_name && (const_get(constant).has_value?(flag_value) || flag_value.nil?)

--- a/magma/lib/magma/server.rb
+++ b/magma/lib/magma/server.rb
@@ -26,8 +26,8 @@ class Magma
 
     post '/update_model', action: 'update_model#action', auth: { user: { is_admin?: :project_name } }
 
-    get '/flags/:project_name/', action: 'flags#get', auth: { user: { can_view?: :project_name } }
-    post '/flags/:project_name/', action: 'flags#set', auth: { user: { is_admin?: :project_name } }
+    get '/flags/:project_name', action: 'flags#get', auth: { user: { can_view?: :project_name } }
+    post '/flags/:project_name', action: 'flags#set', auth: { user: { is_admin?: :project_name } }
 
     post '/gnomon/rules', action: 'gnomon#rules', auth: { user: { is_supereditor?: true } }
     get '/gnomon/:project_name', action: 'gnomon#get', auth: { user: { can_view?: :project_name } }

--- a/magma/lib/magma/server.rb
+++ b/magma/lib/magma/server.rb
@@ -6,6 +6,7 @@ require_relative '../magma/server/query'
 require_relative '../magma/server/update'
 require_relative '../magma/server/gnomon'
 require_relative '../magma/server/update_model'
+require_relative '../magma/server/flag'
 
 class Magma
   class Server < Etna::Server
@@ -24,6 +25,9 @@ class Magma
     post '/update', as: :update, action: 'update#action', auth: { user: { can_edit?: :project_name } }
 
     post '/update_model', action: 'update_model#action', auth: { user: { is_admin?: :project_name } }
+
+    get '/flags/:project_name/', action: 'flags#get', auth: { user: { can_view?: :project_name } }
+    post '/flags/:project_name/', action: 'flags#set', auth: { user: { is_admin?: :project_name } }
 
     post '/gnomon/rules', action: 'gnomon#rules', auth: { user: { is_supereditor?: true } }
     get '/gnomon/:project_name', action: 'gnomon#get', auth: { user: { can_view?: :project_name } }

--- a/magma/lib/magma/server/controller.rb
+++ b/magma/lib/magma/server/controller.rb
@@ -3,7 +3,6 @@ class Magma
     def initialize(request, action=nil)
       super
       @project_name = @params[:project_name]
-      @flags = Magma::Project.flags(@project_name)
     end
 
     def handle_error(e)

--- a/magma/lib/magma/server/controller.rb
+++ b/magma/lib/magma/server/controller.rb
@@ -3,6 +3,7 @@ class Magma
     def initialize(request, action=nil)
       super
       @project_name = @params[:project_name]
+      @flags = Magma::Project.flags(@project_name)
     end
 
     def handle_error(e)

--- a/magma/lib/magma/server/flag.rb
+++ b/magma/lib/magma/server/flag.rb
@@ -1,0 +1,18 @@
+require_relative 'controller'
+
+class FlagsController < Magma::Controller
+  def get
+    success_json({flags: @flags})
+  end
+
+  def set
+    require_param(:flags)
+    Magma::Flag.update_or_create(project_name, @params[:flags])
+    success_json({success: 200})
+  end
+
+  def project_name
+    @params[:project_name]
+  end
+
+end

--- a/magma/lib/magma/server/flag.rb
+++ b/magma/lib/magma/server/flag.rb
@@ -16,7 +16,7 @@ class FlagsController < Magma::Controller
     @params[:flags].each do |flag|
       flag.each do |flag_name, flag_value|
 
-        unless Magma::Flags.flag_valid?(flag_name.to_s, flag_value)
+        unless Magma::Flags.is_registered(flag_name.to_s, flag_value)
           raise Etna::BadRequest,  "Flag with name: \"#{flag_name}\", value: \"#{flag_value}\" is not registered in the Magma::Flags module."
         end
 

--- a/magma/lib/magma/server/flag.rb
+++ b/magma/lib/magma/server/flag.rb
@@ -1,18 +1,26 @@
 require_relative 'controller'
 
 class FlagsController < Magma::Controller
+
+  def initialize(request, action = nil)
+    super
+    @flags = Magma::Project.flags(@project_name)
+  end
+
   def get
     success_json({flags: @flags})
   end
 
   def set
     require_param(:flags)
-    Magma::Flag.update_or_create(project_name, @params[:flags])
-    success_json({success: 200})
-  end
+    @params[:flags].each do |flag|
+      flag.each do |flag_name, flag_value|
+        update_key =  {project_name: @project_name, flag_name: flag_name.to_s}
+        Magma::Flag.update_or_create(update_key, {value: flag_value})
+      end
+    end
 
-  def project_name
-    @params[:project_name]
+    success_json({success: 200})
   end
 
 end

--- a/magma/lib/magma/server/flag.rb
+++ b/magma/lib/magma/server/flag.rb
@@ -15,6 +15,11 @@ class FlagsController < Magma::Controller
     require_param(:flags)
     @params[:flags].each do |flag|
       flag.each do |flag_name, flag_value|
+
+        unless Magma::Flags.flag_valid?(flag_name.to_s, flag_value)
+          raise Etna::BadRequest,  "Flag with name: \"#{flag_name}\", value: \"#{flag_value}\" is not registered in the Magma::Flags module."
+        end
+
         update_key =  {project_name: @project_name, flag_name: flag_name.to_s}
         Magma::Flag.update_or_create(update_key, {value: flag_value})
       end

--- a/magma/spec/flags_spec.rb
+++ b/magma/spec/flags_spec.rb
@@ -60,12 +60,15 @@ describe FlagsController do
 
   context 'set API' do
 
+    before do
+      unregister_flags
+    end
+
     context 'registered Flags' do
 
       it 'complains if the flag name is not registered in the Flags module' do
         auth_header(:admin)
         json_post('/flags/labors', flags: [rainy_flag])
-        binding.pry
         expect(JSON.parse(last_response.body)["error"]).to eq(unregistered_err_msg("is_rainy", "true"))
       end
 

--- a/magma/spec/flags_spec.rb
+++ b/magma/spec/flags_spec.rb
@@ -1,0 +1,72 @@
+describe FlagsController do
+  include Rack::Test::Methods
+
+  let(:test_flags) { { mythology: "greek", contains_extra_labor: "true" } }
+
+  def app
+    OUTER_APP
+  end
+
+  def create_flags
+    test_flags.each do |k,v|
+      create(:flag, project_name: "labors", flag_name: k, value: v)
+  end
+  end
+
+  context 'get API' do
+    it 'shows available flags for authorized users' do
+      create_flags
+      auth_header(:viewer)
+      get('/flags/labors')
+      expect(last_response.status).to eq(200)
+      expect(json_body[:flags]).to eq(test_flags)
+    end
+
+    it 'complains if you are not authorized to view flags' do
+      create_flags
+      get('/flags/labors')
+      expect(last_response.status).to eq(401)
+    end
+  end
+
+  context 'set API' do
+    it 'correctly updates a flag' do
+      create_flags
+      auth_header(:admin)
+      json_post('/flags/labors', flags: [{contains_extra_labor: "false"}])
+      get('/flags/labors')
+      expect(json_body[:flags][:contains_extra_labor]).to eq("false")
+      expect(json_body[:flags][:mythology]).to eq("greek")
+    end
+
+    it 'correctly creates flags' do
+      create_flags
+      auth_header(:admin)
+      json_post('/flags/labors', flags: [{is_deprecated: "false"}, {is_rainy: "true"}])
+      get('/flags/labors')
+      expect(json_body[:flags][:is_deprecated]).to eq("false")
+      expect(json_body[:flags][:is_rainy]).to eq("true")
+      expect(json_body[:flags][:contains_extra_labor]).to eq("true")
+      expect(json_body[:flags][:mythology]).to eq("greek")
+    end
+
+    it 'correctly creates a flag if none exist' do
+      auth_header(:admin)
+      json_post('/flags/labors', flags: [{deprecated: "false"}])
+      get('/flags/labors')
+      expect(json_body[:flags][:deprecated]).to eq("false")
+    end
+
+    it 'complains if you are not authorized to update flags' do
+      create_flags
+      auth_header(:viewer)
+      json_post('/flags/labors', flags: [{deprecated: "false"}])
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+
+
+
+end
+

--- a/magma/spec/flags_spec.rb
+++ b/magma/spec/flags_spec.rb
@@ -2,20 +2,49 @@ describe FlagsController do
   include Rack::Test::Methods
 
   let(:test_flags) { { mythology: "greek", contains_extra_labor: "true" } }
+  let(:rainy_flag) { { is_rainy: "true" }}
+  let(:deprecated_flag) { { is_deprecated: "true" }}
+
+  let(:registered_flags) {
+    {
+      MYTHOLOGY: {
+        name: "mythology",
+        greek: "greek"
+      },
+      EXTRA_LABOR: {
+        name: "contains_extra_labor",
+        true: "true",
+        false: "false"
+      },
+      RAINY: {
+        name: "is_rainy",
+        true: "true",
+        false: "false"
+      },
+      DEPRECATED: {
+        name: "is_deprecated",
+        true: "true"
+      }
+    }
+  }
 
   def app
     OUTER_APP
   end
 
-  def create_flags
-    test_flags.each do |k,v|
-      create(:flag, project_name: "labors", flag_name: k, value: v)
-    end
+  def flag_setup
+    register_flag(registered_flags[:MYTHOLOGY])
+    register_flag(registered_flags[:EXTRA_LABOR])
+    create_flags_in_db(test_flags)
+  end
+
+  def unregistered_err_msg(flag_name, flag_value)
+    "Flag with name: \"#{flag_name}\", value: \"#{flag_value}\" is not registered in the Magma::Flags module."
   end
 
   context 'get API' do
     it 'shows available flags for authorized users' do
-      create_flags
+      flag_setup
       auth_header(:viewer)
       get('/flags/labors')
       expect(last_response.status).to eq(200)
@@ -23,7 +52,7 @@ describe FlagsController do
     end
 
     it 'complains if you are not authorized to view flags' do
-      create_flags
+      flag_setup
       get('/flags/labors')
       expect(last_response.status).to eq(401)
     end
@@ -31,10 +60,35 @@ describe FlagsController do
 
   context 'set API' do
 
+    context 'registered Flags' do
+
+      it 'complains if the flag name is not registered in the Flags module' do
+        auth_header(:admin)
+        json_post('/flags/labors', flags: [rainy_flag])
+        binding.pry
+        expect(JSON.parse(last_response.body)["error"]).to eq(unregistered_err_msg("is_rainy", "true"))
+      end
+
+      it 'complains if the value is not registered in the Flag module ' do
+        auth_header(:admin)
+        register_flag(registered_flags[:RAINY])
+        json_post('/flags/labors', flags: [{is_rainy: "doh!"}])
+        expect(JSON.parse(last_response.body)["error"]).to eq(unregistered_err_msg("is_rainy", "doh!"))
+      end
+
+      it 'allows flags creates when Flags are registered in the Flag module' do
+        auth_header(:admin)
+        register_flag(registered_flags[:RAINY])
+        json_post('/flags/labors', flags: [rainy_flag])
+        get('/flags/labors')
+        expect(json_body[:flags][:is_rainy]).to eq("true")
+      end
+    end
+
     context 'creates and updates' do
 
       it 'correctly updates a flag' do
-        create_flags
+        flag_setup
         auth_header(:admin)
         json_post('/flags/labors', flags: [{contains_extra_labor: "false"}])
         get('/flags/labors')
@@ -43,27 +97,30 @@ describe FlagsController do
       end
 
       it 'correctly creates flags' do
-        create_flags
+        flag_setup
+        register_flag(registered_flags[:RAINY])
+        register_flag(registered_flags[:DEPRECATED])
         auth_header(:admin)
-        json_post('/flags/labors', flags: [{is_deprecated: "false"}, {is_rainy: "true"}])
+        json_post('/flags/labors', flags: [deprecated_flag, rainy_flag])
         get('/flags/labors')
-        expect(json_body[:flags][:is_deprecated]).to eq("false")
+        expect(json_body[:flags][:is_deprecated]).to eq("true")
         expect(json_body[:flags][:is_rainy]).to eq("true")
         expect(json_body[:flags][:contains_extra_labor]).to eq("true")
         expect(json_body[:flags][:mythology]).to eq("greek")
       end
 
       it 'correctly creates a flag if none exist' do
+        register_flag(registered_flags[:DEPRECATED])
         auth_header(:admin)
-        json_post('/flags/labors', flags: [{deprecated: "false"}])
+        json_post('/flags/labors', flags: [deprecated_flag])
         get('/flags/labors')
-        expect(json_body[:flags][:deprecated]).to eq("false")
+        expect(json_body[:flags][:is_deprecated]).to eq("true")
       end
 
       it 'complains if you are not authorized to update flags' do
-        create_flags
+        register_flag(registered_flags[:DEPRECATED])
         auth_header(:viewer)
-        json_post('/flags/labors', flags: [{deprecated: "false"}])
+        json_post('/flags/labors', flags: [deprecated_flag])
         expect(last_response.status).to eq(403)
       end
     end
@@ -71,7 +128,7 @@ describe FlagsController do
     context 'deletes' do
 
       it 'correctly deletes a flag' do
-        create_flags
+        flag_setup
         auth_header(:admin)
         json_post('/flags/labors', flags: [{mythology: nil}])
         get('/flags/labors')
@@ -80,13 +137,15 @@ describe FlagsController do
       end
 
       it 'gracefully handles when flag does not exist' do
+        register_flag(registered_flags[:RAINY])
         auth_header(:admin)
-        json_post('/flags/labors', flags: [{mythology: nil}])
+        json_post('/flags/labors', flags: [rainy_flag])
+        expect(last_response.status).to eq(200)
+        json_post('/flags/labors', flags: [{is_rainy: nil}])
         get('/flags/labors')
         expect(json_body[:flags]).to be_empty
         expect(last_response.status).to eq(200)
       end
     end
-
   end
 end

--- a/magma/spec/flags_spec.rb
+++ b/magma/spec/flags_spec.rb
@@ -64,9 +64,5 @@ describe FlagsController do
       expect(last_response.status).to eq(403)
     end
   end
-
-
-
-
 end
 

--- a/magma/spec/flags_spec.rb
+++ b/magma/spec/flags_spec.rb
@@ -10,7 +10,7 @@ describe FlagsController do
   def create_flags
     test_flags.each do |k,v|
       create(:flag, project_name: "labors", flag_name: k, value: v)
-  end
+    end
   end
 
   context 'get API' do

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -517,6 +517,18 @@ def create_identifier(id, params={})
   )
 end
 
+def register_flag(flag_hash)
+    # This dynamically creates constants in the Flags mode and "registers" them
+    # The first argument is just the name of the constant, it can be random.
+    constant_name = (1..4).map { ('A'..'Z').to_a.sample }.join
+    Magma::Flags.const_set(constant_name, flag_hash)
+end
+
+def create_flags_in_db(flag_hash)
+  flag_hash.each do |k,v|
+    create(:flag, project_name: "labors", flag_name: k, value: v)
+  end
+end
 
 VALID_GRAMMAR_CONFIG={
   tokens: {

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -520,8 +520,14 @@ end
 def register_flag(flag_hash)
     # This dynamically creates constants in the Flags mode and "registers" them
     # The first argument is just the name of the constant, it can be random.
-    constant_name = (1..4).map { ('A'..'Z').to_a.sample }.join
+    constant_name = 'TEST_' + (1..4).map { ('A'..'Z').to_a.sample }.join
     Magma::Flags.const_set(constant_name, flag_hash)
+end
+
+def unregister_flags
+  Magma::Flags.constants.select { |const| const.to_s.start_with?('TEST_') }.each do |const|
+    Magma::Flags.module_eval { remove_const(const) }
+  end
 end
 
 def create_flags_in_db(flag_hash)


### PR DESCRIPTION
## What

This adds a Flag API to magma. Currently it supports:

- `get` requests. You can view all the available flags for a project
  - Via: `/flags/{project_name`
- `post` requests. You can either create or update flags. 
  - Via: `/flags/{project_name}` and submitting a parameter: `flags: [{flag_name: value}])`
  - We can delete flags when `{flag_name: nil}`

### Other noteworthy changes

We've decided that in order to create any flags in the Flag API, they must be registered in the `Flags::Module`.

There is a function called `is_registered?` that verifies this.

#### Testing impacts

The `is_registered` constraint makes testing the flag functionality a bit tricky. In particular - depending on what you are trying to test - you may need to use a helper function in `spec_helper` called `register_flag` that takes in a hash and registers it as a constant in `Magma::Flags`. 

If you use this function it is important to use `unregister_flags` at the end of your tests (or use it a `before block`)

## How to test

`rspec ./spec/flags_spec.rb`
