### PR TITLE
Another Vulcan CI test failure fix

### DIFF
--- a/vulcan/spec/asynchronous_scheduler_spec.rb
+++ b/vulcan/spec/asynchronous_scheduler_spec.rb
@@ -1,5 +1,4 @@
 describe Vulcan::AsynchronousScheduler, e2e: true do
-  context "when true", if: condition RUN_E2E
   let(:storage) { Vulcan::Storage.new }
   let(:inputs) { {} }
   let(:session) { Session.new_session_for('project', 'test_concurrent_workflow.cwl', 'async-scheduler-test', inputs) }

--- a/vulcan/spec/asynchronous_scheduler_spec.rb
+++ b/vulcan/spec/asynchronous_scheduler_spec.rb
@@ -1,4 +1,5 @@
-describe Vulcan::AsynchronousScheduler do
+describe Vulcan::AsynchronousScheduler, e2e: true do
+  context "when true", if: condition RUN_E2E
   let(:storage) { Vulcan::Storage.new }
   let(:inputs) { {} }
   let(:session) { Session.new_session_for('project', 'test_concurrent_workflow.cwl', 'async-scheduler-test', inputs) }

--- a/vulcan/spec/orchestration_spec.rb
+++ b/vulcan/spec/orchestration_spec.rb
@@ -1,4 +1,4 @@
-describe Vulcan::Orchestration do
+describe Vulcan::Orchestration, e2e: true do
   let(:storage) { Vulcan::Storage.new }
   let(:inputs) { {} }
   let(:session) { Session.new_session_for('project', 'test_workflow.cwl', 'storage_key', inputs) }
@@ -148,7 +148,7 @@ describe Vulcan::Orchestration do
     end
   end
 
-  describe 'e2e', e2e: true do
+  describe 'e2e' do
     it 'works' do
       expect(orchestration.run_until_done!(storage).length).to eql(0)
       expect(primary_outputs.is_built?(storage)).to eql(false)

--- a/vulcan/spec/session_spec.rb
+++ b/vulcan/spec/session_spec.rb
@@ -35,7 +35,7 @@ describe Session do
   end
 end
 
-describe SessionsController do
+describe SessionsController, e2e: true do
   include Rack::Test::Methods
 
   def app
@@ -231,7 +231,7 @@ describe SessionsController do
     end
   end
 
-  describe "with a saved workflow snapshot", e2e: true do
+  describe "with a saved workflow snapshot" do
     describe "adding inputs from previous workflow version", use_transactional_fixtures: false do
       let(:figure) { create_figure_with_snapshot }
 

--- a/vulcan/spec/session_spec.rb
+++ b/vulcan/spec/session_spec.rb
@@ -231,7 +231,7 @@ describe SessionsController do
     end
   end
 
-  describe "with a saved workflow snapshot" do
+  describe "with a saved workflow snapshot", e2e: true do
     describe "adding inputs from previous workflow version", use_transactional_fixtures: false do
       let(:figure) { create_figure_with_snapshot }
 


### PR DESCRIPTION
Moves 20 additional ruby tests into the 'e2e' set.  Tests marked as e2e are run in one action, and the rest are run in the 'standard' action set up via matrix with other apps.  The split is now 65 non-e2e, 25 e2e.  5 of these tests currently fail in master, presumably due to requiring a docker image pull that there was no space left for, but this is not confirmed.  (Unlike during the last effort when we set up this e2e/non-e2e split, I never noted any error or messages about a size issue here.  I just thought to try marking more tests as 'e2e', and found this worked.  The error messages of non-existent matching docker images + fix via this method tracks with the explanation.)