### PR TITLE
bulk create API

### DIFF
--- a/magma/lib/magma/server.rb
+++ b/magma/lib/magma/server.rb
@@ -34,6 +34,7 @@ class Magma
     get '/gnomon/:project_name/list/:rule_name', action: 'gnomon#list', auth: { user: { can_view?: :project_name } }
     get '/gnomon/:project_name/rule/:rule_name', action: 'gnomon#rule', auth: { user: { can_view?: :project_name } }
     post '/gnomon/:project_name/generate/:rule_name/:identifier', action: 'gnomon#generate', auth: { user: { is_admin?: :project_name } }
+    post '/gnomon/:project_name/generate', action: 'gnomon#bulk_generate', auth: { user: { is_admin?: :project_name } }
 
     get '/' do
       [ 200, {}, [ 'Magma is available.' ] ]


### PR DESCRIPTION
This adds a bulk generate API for Gnomon, which mostly behaves like the existing generate API, except that it accepts a list of names and rules and returns only names that were generated (or various 422s).