### PR TITLE
promote `--list` option in metis_client

### DIFF
--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1569,13 +1569,15 @@ EOT
 
       puts "Found #{archived_files_count} of #{files.length} files on Metis."
       puts "Total unarchived size: #{byte_format(unarchived_size)}"
-      if options[:list] && !unarchived_files.empty?
-        puts "\nMissing files:"
-        puts unarchived_files
-        puts "Archived files:"
-        puts archived_files
-      elsif !unarchived_files.empty?
-        puts "Run with --list option added to see missing files."
+      if !unarchived_files.empty?
+        if options[:list]
+          puts "Archived files:"
+          puts archived_files
+          puts "\nMissing files:"
+          puts unarchived_files
+        else
+          puts "Run with --list option added to see missing files."
+        end
       end
     end
   end

--- a/metis/bin/metis_client
+++ b/metis/bin/metis_client
@@ -1574,6 +1574,8 @@ EOT
         puts unarchived_files
         puts "Archived files:"
         puts archived_files
+      elsif !unarchived_files.empty?
+        puts "Run with --list option added to see missing files."
       end
     end
   end


### PR DESCRIPTION
This mini PR just adds an extra text line to `validate` runs notifying the users of the `--list` option, when 1) they didn't do it, and 2) some of there files were found not to be in metis.  In these cases, just knowing '1 file did not exist in metis.' is not enough, and what they will want to know is "which file?".  The `--list` option is how to output that.