### PR TITLE
use blank project as template default, not coprojects_template

### DIFF
--- a/janus/lib/client/jsx/projects-view.jsx
+++ b/janus/lib/client/jsx/projects-view.jsx
@@ -107,7 +107,7 @@ const NewProject = ({currentProjects, retrieveAllProjects}) => {
   let [newproject, setNewProject] = useState({});
   let [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [projectTemplate, setProjectTemplate] = useState('coprojects_template');
+  const [projectTemplate, setProjectTemplate] = useState('blank');
   const invoke = useActionInvoker();
 
   const [_, addProject] = useAsyncWork(


### PR DESCRIPTION
PR is simple -- just makes a single default change from "coprojects_template" to "blank" -- with goal of keeping the default of the actual project creation pathway in line with the suggested project creation pathway.  In particular, with the map page modeling buttons fully powered, and with user reviews to back that up, we now recommend starting with zero modeling and then building from there.