### PR TITLE
This PR attempts to fix a build issue within swarm-keeper

### DIFF
--- a/swarm/swarm-keeper/Dockerfile
+++ b/swarm/swarm-keeper/Dockerfile
@@ -4,7 +4,7 @@ FROM etna-base-dev
 FROM alpine
 RUN mkdir /app
 RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client vim
-RUN pip install -U requests[socks] yq rich
+RUN pip install -U --break-system-packages requests[socks] yq rich
 COPY lib/* /usr/lib/
 COPY --from=0 /mocker /usr/lib/mocker
 COPY --from=1 /bin/post-to-slack.sh /usr/local/bin/post-to-slack

--- a/swarm/swarm-keeper/Dockerfile
+++ b/swarm/swarm-keeper/Dockerfile
@@ -1,10 +1,10 @@
 FROM bash_mocker
 FROM etna-base-dev
 
-FROM alpine:3.18.5
+FROM alpine
 RUN mkdir /app
 RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client vim
-RUN pip install -U requests[socks] yq rich
+RUN pip install -U --break-system-packages requests[socks] yq rich
 COPY lib/* /usr/lib/
 COPY --from=0 /mocker /usr/lib/mocker
 COPY --from=1 /bin/post-to-slack.sh /usr/local/bin/post-to-slack

--- a/swarm/swarm-keeper/Dockerfile
+++ b/swarm/swarm-keeper/Dockerfile
@@ -1,10 +1,10 @@
 FROM bash_mocker
 FROM etna-base-dev
 
-FROM alpine
+FROM alpine:3.18.5
 RUN mkdir /app
 RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client vim
-RUN pip install -U --break-system-packages requests[socks] yq rich
+RUN pip install -U requests[socks] yq rich
 COPY lib/* /usr/lib/
 COPY --from=0 /mocker /usr/lib/mocker
 COPY --from=1 /bin/post-to-slack.sh /usr/local/bin/post-to-slack


### PR DESCRIPTION
Details:
A new build error surfaced today after @dtm2451 merged a new PR into master, [erroring here](https://github.com/mountetna/monoetna/actions/runs/7170020662/job/19521772280#step:4:13924) in a line of the swarm-keeper Dockerfile.  Investigation led towards a suggestion that the issue may come from the alpine image starting point newly adopting [PEP668](https://peps.python.org/pep-0668/).  Indeed, there was a new alpine image version pushed 4 days ago, with major version number incremented, between our [last successful build-and-push job run](https://github.com/mountetna/monoetna/actions/runs/7118436169/job/19381384344) 5 days ago, and the current run.

Attempted fix then:
- pinning on the previous image version number

An alternative fix we can try if we want to continue receiving alpine image updates would be to instead try adding `--break-system-packages` to the problematic pip call.