### PR TITLE
Update data-frame loader

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -121,7 +121,7 @@ class MetisLoaderConfig(EtlConfigResponse):
             if isTable:
                 data['__temp__']=['::temp-id-' + str(temp) for temp in data.index]
                 data = data.set_index('__temp__', drop=True)
-                if script.get(['blank_table'], False):
+                if script.get('blank_table', False):
                     for parent_name in set(list(data[template.parent])):
                         if not self.get_identifier(template.parent, parent_name):
                             continue

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -102,8 +102,13 @@ class MetisLoaderConfig(EtlConfigResponse):
                     else:
                         # Attempt to use pandas' automated detection
                         separator = None
-                # Maybe Future Feature: expose additional blanker value in config ui
-                data = pandas.read_table(file_reader, sep=separator, engine = 'python').replace({numpy.nan: None})
+                # Load dataframe
+                data = pandas.read_table(file_reader, sep=separator, engine = 'python', na_filter=False)
+                # Blank data equaling hole_value or empty string (None's ignored from the update-build later on)
+                replacements = {'': None}
+                if 'hole_value' in script:
+                    replacements[script['hole_value']] = None
+                data=data.replace(replacements)
             if len(data.columns) < 2:
                 raise MetisLoaderError(f"{file.file_name} seems to have fewer than 2 columns. Check the 'format' configuration for this data_frame loader.")
             if not set(columns).issubset(data.columns):

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -122,7 +122,7 @@ class MetisLoaderConfig(EtlConfigResponse):
             if isTable:
                 data['__temp__']=['::temp-id-' + str(temp) for temp in data.index]
                 data = data.set_index('__temp__', drop=True)
-                if script['blank_table']:
+                if script.get(['blank_table'], False):
                     for parent_name in set(list(data[template.parent])):
                         if not self.get_identifier(template.parent, parent_name):
                             continue

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -93,12 +93,12 @@ class MetisLoaderConfig(EtlConfigResponse):
                 if script['format']=="csv":
                     separator = ","
                 if script['format']=="tsv":
-                    separator = "\\t"
+                    separator = "\t"
                 if script['format']=="auto-detect":
                     if re.search("csv$", file.file_path) is not None:
                         separator = ","
                     elif re.search("tsv$", file.file_path) is not None:
-                        separator = "\\t"
+                        separator = "\t"
                     else:
                         # Attempt to use pandas' automated detection
                         separator = None

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -104,11 +104,6 @@ class MetisLoaderConfig(EtlConfigResponse):
                         separator = None
                 # Load dataframe
                 data = pandas.read_table(file_reader, sep=separator, engine = 'python', na_filter=False)
-                # Blank data equaling hole_value or empty string (None's ignored from the update-build later on)
-                replacements = {'': None}
-                if 'hole_value' in script:
-                    replacements[script['hole_value']] = None
-                data=data.replace(replacements)
             if len(data.columns) < 2:
                 raise MetisLoaderError(f"{file.file_name} seems to have fewer than 2 columns. Check the 'format' configuration for this data_frame loader.")
             if not set(columns).issubset(data.columns):
@@ -118,6 +113,10 @@ class MetisLoaderConfig(EtlConfigResponse):
                 raise MetisLoaderError(f"{file.file_name} has unexpected NA values after all parsing. Data rows may be shorter than the column row indicates.")
             # Trim to mapped columns and convert to attribute names
             data = data.rename(columns={v: k for k,v in column_map.items()})[attributes]
+            # Blank data equaling values_to_ignore by setting as None (None's are ignored when updates are constructed)
+            if 'values_to_ignore' in script:
+                replacements = {k: None for k in script['values_to_ignore'].split(',')}
+                data=data.replace(replacements)
             # Determine Updates
             if isTable:
                 data['__temp__']=['::temp-id-' + str(temp) for temp in data.index]

--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -114,6 +114,8 @@ class MetisLoaderConfig(EtlConfigResponse):
             if not set(columns).issubset(data.columns):
                 missing = ', '.join([col for col in columns if col not in data.columns])
                 raise MetisLoaderError(f"{file.file_name} is missing column(s) targetted by {model_name} data_frame loader 'column_map': {missing}.")
+            if pandas.isna(data).values.any():
+                raise MetisLoaderError(f"{file.file_name} has unexpected NA values after all parsing. Data rows may be shorter than the column row indicates.")
             # Trim to mapped columns and convert to attribute names
             data = data.rename(columns={v: k for k,v in column_map.items()})[attributes]
             # Determine Updates

--- a/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
@@ -184,7 +184,7 @@ class TestMetisLinker:
                                     "name": "name",
                                     "species": "SPECIES"
                                 },
-                                "hole_value": "__"
+                                "values_to_ignore": "__"
                             }
                         ]
                     }
@@ -193,7 +193,7 @@ class TestMetisLinker:
         }
         # csv format, file columns do match the map, script also set to test auto detection that its a csv file.
         # For table version, DON'T blank past values
-        # Config lacks a 'hole_value' definition.
+        # Config lacks a 'values_to_ignore' definition.
         config2 = {
             "project_name": "labors",
             "config": {
@@ -345,7 +345,7 @@ class TestMetisLinker:
             }
         }
 
-        # given a 'good' config, with hole_value matching a value in the file, we get a shortened update
+        # given a 'good' config, with values_to_ignore matching a value in the file, we get a shortened update
         update5 = MetisLoaderConfig(**config1hole, rules=rules).update_for(tail, metis, model_std)
         assert asdict(update5)['revisions'] == {
             'victim': {

--- a/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
@@ -158,7 +158,8 @@ class TestMetisLinker:
                                 "blank_table": True,
                                 "column_map": {
                                     "name": "name",
-                                    "species": "SPECIES"
+                                    "species": "SPECIES",
+                                    "target_name": "target_name"
                                 }
                             }
                         ]
@@ -166,7 +167,7 @@ class TestMetisLinker:
                 }
             }
         }
-        # Same as above, just additionally set to ignore data that are "__"
+        # Same as above, just additionally set to ignore data that are "__" or empty strings
         config1hole = {
             "project_name": "labors",
             "config": {
@@ -182,9 +183,10 @@ class TestMetisLinker:
                                 "blank_table": True,
                                 "column_map": {
                                     "name": "name",
-                                    "species": "SPECIES"
+                                    "species": "SPECIES",
+                                    "target_name": "target_name"
                                 },
-                                "values_to_ignore": "__"
+                                "values_to_ignore": "__,"
                             }
                         ]
                     }
@@ -209,7 +211,8 @@ class TestMetisLinker:
                                 "blank_table": False,
                                 "column_map": {
                                     "name": "name",
-                                    "species": "SPECIES"
+                                    "species": "SPECIES",
+                                    "target_name": "target_name"
                                 }
                             }
                         ]
@@ -233,7 +236,8 @@ class TestMetisLinker:
                                 "blank_table": True,
                                 "column_map": {
                                     "name": "name",
-                                    "species": "species"
+                                    "species": "species",
+                                    "target_name": "target_name"
                                 }
                             }
                         ]
@@ -257,7 +261,8 @@ class TestMetisLinker:
                                 "blank_table": True,
                                 "column_map": {
                                     "name": "name",
-                                    "species": "SPECIES"
+                                    "species": "SPECIES",
+                                    "target_name": "target_name"
                                 }
                             }
                         ]
@@ -278,7 +283,8 @@ class TestMetisLinker:
                     parent='stub',
                     attributes={
                         'name': Attribute({ 'attribute_type': 'identifier' }),
-                        'species': Attribute({ 'attribute_type': 'string' })
+                        'species': Attribute({ 'attribute_type': 'string' }),
+                        'target_name': Attribute({ 'attribute_type': 'string' })
                     }
                 ),
                 'isTable': False
@@ -291,7 +297,8 @@ class TestMetisLinker:
                     parent='name',
                     attributes={
                         'name': Attribute({ 'attribute_type': 'parent' }),
-                        'species': Attribute({ 'attribute_type': 'string' })
+                        'species': Attribute({ 'attribute_type': 'string' }),
+                        'target_name': Attribute({ 'attribute_type': 'string' })
                     }
                 ),
                 'isTable': True
@@ -302,8 +309,8 @@ class TestMetisLinker:
 
         # And we have these files
         files = {
-            'village-1.tsv': 'name\tSPECIES\nLABORS-LION-H2-C1\t__\n',
-            'village-2.csv': 'name,SPECIES\nLABORS-LION-H2-C1,__\n'
+            'village-1.tsv': 'name\tSPECIES\ttarget_name\nLABORS-LION-H2-C1\t__\t\n',
+            'village-2.csv': 'name,SPECIES,target_name\nLABORS-LION-H2-C1,__,\n'
         }
 
         def dummy_file(file):
@@ -320,7 +327,8 @@ class TestMetisLinker:
         assert asdict(update1)['revisions'] == {
             'victim': {
                 'LABORS-LION-H2-C1': {
-                    'species': '__'
+                    'species': '__',
+                    'target_name': ''
                 }
             }
         }
@@ -332,7 +340,8 @@ class TestMetisLinker:
             'victim': {
                 '::temp-id-0': {
                     'name': 'LABORS-LION-H2-C1',
-                    'species': '__'
+                    'species': '__',
+                    'target_name': ''
                 }
             }
         }
@@ -340,7 +349,8 @@ class TestMetisLinker:
             'victim': {
                 '::temp-id-0': {
                     'name': 'LABORS-LION-H2-C1',
-                    'species': '__'
+                    'species': '__',
+                    'target_name': ''
                 }
             }
         }
@@ -372,7 +382,8 @@ class TestMetisLinker:
                         identifier='id',
                         attributes={
                             'name': Attribute({ 'attribute_type': 'identifier' }),
-                            'species': Attribute({ 'attribute_type': 'string' })
+                            'species': Attribute({ 'attribute_type': 'string' }),
+                            'target_name': Attribute({ 'attribute_type': 'string' })
                         }
                     ),
                     'isTable': isTable
@@ -390,7 +401,8 @@ class TestMetisLinker:
                     'template': Template(
                         identifier='name',
                         attributes={
-                            'name': Attribute({ 'attribute_type': 'identifier' })
+                            'name': Attribute({ 'attribute_type': 'identifier' }),
+                            'target_name': Attribute({ 'attribute_type': 'string' })
                         }
                     ),
                     'isTable': False

--- a/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
@@ -166,8 +166,34 @@ class TestMetisLinker:
                 }
             }
         }
+        # Same as above, just additionally set to ignore data that are "__"
+        config1hole = {
+            "project_name": "labors",
+            "config": {
+                "bucket_name": "pics",
+                "models": {
+                    "victim": {
+                        "scripts": [
+                            {
+                                "type": "data_frame",
+                                "folder_path": "villages",
+                                "file_match": "*.tsv",
+                                "format": "tsv",
+                                "blank_table": True,
+                                "column_map": {
+                                    "name": "name",
+                                    "species": "SPECIES"
+                                },
+                                "hole_value": "__"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
         # csv format, file columns do match the map, script also set to test auto detection that its a csv file.
         # For table version, DON'T blank past values
+        # Config lacks a 'hole_value' definition.
         config2 = {
             "project_name": "labors",
             "config": {
@@ -276,8 +302,8 @@ class TestMetisLinker:
 
         # And we have these files
         files = {
-            'village-1.tsv': 'name\tSPECIES\nLABORS-LION-H2-C1\tlion\n',
-            'village-2.csv': 'name,SPECIES\nLABORS-LION-H2-C1,lion\n'
+            'village-1.tsv': 'name\tSPECIES\nLABORS-LION-H2-C1\t__\n',
+            'village-2.csv': 'name,SPECIES\nLABORS-LION-H2-C1,__\n'
         }
 
         def dummy_file(file):
@@ -294,7 +320,7 @@ class TestMetisLinker:
         assert asdict(update1)['revisions'] == {
             'victim': {
                 'LABORS-LION-H2-C1': {
-                    'species': 'lion'
+                    'species': '__'
                 }
             }
         }
@@ -306,7 +332,7 @@ class TestMetisLinker:
             'victim': {
                 '::temp-id-0': {
                     'name': 'LABORS-LION-H2-C1',
-                    'species': 'lion'
+                    'species': '__'
                 }
             }
         }
@@ -314,8 +340,16 @@ class TestMetisLinker:
             'victim': {
                 '::temp-id-0': {
                     'name': 'LABORS-LION-H2-C1',
-                    'species': 'lion'
+                    'species': '__'
                 }
+            }
+        }
+
+        # given a 'good' config, with hole_value matching a value in the file, we get a shortened update
+        update5 = MetisLoaderConfig(**config1hole, rules=rules).update_for(tail, metis, model_std)
+        assert asdict(update5)['revisions'] == {
+            'victim': {
+                'LABORS-LION-H2-C1': {}
             }
         }
 

--- a/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
@@ -195,14 +195,24 @@ export const BlankTable = ({value, update, modelName, classes}:ScriptItem) => {
   </Typography>
 }
 
-export const HoleValue = ({value, update, modelName, classes}:ScriptItem) => {
+export const ValuesToIgnore = ({value, update, modelName, classes}:ScriptItem) => {
+  function displayTargetValues(value: string) {
+    // wrap each in 's unless empty string, and stress empty string
+    const targets = value.split(',')
+      .map(function(x) {
+        return ("'" + x + "'").replace(/^''$/, 'empty string')
+      })
+    const start = `${targets.length} Target${(targets.length > 1) ? 's' : ''}`
+    return `${start}: ` + (targets.join(", "))
+  }
   return <Grid item container>
-    <Grid item xs={3}>
+    <Grid item xs={6}>
       <TextField
-        label='Value to ignore when seen, e.g. NA'
+        placeholder={'comma separated list with space respected'}
         InputLabelProps={{shrink: true}}
         fullWidth
         value={value}
+        helperText={displayTargetValues(value as string)}
         onChange={
           (e: React.ChangeEvent<HTMLInputElement>) => update(e.target.value)
         }

--- a/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
@@ -203,7 +203,7 @@ export const ValuesToIgnore = ({value, update, modelName, classes}:ScriptItem) =
         return ("'" + x + "'").replace(/^''$/, 'empty string')
       })
     const start = `${targets.length} Target${(targets.length > 1) ? 's' : ''}`
-    return `${start}: ` + (targets.join(", "))
+    return `${start}: ` + (targets.join(', '))
   }
   return <Grid item container>
     <Grid item xs={6}>

--- a/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react';
 import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import Switch from '@material-ui/core/Switch';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 import {PickFolder} from 'etna-js/components/metis_exploration';
 
@@ -158,17 +158,41 @@ export const BlankTable = ({value, update, modelName, classes}:ScriptItem) => {
     update(true)
   }
 
-  return <Grid item container direction='column'>
-    <FormControlLabel
-      label="Blank Previous Values (Table models only)"
-      control={<Switch
-        checked={isTable && value}
+  const the_switch = <Grid item>
+      <Switch
+        checked={isTable && value} onChange={()=>update(!value)}
         disabled={!isTable}
-        onChange={()=>update(!value)}
         color="primary"
-      />}
-    />
-  </Grid>
+        />
+    </Grid>
+
+  return <Typography component="div">
+      {
+        isTable ?
+          <Grid item container direction='row'
+            component="label"
+            alignItems="center"
+            spacing={1}>
+            <Grid item>
+              Append to Previous Values
+            </Grid>
+            <Grid item>
+              {the_switch}
+            </Grid>
+            <Grid item>
+              Clear Previous Values
+            </Grid>
+          </Grid> :
+          <Grid item container direction='row' alignItems="center">
+            <Grid item>
+              {the_switch}
+            </Grid>
+            <Grid item>
+              Table Models Only
+            </Grid>
+          </Grid>
+      }
+  </Typography>
 }
 
 export const ColumnMap = ({value, update, modelName, classes}:ScriptItem) => {

--- a/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form-components.tsx
@@ -195,6 +195,22 @@ export const BlankTable = ({value, update, modelName, classes}:ScriptItem) => {
   </Typography>
 }
 
+export const HoleValue = ({value, update, modelName, classes}:ScriptItem) => {
+  return <Grid item container>
+    <Grid item xs={3}>
+      <TextField
+        label='Value to ignore when seen, e.g. NA'
+        InputLabelProps={{shrink: true}}
+        fullWidth
+        value={value}
+        onChange={
+          (e: React.ChangeEvent<HTMLInputElement>) => update(e.target.value)
+        }
+      />
+    </Grid>
+  </Grid>;
+}
+
 export const ColumnMap = ({value, update, modelName, classes}:ScriptItem) => {
 
   const {models} = useContext(MagmaContext);

--- a/polyphemus/lib/client/jsx/etl/metis-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form.tsx
@@ -24,7 +24,7 @@ import {PickBucket} from 'etna-js/components/metis_exploration';
 
 import {Script, Job} from '../polyphemus';
 import AddModel from './add-model';
-import { AttributeName, ColumnMap, DefaultItem, FileMatch, FolderPath, TableFormat, useMetisFormStyles, BlankTable } from './metis-form-components';
+import { AttributeName, ColumnMap, DefaultItem, FileMatch, FolderPath, TableFormat, useMetisFormStyles, BlankTable, HoleValue } from './metis-form-components';
 
 const SCRIPT_TYPES = [ 'file', 'file_collection', 'data_frame' ];
 
@@ -36,6 +36,7 @@ const SCRIPT_ITEMS = {
   column_map: ColumnMap,
   blank_table: BlankTable,
   // extracted_columns: ExtractedColumns,
+  hole_value: HoleValue,
   default: DefaultItem
 };
 

--- a/polyphemus/lib/client/jsx/etl/metis-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form.tsx
@@ -24,7 +24,7 @@ import {PickBucket} from 'etna-js/components/metis_exploration';
 
 import {Script, Job} from '../polyphemus';
 import AddModel from './add-model';
-import { AttributeName, ColumnMap, DefaultItem, FileMatch, FolderPath, TableFormat, useMetisFormStyles, BlankTable, HoleValue } from './metis-form-components';
+import { AttributeName, ColumnMap, DefaultItem, FileMatch, FolderPath, TableFormat, useMetisFormStyles, BlankTable, ValuesToIgnore } from './metis-form-components';
 
 const SCRIPT_TYPES = [ 'file', 'file_collection', 'data_frame' ];
 
@@ -36,7 +36,7 @@ const SCRIPT_ITEMS = {
   column_map: ColumnMap,
   blank_table: BlankTable,
   // extracted_columns: ExtractedColumns,
-  hole_value: HoleValue,
+  values_to_ignore: ValuesToIgnore,
   default: DefaultItem
 };
 

--- a/polyphemus/lib/etls/metis/loader.rb
+++ b/polyphemus/lib/etls/metis/loader.rb
@@ -95,7 +95,7 @@ module Metis
                 minProperties: 2,
                 additionalProperties: { type: "string" }
               },
-              hole_value: {type: "string"}
+              values_to_ignore: {type: "string"}
             },
             required: ["type", "folder_path", "file_match", "format", "column_map"]
           }

--- a/polyphemus/lib/etls/metis/loader.rb
+++ b/polyphemus/lib/etls/metis/loader.rb
@@ -94,7 +94,8 @@ module Metis
                 type: "object",
                 minProperties: 2,
                 additionalProperties: { type: "string" }
-              }
+              },
+              hole_value: {type: "string"}
             },
             required: ["type", "folder_path", "file_match", "format", "column_map"]
           }

--- a/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
+++ b/vulcan/lib/server/workflows/scripts/VIZ_file_df.py
@@ -10,7 +10,7 @@ file = File(
     file_path=fileInfo['path'], project_name=project_name, bucket_name=fileInfo['bucket'], download_url = None
 )
 
-separator = "\\t"
+separator = "\t"
 if re.search("csv$", file.file_path) is not None:
     separator = ","
 


### PR DESCRIPTION
## This PR:
- adds a 'hole_value' textfield to the data-frame loader config
  - Relatedly, turns off pandas' default na filtration when the data_frame is loaded in to not create additional, hidden to the user, 'hole_value' ignorance.  Importantly, this means that this loader can functionally be used to fill attributes as "NA" / "N/A" / "null" if wanted by the user.  All of these examples are treated as missing data by pandas.read_table in the default behavior that's turned off here.
- Adjusts the labeling of the 'blank_table' switch

### 'hole_value' UI:
![image](https://github.com/mountetna/monoetna/assets/38870347/7980f44c-7bcc-4779-98d4-3111dbf3cb1b)

### Previous 'blank_table' look:
non-table model
![image](https://github.com/mountetna/monoetna/assets/38870347/1e13f36b-93f8-4062-afbe-fde74de92bef)
table model
![image](https://github.com/mountetna/monoetna/assets/38870347/8d9d1e39-3083-44e1-8d85-7163b24b2c77)

### NEW 'blank_table' look:
non-table model
![image](https://github.com/mountetna/monoetna/assets/38870347/262bd16e-d510-461d-af5a-f0077f5cb9c9)
table model
![image](https://github.com/mountetna/monoetna/assets/38870347/cd8a5a07-a531-4710-91ed-bad1e2da6a66)
