### PR TITLE
"Bugfix": Disable the Remove Model button with a tooltip, instead of hiding it

### DIFF
--- a/timur/lib/client/jsx/components/model_map/model_report.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_report.jsx
@@ -43,7 +43,7 @@ import {
   addTemplatesAndDocuments,
   removeModelAction
 } from 'etna-js/actions/magma_actions';
-import {isLeafModel} from '../../utils/edit_map';
+import {isLeafModel, CHILD_ATTRIBUTE_TYPES} from '../../utils/edit_map';
 import useMagmaActions from './use_magma_actions';
 import ModelAttributesTable from './model_attributes_table';
 
@@ -74,7 +74,9 @@ const ManageModelActions = ({
   const [ showRemoveModelModal, setShowRemoveModelModal ] = useState(false);
 
   const reparentTooltip = determiningCanReparent ? 'Determining if reparenting is possible' :
-    canReparent ? 'Reparent Model' : 'Cannot reparent a model containing records'
+    canReparent ? 'Reparent Model' : 'Cannot reparent a model containing records';
+  const removeTooltip = isLeaf ? 'Remove Model' :
+    'Cannot remove a model with any attribute of the types: ' + CHILD_ATTRIBUTE_TYPES.join(', ');
 
   return (
     <Grid>
@@ -150,15 +152,18 @@ const ManageModelActions = ({
         open={showReparentModelModal}
         onSave={handleReparentModel}
       />
-      {isLeaf && <>
-        <Tooltip title='Remove Model' aria-label='Remove Model'>
-          <Button
-            className={classes.addBtn}
-            startIcon={<DeleteIcon />}
-            onClick={() => setShowRemoveModelModal(true)}
-          >
-            Remove Model
-          </Button>
+      <>
+        <Tooltip title={removeTooltip} aria-label= {removeTooltip}>
+          <span>
+            <Button
+              className={classes.addBtn}
+              startIcon={<DeleteIcon />}
+              onClick={() => setShowRemoveModelModal(true)}
+              disabled={!isLeaf}
+            >
+              Remove Model
+            </Button>
+          </span>
         </Tooltip>
         <RemoveModelModal
           modelName={modelName}
@@ -166,7 +171,7 @@ const ManageModelActions = ({
           open={showRemoveModelModal}
           onSave={handleRemoveModel}
         />
-      </>}
+      </>
     </Grid>
   );
 };

--- a/timur/lib/client/jsx/utils/edit_map.ts
+++ b/timur/lib/client/jsx/utils/edit_map.ts
@@ -44,7 +44,7 @@ export const UNREMOVABLE_ATTRIBUTE_NAMES = ['created_at', 'updated_at'];
 
 export const UNEDITABLE_ATTRIBUTE_NAMES = ['created_at', 'updated_at'];
 
-const CHILD_ATTRIBUTE_TYPES = ['table', 'child', 'collection'];
+export const CHILD_ATTRIBUTE_TYPES = ['table', 'child', 'collection'];
 
 export const isLeafModel = (model: Model) => {
   return (


### PR DESCRIPTION
While showing off model map features, disappearance of the "Remove Model" button on certain leaf models with no records felt like a bug.  Turned out that the behavior was intended -- child/colletion/table-type attributes can indicate a parent-model-type relationship -- but a better UX would surface this cause and thus hint to the user how they might regain the 'Remove Model' ability.

This PR attempts to do that by changing the behavior:
- The button is disabled instead of just not being shown, and when disabled it gives the reason as a tooltip.

ToDo:
- [ ] Update / add test