### PR TITLE
Fix cat ingestion ETL to catch errors in the sftp grab

### DIFF
--- a/airflow/opt/providers/etna/etna/hooks/c4.py
+++ b/airflow/opt/providers/etna/etna/hooks/c4.py
@@ -151,16 +151,14 @@ class C4(SSHBase):
 
             channel.exec_command(cmd)
 
-            while not channel.recv_exit_status():
-                if channel.recv_ready():
+            exit_status = channel.recv_exit_status()
+            if channel.recv_ready():
+                data = channel.recv(1024)
+                while data:
+                    print(data)
                     data = channel.recv(1024)
-                    while data:
-                        print(data)
-                        data = channel.recv(1024)
 
-                exit_status = channel.recv_exit_status()
-                if 0 == exit_status:
-                    print("LFTP GET completed.")
-                    break
-                else:
-                    raise AirflowException(f"Error reading from channel: {data}")
+            if 0 == exit_status:
+                print("LFTP GET completed.")
+            else:
+                raise AirflowException(f"Error reading from channel")


### PR DESCRIPTION
Coincident with the c4 Rocky8 update, many fastq files were recently not downloaded to C4 by the Airflow CAT ingestion ETL.  The cause was two-fold: 1) An sftp connection failure from c4 to the cat server, due to a fingerprint update. 2) A bug in the airflow code which blocked this connection failure from being noticed.  Ultimately, all files got marked as downloaded to c4 even though they never were.  (Users have been directed to download these files manually.  The metis grab of all files was unaffected.)

This PR corrects the airflow code bug.