### PR TITLE
Add autolink parent identifiers option to metis linkers

### DIFF
--- a/airflow/opt/providers/etna/etna/etls/metis_linker.py
+++ b/airflow/opt/providers/etna/etna/etls/metis_linker.py
@@ -64,8 +64,6 @@ class MetisLoaderConfig(EtlConfigResponse):
             if match.match(file.file_path)
         ]
         return files
-        
-
 
     def data_frame_update(self, model_name, script, tail, update, metis, model):
         isTable=model['isTable']
@@ -173,7 +171,7 @@ class MetisLoaderConfig(EtlConfigResponse):
             )
 
     def update_for(self, tail, metis=None, models=None):
-        update = UpdateRequest(project_name=self.project_name, dry_run=(not self.params.get('commit', False)))
+        update = UpdateRequest(project_name=self.project_name, dry_run=(not self.params.get('commit', False)), autolink = self.config.get('autolink', False))
 
         for model_name, model_config in self.config.get("models",{}).items():
             for script in model_config.get("scripts",[]):
@@ -319,6 +317,7 @@ Job failed with error: {i['error']}
 Upload Summary : {i['start']} -> {i['end']} 
 Models: {', '.join(i['response'].models.keys())}
 Committed to Magma: {i['commit']}
+Autolinked Parent Identifiers: {i['autolink']}
 '''
             for model_name, model in i['response'].models.items():
                 summary += f"{model_name} records updated: {', '.join(model.documents.keys())}\n"
@@ -336,7 +335,6 @@ Committed to Magma: {i['commit']}
                     if 'error' in updates[ config.config_id ]:
                         raise Exception(updates[ config.config_id ]['error'])
 
-                    commit = config.params.get('commit', False)
                     with hook.magma() as magma:
                         response = magma.update(updates[ config.config_id ], page_size=1000)
 
@@ -359,7 +357,8 @@ Committed to Magma: {i['commit']}
                             output=upload_report(
                                 project_name=config.project_name,
                                 response=response,
-                                commit=commit,
+                                commit=config.params.get('commit', False),
+                                autolink=config.config.get('autolink', False),
                                 start=start,
                                 end=end
                             )

--- a/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
+++ b/airflow/opt/providers/etna/etna/tests/test_metis_linker.py
@@ -147,6 +147,7 @@ class TestMetisLinker:
             "project_name": "labors",
             "config": {
                 "bucket_name": "pics",
+                "autolink": True,
                 "models": {
                     "victim": {
                         "scripts": [
@@ -172,6 +173,7 @@ class TestMetisLinker:
             "project_name": "labors",
             "config": {
                 "bucket_name": "pics",
+                "autolink": True,
                 "models": {
                     "victim": {
                         "scripts": [
@@ -200,6 +202,7 @@ class TestMetisLinker:
             "project_name": "labors",
             "config": {
                 "bucket_name": "pics",
+                "autolink": True,
                 "models": {
                     "victim": {
                         "scripts": [
@@ -225,6 +228,7 @@ class TestMetisLinker:
             "project_name": "labors",
             "config": {
                 "bucket_name": "pics",
+                "autolink": True,
                 "models": {
                     "victim": {
                         "scripts": [
@@ -250,6 +254,7 @@ class TestMetisLinker:
             "project_name": "labors",
             "config": {
                 "bucket_name": "pics",
+                "autolink": True,
                 "models": {
                     "victim": {
                         "scripts": [
@@ -362,6 +367,11 @@ class TestMetisLinker:
                 'LABORS-LION-H2-C1': {}
             }
         }
+
+        # autolink and dry_run carry through
+        update6 = MetisLoaderConfig(**config1, rules=rules, params={"commit": False}).update_for(tail, metis, model_std)
+        assert asdict(update1)['dry_run'] == True
+        assert asdict(update1)['autolink'] == True
 
         # Note that path3 also makes use of auto file format detection, but is expected to fail later, after the data_frame is read in and found to be missing a mapped column.
         with raises(MetisLoaderError, match=r"missing column.*species"):

--- a/docker/archimedes-base/Dockerfile
+++ b/docker/archimedes-base/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
       --no-install-recommends
 
 # add postgres 10 repo for debian bionic
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update \

--- a/docker/archimedes-base/Dockerfile
+++ b/docker/archimedes-base/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
       --no-install-recommends
 
 # add postgres 10 repo for debian bionic
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update \

--- a/docker/archimedes-node-base/Dockerfile
+++ b/docker/archimedes-node-base/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
       --no-install-recommends
 
 # add postgres 10 repo for debian bionic
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update \

--- a/docker/archimedes-node-base/Dockerfile
+++ b/docker/archimedes-node-base/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
       --no-install-recommends
 
 # add postgres 10 repo for debian bionic
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update \

--- a/docker/etna-base-dev/Dockerfile
+++ b/docker/etna-base-dev/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=0 /certs/rootCA.pem /usr/local/share/ca-certificates/devRoot.crt
 RUN chmod 644 /usr/local/share/ca-certificates/devRoot.crt && update-ca-certificates
 
 # add postgres 10 repo for debian bionic
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get update \

--- a/etna/packages/etna-js/components/metis_exploration.tsx
+++ b/etna/packages/etna-js/components/metis_exploration.tsx
@@ -55,7 +55,7 @@ export function PickBucket({ project_name=CONFIG.project_name, setBucket, bucket
   project_name?: string;
   setBucket: any;
   bucket: string;
-  label?: string;
+  label?: string | null;
   className?: string;
   disablePortal?: boolean;
 }){

--- a/etna/packages/etna-js/components/metis_exploration.tsx
+++ b/etna/packages/etna-js/components/metis_exploration.tsx
@@ -94,7 +94,7 @@ export function PickBucket({ project_name=CONFIG.project_name, setBucket, bucket
           onInputChange={(event: any, newInputState: string) => {
             setInputState(newInputState);
           }}
-          style={{paddingTop: label!==undefined ? 8 : undefined}}
+          style={{paddingTop: label!=undefined ? 8 : undefined}}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/etna/packages/etna-py/src/mountetna/magma.py
+++ b/etna/packages/etna-py/src/mountetna/magma.py
@@ -67,6 +67,7 @@ class UpdateRequest:
     )
     project_name: str = ""
     dry_run: bool = False
+    autolink: bool = False
 
     def __bool__(self):
         return not self.empty()
@@ -293,14 +294,14 @@ class Pager:
 
             if page_count > page_size:
                 results.extend(
-                    self.magma.update(UpdateRequest(project_name=update.project_name, revisions=page))
+                    self.magma.update(UpdateRequest(project_name=update.project_name, revisions=page, dry_run=update.dry_run, autolink=update.autolink))
                 )
 
                 page = {}
                 page_count = 0
 
         results.extend(
-            self.magma.update(UpdateRequest(project_name=update.project_name, revisions=page))
+            self.magma.update(UpdateRequest(project_name=update.project_name, revisions=page, dry_run=update.dry_run, autolink=update.autolink))
         )
 
         return results

--- a/etna/packages/etna-py/src/mountetna/tests/test_magma.py
+++ b/etna/packages/etna-py/src/mountetna/tests/test_magma.py
@@ -60,7 +60,7 @@ def test_magma_update(project_template: Dict, labor_template: Dict):
 
 @responses.activate
 def test_magma_update_pages(labor_template: Dict):
-    ''' it updates records in magma by pages'''
+    ''' it updates records in magma by pages, with dry_run and autolink passed through'''
     responses.add(
         responses.POST,
         "https://magma.test/update",
@@ -100,9 +100,28 @@ def test_magma_update_pages(labor_template: Dict):
         "The Lernean Hydra" : { "country" : "Lerna" },
         "The Ceryneian Hind" : { "country" : "Ceryneia" },
         "The Erymanthian Boar" : { "country" : "Erymanthia" }
-    } } }), page_size=2 )
+    } },
+    "dry_run": True, "autolink": True}), page_size=2 )
 
     assert responses.assert_call_count("https://magma.test/update", 2) is True
+    len_calls=len(responses.calls)
+    last2=[len_calls-2, len_calls-1]
+    assert all(['"dry_run":true' in str(responses.calls[i].request.body) for i in last2]) is True
+    assert all(['"autolink":true' in str(responses.calls[i].request.body) for i in last2]) is True
+
+    response = client.update(UpdateRequest(**{ "project_name":"ipi", "revisions": { "labor": {
+        "The Nemean Lion" : { "country" : "Nemea" },
+        "The Lernean Hydra" : { "country" : "Lerna" },
+        "The Ceryneian Hind" : { "country" : "Ceryneia" },
+        "The Erymanthian Boar" : { "country" : "Erymanthia" }
+    } },
+    "dry_run": False, "autolink": False}), page_size=2 )
+
+    assert responses.assert_call_count("https://magma.test/update", 4) is True
+    len_calls=len(responses.calls)
+    last2=[len_calls-2, len_calls-1]
+    assert all(['"dry_run":false' in str(responses.calls[i].request.body) for i in last2]) is True
+    assert all(['"autolink":false' in str(responses.calls[i].request.body) for i in last2]) is True
 
 @responses.activate
 def test_magma_query():

--- a/magma/lib/magma/loader.rb
+++ b/magma/lib/magma/loader.rb
@@ -204,9 +204,6 @@ class Magma
 
           return unless flag_value == gnomon_mode[:identifier] || flag_value == gnomon_mode[:pattern]
 
-          # Do not auto attach disconnected records
-          next if record.explicitly_disconnected_from_parent?
-
           # Attempt to find parent models
           parent_models = find_parent_models(record_name)
           next if parent_models.empty?

--- a/magma/lib/magma/server/update.rb
+++ b/magma/lib/magma/server/update.rb
@@ -25,7 +25,7 @@ class UpdateController < Magma::Controller
       end
     end
     @loader.push_implicit_link_revisions(@revisions)
-    @loader.autolink_parent_identifiers
+    @loader.autolink_parent_identifiers if @params[:autolink]
     return @loader.dispatch_record_set
   rescue Magma::LoadFailed => m
     log(m.complaints)

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -22,7 +22,7 @@ describe UpdateController do
     @project = create(:project, name: 'The Twelve Labors of Hercules')
   end
 
-  def update(revisions, user_type=:editor, params: {autolink: True})
+  def update(revisions, user_type=:editor, params: {autolink: TRUE})
     auth_header(user_type)
     json_post(:update, {project_name: 'labors', revisions: revisions}.update(params))
   end

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -22,7 +22,7 @@ describe UpdateController do
     @project = create(:project, name: 'The Twelve Labors of Hercules')
   end
 
-  def update(revisions, user_type=:editor, params: {})
+  def update(revisions, user_type=:editor, params: {autolink: True})
     auth_header(user_type)
     json_post(:update, {project_name: 'labors', revisions: revisions}.update(params))
   end

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -1375,6 +1375,37 @@ describe UpdateController do
 
         end
 
+        it 'does not happen when autolink param not given (default!)' do
+
+          create(:flag, :gnomon_identifier)
+          grammar = create(:grammar, { project_name: 'labors', version_number: 1, config: HIERARCHY_GRAMMAR_CONFIG, comment: 'update' })
+
+          project_identifier = create_identifier("The Twelve Labors of Hercules", rule: 'project', grammar: grammar)
+          labor_identifier = create_identifier("The Nemean Lion", rule: 'labor', grammar: grammar)
+          monster_identifier = create_identifier("LABORS-LION-NEMEAN", rule: 'monster', grammar: grammar)
+          victim_identifier = create_identifier("LABORS-LION-NEMEAN-H2-C1", rule: 'victim', grammar: grammar)
+
+          expect(Labors::Labor.count).to be(0)
+          expect(Labors::Victim.count).to be(0)
+          expect(Labors::Monster.count).to be(0)
+
+          update(
+            victim: {
+              victim_identifier.identifier => { weapon: 'sword' }
+            },
+            params: {autolink: false}
+          )
+
+          expect(last_response.status).to eq(200)
+
+          expect(Labors::Victim.first.weapon).to eq('sword')
+          expect(Labors::Victim.first.name).to eq(victim_identifier.identifier)
+          expect(Labors::Labor.count).to be(0)
+          expect(Labors::Victim.count).to be(1)
+          expect(Labors::Monster.count).to be(0)
+
+        end
+
         it 'rejects all updates when a hierarchical grammar exists but identifiers do not exist' do
 
           create(:flag, :gnomon_identifier)
@@ -1530,6 +1561,36 @@ describe UpdateController do
           expect(Labors::Labor.first.project_id).to eq(Labors::Project.first.id)
           expect(Labors::Project.first.name).to eq(project_identifier)
         end
+
+        it 'does not happen when autolink param not given (default!)' do
+
+          create(:flag, :gnomon_pattern)
+          grammar = create(:grammar, { project_name: 'labors', version_number: 1, config: HIERARCHY_GRAMMAR_CONFIG, comment: 'update' })
+
+          project_identifier = "The Twelve Labors of Hercules"
+          labor_identifier = "The Nemean Lion"
+          monster_identifier = "LABORS-LION-NEMEAN"
+          victim_identifier = "LABORS-LION-NEMEAN-H2-C1"
+
+          expect(Labors::Labor.count).to be(0)
+          expect(Labors::Victim.count).to be(0)
+          expect(Labors::Monster.count).to be(0)
+
+          update(
+            victim: {
+              victim_identifier => { weapon: 'sword' }
+            },
+            params: {autolink: false}
+          )
+
+          expect(last_response.status).to eq(200)
+
+          expect(Labors::Victim.first.weapon).to eq('sword')
+          expect(Labors::Victim.first.name).to eq(victim_identifier.identifier)
+          expect(Labors::Labor.count).to be(0)
+          expect(Labors::Victim.count).to be(1)
+          expect(Labors::Monster.count).to be(0)
+        end
       end
     end
 
@@ -1552,7 +1613,8 @@ describe UpdateController do
         update(
           victim: {
             victim_identifier => { monster: nil }
-          }
+          },
+          params: {autolink: false}
         )
 
         expect(last_response.status).to eq(200)
@@ -3523,7 +3585,7 @@ describe UpdateController do
       expect(last_response.status).to eq(200)
 
       output = <<EOT
-WARN:2000-01-01T00:00:00+00:00 8fzmq8 User copreus@twelve-labors.org calling update#action with params {:project_name=>"labors", :revisions=>{:victim=>{:"John Doe"=>{:birthday=>"*"}}}}
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User copreus@twelve-labors.org calling update#action with params {:project_name=>"labors", :revisions=>{:victim=>{:"John Doe"=>{:birthday=>"*"}}}, :autolink=>\"true\"}
 EOT
 
       expect(File.read(@log_file)).to eq(output)
@@ -3548,7 +3610,7 @@ EOT
 
       output = <<EOT
 WARN:2000-01-01T00:00:00+00:00 8fzmq8 ["Cannot revise restricted attribute :birthday on victim 'John Doe'"]
-WARN:2000-01-01T00:00:00+00:00 8fzmq8 User eurystheus@twelve-labors.org calling update#action with params {:project_name=>"labors", :revisions=>{:victim=>{:"John Doe"=>{:birthday=>"*"}}}}
+WARN:2000-01-01T00:00:00+00:00 8fzmq8 User eurystheus@twelve-labors.org calling update#action with params {:project_name=>"labors", :revisions=>{:victim=>{:"John Doe"=>{:birthday=>"*"}}}, :autolink=>\"true\"}
 EOT
 
       expect(File.read(@log_file)).to eq(output)

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -22,7 +22,7 @@ describe UpdateController do
     @project = create(:project, name: 'The Twelve Labors of Hercules')
   end
 
-  def update(revisions, user_type=:editor, params: {autolink: TRUE})
+  def update(revisions, user_type=:editor, params: {autolink: true})
     auth_header(user_type)
     json_post(:update, {project_name: 'labors', revisions: revisions}.update(params))
   end

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -1389,11 +1389,11 @@ describe UpdateController do
           expect(Labors::Victim.count).to be(0)
           expect(Labors::Monster.count).to be(0)
 
-          update(
+          update({
             victim: {
               victim_identifier.identifier => { weapon: 'sword' }
-            },
-            params: {autolink: false}
+            }},
+            params: {}
           )
 
           expect(last_response.status).to eq(200)
@@ -1576,17 +1576,17 @@ describe UpdateController do
           expect(Labors::Victim.count).to be(0)
           expect(Labors::Monster.count).to be(0)
 
-          update(
+          update({
             victim: {
               victim_identifier => { weapon: 'sword' }
-            },
-            params: {autolink: false}
+            }},
+            params: {}
           )
 
           expect(last_response.status).to eq(200)
 
           expect(Labors::Victim.first.weapon).to eq('sword')
-          expect(Labors::Victim.first.name).to eq(victim_identifier.identifier)
+          expect(Labors::Victim.first.name).to eq(victim_identifier)
           expect(Labors::Labor.count).to be(0)
           expect(Labors::Victim.count).to be(1)
           expect(Labors::Monster.count).to be(0)
@@ -1610,10 +1610,10 @@ describe UpdateController do
         )
 
         # Detach the child
-        update(
+        update({
           victim: {
             victim_identifier => { monster: nil }
-          },
+          }},
           params: {autolink: false}
         )
 

--- a/polyphemus/lib/client/jsx/etl/metis-form.tsx
+++ b/polyphemus/lib/client/jsx/etl/metis-form.tsx
@@ -18,6 +18,8 @@ import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CopyIcon from '@material-ui/icons/FileCopy';
 import Pagination from '@material-ui/lab/Pagination';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 import {SchemaContext, SchemaProvider} from './schema-context';
 import {PickBucket} from 'etna-js/components/metis_exploration';
@@ -309,6 +311,7 @@ const MetisModel = ({
 
 export type Config = {
   bucket_name: string,
+  autolink: boolean,
   models: { [modelName: string]: Model };
 };
 
@@ -360,13 +363,36 @@ const MetisForm = ({
     [config, update]
   )
 
+  const setAutoLink = useCallback(
+    (autolink: boolean) => {
+      let c = {...config, autolink };
+      update(c as Config);
+    },
+    [config, update]
+  )
+
   const modelConfig = useMemo(() => {
     return configModels[modelName];
   }, [config, modelName]);
 
   return (
     <Grid container className={classes.form} direction='column'>
-      <Grid item container className={classes.bucket_name}><PickBucket setBucket={setBucket} project_name={project_name} bucket={bucket_name}/></Grid>
+      <Grid item container>
+        <Grid item xs={3} style={{paddingLeft:'10px'}}>Autolink Parent Identifiers</Grid>
+        <Grid item xs={9}>
+          <Switch
+            checked={config.autolink}
+            onChange={()=>setAutoLink(!config.autolink)}
+            color="primary"
+          />
+        </Grid>
+      </Grid>
+      <Grid item container>
+        <Grid item xs={3} style={{paddingLeft:'10px'}}>Bucket</Grid>
+        <Grid item xs={9}>
+          <PickBucket setBucket={setBucket} project_name={project_name} bucket={bucket_name} label={null}/>
+        </Grid>
+      </Grid>
       <Grid item container className={classes.tabs}>
         <Grid item className={classes.tab_scroll}>
           <Tabs

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -22,7 +22,6 @@ import Paper from '@material-ui/core/Paper';
 
 import {runTime} from './etl/run-state';
 import {MagmaContext} from 'etna-js/contexts/magma-context';
-import { ReactElement } from 'react';
 
 const useStyles = makeStyles((theme) => ({
   etls: {
@@ -172,82 +171,76 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     }, [ orderBy, order ]
   );
 
-  let add_button: ReactElement = null
-  let primary_contents: ReactElement = <></>
-  if (selected && selectedEtl) {
-    primary_contents = <EtlConfig
-      {...selectedEtl}
-      onUpdate={addEtl}
-      job={jobs.find((j) => j.name == selectedEtl?.etl)}
-    />
-  } else {
-    add_button = <Grid item>
-      <Button disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Add Loader</Button>
-      <EtlCreate
-        project_name={project_name}
-        open={create}
-        onClose={() => setCreate(false)}
-        onCreate={addEtl}
-        jobs={jobs}
-      />
-    </Grid>
-    primary_contents = <TableContainer className={classes.etl_list}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            {headCells.map((cell) =>
-            <TableCell key={cell.id}
-              align={cell.align}
-              sortDirection={ orderBy === cell.id ? order : 'asc' }>
-              <TableSortLabel
-                active={ orderBy === cell.id }
-                direction={ orderBy === cell.id ? order : 'asc' }
-                onClick={ () => sortBy(cell.id) }>
-                {cell.id}
-              </TableSortLabel>
-            </TableCell>
-            )}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {etls
-            .sort((a, b) => compareBy(a, b))
-            .map((etl: Etl) => (
-              <EtlConfigRow
-                key={etl.name}
-                {...etl}
-                onClick={ () => setSelected(etl.config_id) }
-                job={jobs.find((j) => j.name == etl.etl)}
-              />
-            ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  }
-
   return (
     <Grid id='polyphemus-main'>
       {!jobs ? null : (
         <Grid className={classes.etls} item xs={12}>
-          <Grid item container direction alignItems="center">
-            <Grid item xs={5}>
-              <Breadcrumbs className={classes.title}>
-                <Typography>
-                  {project_name}
-                </Typography>
-                {
-                  selected
-                  ? <Typography className={classes.link} onClick={ () => setSelected(null) }>data loaders</Typography>
-                  : <Typography>data loaders</Typography>
-                }
-                {
-                  selected ? <Typography>{ selectedEtl?.name }</Typography> : null
-                }
-              </Breadcrumbs>
-            </Grid>
-            {add_button}
-          </Grid>
-          {primary_contents}
+          <Breadcrumbs className={classes.title}>
+            <Typography>
+              {project_name}
+            </Typography>
+            {
+              selected
+              ? <Typography className={classes.link} onClick={ () => setSelected(null) }>data loaders</Typography>
+              : <Typography>data loaders</Typography>
+            }
+            {
+              selected ? <Typography>{ selectedEtl?.name }</Typography> : null
+            }
+          </Breadcrumbs>
+          {
+            selected && selectedEtl
+            ? <EtlConfig
+                {...selectedEtl}
+                onUpdate={addEtl}
+                job={jobs.find((j) => j.name == selectedEtl?.etl)}
+              />
+            :
+              <TableContainer className={classes.etl_list}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      {headCells.map((cell) =>
+                      <TableCell key={cell.id}
+                        align={cell.align}
+                        sortDirection={ orderBy === cell.id ? order : 'asc' }>
+                        <TableSortLabel
+                          active={ orderBy === cell.id }
+                          direction={ orderBy === cell.id ? order : 'asc' }
+                          onClick={ () => sortBy(cell.id) }>
+                          {cell.id}
+                        </TableSortLabel>
+                      </TableCell>
+                      )}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {etls
+                      .sort((a, b) => compareBy(a, b))
+                      .map((etl: Etl) => (
+                        <EtlConfigRow
+                          key={etl.name}
+                          {...etl}
+                          onClick={ () => setSelected(etl.config_id) }
+                          job={jobs.find((j) => j.name == etl.etl)}
+                        />
+                      ))}
+                    <TableRow key='add-loader' className={classes.etlrow}>
+                      <Grid style={{padding: '5px'}}>
+                        <Button onClick={() => setCreate(true)}>Add Loader</Button>
+                        <EtlCreate
+                          project_name={project_name}
+                          open={create}
+                          onClose={() => setCreate(false)}
+                          onCreate={addEtl}
+                          jobs={jobs}
+                        />
+                      </Grid>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+          }
         </Grid>
       )}
     </Grid>

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -29,8 +29,7 @@ const useStyles = makeStyles((theme) => ({
   },
   etl_list: {
     border: '1px solid #ccc',
-    height: 'calc(100vh - 160px)',
-    marginBottom: '5px'
+    height: 'calc(100vh - 127px)'
   },
   title: {
     padding: '15px',

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -22,6 +22,7 @@ import Paper from '@material-ui/core/Paper';
 
 import {runTime} from './etl/run-state';
 import {MagmaContext} from 'etna-js/contexts/magma-context';
+import { ReactElement } from 'react';
 
 const useStyles = makeStyles((theme) => ({
   etls: {
@@ -171,76 +172,82 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     }, [ orderBy, order ]
   );
 
+  let add_button: ReactElement = null
+  let primary_contents: ReactElement = <></>
+  if (selected && selectedEtl) {
+    primary_contents = <EtlConfig
+      {...selectedEtl}
+      onUpdate={addEtl}
+      job={jobs.find((j) => j.name == selectedEtl?.etl)}
+    />
+  } else {
+    add_button = <Grid item>
+      <Button disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Add Loader</Button>
+      <EtlCreate
+        project_name={project_name}
+        open={create}
+        onClose={() => setCreate(false)}
+        onCreate={addEtl}
+        jobs={jobs}
+      />
+    </Grid>
+    primary_contents = <TableContainer className={classes.etl_list}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {headCells.map((cell) =>
+            <TableCell key={cell.id}
+              align={cell.align}
+              sortDirection={ orderBy === cell.id ? order : 'asc' }>
+              <TableSortLabel
+                active={ orderBy === cell.id }
+                direction={ orderBy === cell.id ? order : 'asc' }
+                onClick={ () => sortBy(cell.id) }>
+                {cell.id}
+              </TableSortLabel>
+            </TableCell>
+            )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {etls
+            .sort((a, b) => compareBy(a, b))
+            .map((etl: Etl) => (
+              <EtlConfigRow
+                key={etl.name}
+                {...etl}
+                onClick={ () => setSelected(etl.config_id) }
+                job={jobs.find((j) => j.name == etl.etl)}
+              />
+            ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  }
+
   return (
     <Grid id='polyphemus-main'>
       {!jobs ? null : (
         <Grid className={classes.etls} item xs={12}>
-          <Breadcrumbs className={classes.title}>
-            <Typography>
-              {project_name}
-            </Typography>
-            {
-              selected
-              ? <Typography className={classes.link} onClick={ () => setSelected(null) }>data loaders</Typography>
-              : <Typography>data loaders</Typography>
-            }
-            {
-              selected ? <Typography>{ selectedEtl?.name }</Typography> : null
-            }
-          </Breadcrumbs>
-          {
-            selected && selectedEtl
-            ? <EtlConfig
-                {...selectedEtl}
-                onUpdate={addEtl}
-                job={jobs.find((j) => j.name == selectedEtl?.etl)}
-              />
-            :
-              <TableContainer className={classes.etl_list}>
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      {headCells.map((cell) =>
-                      <TableCell key={cell.id}
-                        align={cell.align}
-                        sortDirection={ orderBy === cell.id ? order : 'asc' }>
-                        <TableSortLabel
-                          active={ orderBy === cell.id }
-                          direction={ orderBy === cell.id ? order : 'asc' }
-                          onClick={ () => sortBy(cell.id) }>
-                          {cell.id}
-                        </TableSortLabel>
-                      </TableCell>
-                      )}
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {etls
-                      .sort((a, b) => compareBy(a, b))
-                      .map((etl: Etl) => (
-                        <EtlConfigRow
-                          key={etl.name}
-                          {...etl}
-                          onClick={ () => setSelected(etl.config_id) }
-                          job={jobs.find((j) => j.name == etl.etl)}
-                        />
-                      ))}
-                    <TableRow key='add-loader' className={classes.etlrow}>
-                      <Grid style={{padding: '5px'}}>
-                        <Button onClick={() => setCreate(true)}>Add Loader</Button>
-                        <EtlCreate
-                          project_name={project_name}
-                          open={create}
-                          onClose={() => setCreate(false)}
-                          onCreate={addEtl}
-                          jobs={jobs}
-                        />
-                      </Grid>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </TableContainer>
-          }
+          <Grid item container direction alignItems="center">
+            <Grid item xs={5}>
+              <Breadcrumbs className={classes.title}>
+                <Typography>
+                  {project_name}
+                </Typography>
+                {
+                  selected
+                  ? <Typography className={classes.link} onClick={ () => setSelected(null) }>data loaders</Typography>
+                  : <Typography>data loaders</Typography>
+                }
+                {
+                  selected ? <Typography>{ selectedEtl?.name }</Typography> : null
+                }
+              </Breadcrumbs>
+            </Grid>
+            {add_button}
+          </Grid>
+          {primary_contents}
         </Grid>
       )}
     </Grid>

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -196,7 +196,7 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
                 onUpdate={addEtl}
                 job={jobs.find((j) => j.name == selectedEtl?.etl)}
               />
-            : <>
+            :
               <TableContainer className={classes.etl_list}>
                 <Table size="small">
                   <TableHead>
@@ -226,20 +226,21 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
                           job={jobs.find((j) => j.name == etl.etl)}
                         />
                       ))}
+                    <TableRow key='add-loader' className={classes.etlrow}>
+                      <Grid style={{padding: '5px'}}>
+                        <Button onClick={() => setCreate(true)}>Add Loader</Button>
+                        <EtlCreate
+                          project_name={project_name}
+                          open={create}
+                          onClose={() => setCreate(false)}
+                          onCreate={addEtl}
+                          jobs={jobs}
+                        />
+                      </Grid>
+                    </TableRow>
                   </TableBody>
                 </Table>
               </TableContainer>
-              <Grid>
-                <Button onClick={() => setCreate(true)}>Add Loader</Button>
-                <EtlCreate
-                  project_name={project_name}
-                  open={create}
-                  onClose={() => setCreate(false)}
-                  onCreate={addEtl}
-                  jobs={jobs}
-                />
-              </Grid>
-            </>
           }
         </Grid>
       )}

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -196,7 +196,7 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
                 onUpdate={addEtl}
                 job={jobs.find((j) => j.name == selectedEtl?.etl)}
               />
-            :
+            : <>
               <TableContainer className={classes.etl_list}>
                 <Table size="small">
                   <TableHead>
@@ -226,21 +226,20 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
                           job={jobs.find((j) => j.name == etl.etl)}
                         />
                       ))}
-                    <TableRow key='add-loader' className={classes.etlrow}>
-                      <Grid style={{padding: '5px'}}>
-                        <Button onClick={() => setCreate(true)}>Add Loader</Button>
-                        <EtlCreate
-                          project_name={project_name}
-                          open={create}
-                          onClose={() => setCreate(false)}
-                          onCreate={addEtl}
-                          jobs={jobs}
-                        />
-                      </Grid>
-                    </TableRow>
                   </TableBody>
                 </Table>
               </TableContainer>
+              <Grid>
+                <Button onClick={() => setCreate(true)}>Add Loader</Button>
+                <EtlCreate
+                  project_name={project_name}
+                  open={create}
+                  onClose={() => setCreate(false)}
+                  onCreate={addEtl}
+                  jobs={jobs}
+                />
+              </Grid>
+            </>
           }
         </Grid>
       )}

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -29,7 +29,8 @@ const useStyles = makeStyles((theme) => ({
   },
   etl_list: {
     border: '1px solid #ccc',
-    height: 'calc(100vh - 127px)'
+    height: 'calc(100vh - 160px)',
+    marginBottom: '5px'
   },
   title: {
     padding: '15px',

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -18,7 +18,8 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 import TableRow from '@material-ui/core/TableRow';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
-import Paper from '@material-ui/core/Paper';
+import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
+import Tooltip from '@material-ui/core/Tooltip';
 
 import {runTime} from './etl/run-state';
 import {MagmaContext} from 'etna-js/contexts/magma-context';
@@ -182,7 +183,9 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     />
   } else {
     add_button = <Grid item>
-      <Button disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Add Loader</Button>
+      <Tooltip title='Add New Loader' aria-label='Add New Loader' placement="top">
+        <Button startIcon={<LibraryAddIcon />} disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Loader</Button>
+      </Tooltip>
       <EtlCreate
         project_name={project_name}
         open={create}
@@ -229,7 +232,7 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     <Grid id='polyphemus-main'>
       {!jobs ? null : (
         <Grid className={classes.etls} item xs={12}>
-          <Grid item container direction alignItems="center">
+          <Grid item container alignItems="center">
             <Grid item xs={5}>
               <Breadcrumbs className={classes.title}>
                 <Typography>

--- a/polyphemus/lib/client/jsx/polyphemus-main.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-main.tsx
@@ -18,8 +18,7 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 import TableRow from '@material-ui/core/TableRow';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
-import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
-import Tooltip from '@material-ui/core/Tooltip';
+import Paper from '@material-ui/core/Paper';
 
 import {runTime} from './etl/run-state';
 import {MagmaContext} from 'etna-js/contexts/magma-context';
@@ -183,9 +182,7 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     />
   } else {
     add_button = <Grid item>
-      <Tooltip title='Add New Loader' aria-label='Add New Loader' placement="top">
-        <Button startIcon={<LibraryAddIcon />} disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Loader</Button>
-      </Tooltip>
+      <Button disabled={selected && selectedEtl} onClick={() => setCreate(true)}>Add Loader</Button>
       <EtlCreate
         project_name={project_name}
         open={create}
@@ -232,7 +229,7 @@ const PolyphemusMain = ({project_name}: {project_name: string}) => {
     <Grid id='polyphemus-main'>
       {!jobs ? null : (
         <Grid className={classes.etls} item xs={12}>
-          <Grid item container alignItems="center">
+          <Grid item container direction alignItems="center">
             <Grid item xs={5}>
               <Breadcrumbs className={classes.title}>
                 <Typography>

--- a/polyphemus/lib/etls/metis/loader.rb
+++ b/polyphemus/lib/etls/metis/loader.rb
@@ -14,6 +14,7 @@ module Metis
 	type: "object",
         properties: {
           bucket_name: { type: "string" },
+          autolink: { type: "boolean" },
           models: {
             type: "object",
             additionalProperties: {


### PR DESCRIPTION
Adds a top-level toggle to metis loaders which controls whether parent identifiers get automatically created.

Also touches:
- magma update route to add the `autolink` param & remove previous code that would always block this path
- etna PickBucket component to be able to remove its label via explicitly setting `label={null}`
- corrects a bug in the update pagination to send the dry_run and autolink inputs through

ToDo:
- [x] tests
  - [x] magma update itself
  - [x] metis_linker (that pushes through this autolink bit + dry_run from the "commit"-toggle
  - [x] that magma update pagination etna-py passes the autolink + dry_run settings with each update 