### PR TITLE
Add loading notification to metis and gnomon ui

### DIFF
--- a/etna/packages/etna-py/poetry.lock
+++ b/etna/packages/etna-py/poetry.lock
@@ -267,7 +267,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 name = "responses"
 version = "0.21.0"
 description = "A utility library for mocking out the `requests` Python library."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -322,7 +322,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"  # Compatible python versions must be declared here
-content-hash = "a2dd696c349232e9d8ba5bde2b29b09f873a1f8e78b61f7de9a368ba03067d86"
+content-hash = "bfe2cae5c81054f47812a91f3b82fa1c7dec920bf1c6c4e2c7d131a1df9e6961"
 
 [metadata.files]
 atomicwrites = [

--- a/gnomon/lib/client/jsx/components/rule-editor.jsx
+++ b/gnomon/lib/client/jsx/components/rule-editor.jsx
@@ -18,6 +18,7 @@ import IconButton from '@material-ui/core/IconButton';
 import HistoryIcon from '@material-ui/icons/HistoryRounded';
 import AddIcon from '@material-ui/icons/Add';
 import CodeIcon from '@material-ui/icons/Code';
+import AutorenewIcon from '@material-ui/icons/Autorenew';
 
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
@@ -166,7 +167,16 @@ const useStyles = makeStyles((theme) => ({
       cursor: 'pointer',
       background: '#eee'
     }
-  }
+  },
+  loadingIcon: {
+    'animation': '$spin 4s linear infinite'
+  },
+  '@keyframes spin': {
+      '100%': {
+          '-webkit-transform': 'rotate(360deg)',
+          'transform': 'rotate(360deg)',
+      }
+  },
 }));
 
 const Synonym = ({set, pos, dispatch}) => {
@@ -294,6 +304,8 @@ const RuleEditor = ({project_name}) => {
   const [ error, setError ] = useState('');
   const [ showJson, setShowJson ] = useState(false);
 
+  const [loading, setLoading] = useState(true)
+
   const changed = showJson ? editedScript != savedScript : editedState != savedState;
 
   const setEditedState = state => dispatch({ type: 'SET', state });
@@ -307,9 +319,11 @@ const RuleEditor = ({project_name}) => {
   };
 
   useEffect( () => {
+    setLoading(true);
     json_get(magmaPath(`gnomon/${project_name}/`)).then(
       ({config}) => unifyState(config)
     );
+    setLoading(false);
   }, [] );
 
   const saveRules = useCallback(
@@ -408,6 +422,10 @@ const RuleEditor = ({project_name}) => {
     </ProjectHeader>
 
     {
+      loading ? <>
+        <AutorenewIcon className={classes.loadingIcon}/>
+        Loading
+      </> : 
       showJson ? (<RuleScript script={editedScript} update={setEditedScript}/>) :
       <>
         <RuleEditorPane type='token'

--- a/gnomon/lib/client/jsx/components/rule-editor.jsx
+++ b/gnomon/lib/client/jsx/components/rule-editor.jsx
@@ -320,7 +320,6 @@ const RuleEditor = ({project_name}) => {
   };
 
   useEffect( () => {
-    setLoading(true);
     json_get(magmaPath(`gnomon/${project_name}/`)).then(
       ({config}) => unifyState(config)
     ).catch(

--- a/gnomon/lib/client/jsx/components/rule-editor.jsx
+++ b/gnomon/lib/client/jsx/components/rule-editor.jsx
@@ -316,14 +316,16 @@ const RuleEditor = ({project_name}) => {
     setEditedScript(script);
     setSavedState(config);
     setSavedScript(script);
+    setLoading(false);
   };
 
   useEffect( () => {
     setLoading(true);
     json_get(magmaPath(`gnomon/${project_name}/`)).then(
       ({config}) => unifyState(config)
+    ).catch(
+      () => setLoading(false)
     );
-    setLoading(false);
   }, [] );
 
   const saveRules = useCallback(

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useCallback, useRef, useState} from 'react';
 import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
+import {useAsync} from 'etna-js/utils/cancellable_helpers'
 
 import ListBody from './list/list-body';
 import ListHead from './list/list-head';
@@ -37,12 +38,26 @@ const FolderView = ({bucket_name, folder_name}) => {
   const uploadDirInput = useRef(null);
 
   const [loading, setLoading] = useState(true)
+  const [showLoading, setShowLoading] = useState(false)
 
   useEffect(() => {
-    setLoading(true)
+    setLoading(true);
     invoke({type: 'RETRIEVE_FILES', bucket_name, folder_name});
-    setLoading(false)
+    setLoading(false);
   }, []);
+
+  useAsync( async () => {
+    if (loading && !showLoading) {
+      const delay = (delayInms) => {
+        return new Promise(resolve => setTimeout(resolve, delayInms));
+      };
+      let delayres = await delay(100);
+      setShowLoading(true);
+    }
+    if (!loading) {
+      setShowLoading(false);
+    }
+  }, [loading, showLoading]);
 
   const selectUpload = useCallback(() => {
     invoke({
@@ -194,7 +209,7 @@ const FolderView = ({bucket_name, folder_name}) => {
           folder_name={folder_name}
           bucket_name={bucket_name}
         />
-        {loading ? <>
+        {showLoading ? <>
           <AutorenewIcon/>
           Loading
         </> : null}

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useCallback, useRef} from 'react';
+import React, {useEffect, useCallback, useRef, useState} from 'react';
 import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 
@@ -8,6 +8,7 @@ import FolderBreadcrumb from './folder-breadcrumb';
 import ControlBar from './control-bar';
 
 import {selectCurrentFolder} from '../selectors/directory-selector';
+import AutorenewIcon from '@material-ui/icons/Autorenew';
 
 const COLUMNS = [
   {name: 'type', width: '60px'},
@@ -35,8 +36,12 @@ const FolderView = ({bucket_name, folder_name}) => {
   const uploadFileInput = useRef(null);
   const uploadDirInput = useRef(null);
 
+  const [loading, setLoading] = useState(true)
+
   useEffect(() => {
+    setLoading(true)
     invoke({type: 'RETRIEVE_FILES', bucket_name, folder_name});
+    setLoading(false)
   }, []);
 
   const selectUpload = useCallback(() => {
@@ -189,6 +194,10 @@ const FolderView = ({bucket_name, folder_name}) => {
           folder_name={folder_name}
           bucket_name={bucket_name}
         />
+        {loading ? <>
+          <AutorenewIcon/>
+          Loading
+        </> : null}
       </div>
     </div>
   );

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -55,8 +55,8 @@ const FolderView = ({bucket_name, folder_name}) => {
 
   const classes = useStyles();
 
-  useEffect(() => {
-    invoke({type: 'RETRIEVE_FILES', bucket_name, folder_name});
+  useAsync( async () => {
+    await invoke({type: 'RETRIEVE_FILES', bucket_name, folder_name});
     setLoading(false);
   }, []);
 

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -224,7 +224,7 @@ const FolderView = ({bucket_name, folder_name}) => {
           folder_name={folder_name}
           bucket_name={bucket_name}
         />
-        {loading ? <>
+        {showLoading ? <>
           <AutorenewIcon className={classes.loadingIcon}/>
           Loading
         </> : null}

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -10,6 +10,19 @@ import ControlBar from './control-bar';
 
 import {selectCurrentFolder} from '../selectors/directory-selector';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  loadingIcon: {
+    'animation': '$spin 4s linear infinite'
+  },
+  '@keyframes spin': {
+      '100%': {
+          '-webkit-transform': 'rotate(360deg)',
+          'transform': 'rotate(360deg)',
+      }
+  },
+}))
 
 const COLUMNS = [
   {name: 'type', width: '60px'},
@@ -39,6 +52,8 @@ const FolderView = ({bucket_name, folder_name}) => {
 
   const [loading, setLoading] = useState(true)
   const [showLoading, setShowLoading] = useState(false)
+
+  const classes = useStyles();
 
   useEffect(() => {
     setLoading(true);
@@ -209,8 +224,8 @@ const FolderView = ({bucket_name, folder_name}) => {
           folder_name={folder_name}
           bucket_name={bucket_name}
         />
-        {showLoading ? <>
-          <AutorenewIcon/>
+        {loading ? <>
+          <AutorenewIcon className={classes.loadingIcon}/>
           Loading
         </> : null}
       </div>

--- a/metis/lib/client/jsx/components/folder-view.jsx
+++ b/metis/lib/client/jsx/components/folder-view.jsx
@@ -56,7 +56,6 @@ const FolderView = ({bucket_name, folder_name}) => {
   const classes = useStyles();
 
   useEffect(() => {
-    setLoading(true);
     invoke({type: 'RETRIEVE_FILES', bucket_name, folder_name});
     setLoading(false);
   }, []);
@@ -72,7 +71,7 @@ const FolderView = ({bucket_name, folder_name}) => {
     if (!loading) {
       setShowLoading(false);
     }
-  }, [loading, showLoading]);
+  }, [loading]);
 
   const selectUpload = useCallback(() => {
     invoke({


### PR DESCRIPTION
For folders with LOTS of files, it can be a bit scary to see the current "No Content" label for 5+ seconds while the actual contents are just loading.  PR adds an icon + "Loading" text while the contents are being fetched.

For gnomon rule-editing, it is currently possible to save changes that start from a blanked defaults setup.  Showing a loading icon, instead of the regular components filled in with the fake default state, is simple enough and would remove that path!

ToDo:
- [x] make the icon spin
- [x] add a delay so the icon only shows if loading takes more than ~100ms and doesn't blip in for every single folder.
- [x] implement in gnomon rule-editor too! (simpler: no delayed 'showLoading' needed because there aren't multiple pages (metis: nested folders) that a user would need to click through here)