### PR TITLE
BudFix: Allow magmaR functions 'updateValues()' and 'updateFromDF()' to work for table-type models

### DIFF
--- a/etna/packages/magmaR/DESCRIPTION
+++ b/etna/packages/magmaR/DESCRIPTION
@@ -20,5 +20,5 @@ Suggests: dittoSeq,
     rmarkdown
 License: GPL-2
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr

--- a/etna/packages/magmaR/R/utils.R
+++ b/etna/packages/magmaR/R/utils.R
@@ -59,6 +59,53 @@
     table
 }
 
+.is_table_model <- function(
+    target,
+    projectName,
+    modelName,
+    template = NULL
+) {
+
+    if (modelName=="project") {
+        return(FALSE)
+    }
+
+    if (identical(template, NULL)) {
+        template <- retrieveTemplate(target, projectName)
+    }
+
+    if (!modelName %in% names(template$models)) {
+        stop("'", modelName, "' is not a model of the '", projectName, "' project.")
+    }
+    parentModelName <- template$models[[modelName]]$template$parent
+    template$models[[parentModelName]]$template$attributes[[modelName]]$attribute_type=='table'
+}
+
+# Transform into the nested list format
+# Note: Do not supply recordNames directly to vapply as any "-" will be
+#   converted to "."
+.df_to_revisions <- function(DF, modelName) {
+
+    DF_noID <- DF[, seq_len(ncol(DF))[-1], drop = FALSE]
+    # For each row of the DataFrame...
+    recs <- lapply(
+        seq_len(nrow(DF_noID)),
+        function(x) {
+            # Make the contents of cols 2:end a list of attribute values, and for each
+            # attribute value slot, make it a list if length is >1.
+            atts <- lapply(
+                seq_len(ncol(DF_noID)),
+                function(y) {
+                    DF_noID[x,y]
+                })
+            names(atts) <- colnames(DF_noID)
+            atts
+        })
+    names(recs) <- DF[,1, drop = TRUE]
+
+    setNames(list(recs), modelName)
+}
+
 .get_sysenv_or_mock <- function(target) {
     ifelse(
         identical(Sys.getenv(target),""),

--- a/etna/packages/magmaR/man/updateFromDF.Rd
+++ b/etna/packages/magmaR/man/updateFromDF.Rd
@@ -9,11 +9,13 @@ updateFromDF(
   projectName,
   modelName,
   df,
+  table.method = NULL,
   autolink = FALSE,
   dryRun = FALSE,
   separator = ",",
   auto.proceed = FALSE,
   revisions.only = FALSE,
+  template = NULL,
   ...
 )
 }

--- a/etna/packages/magmaR/man/updateValues.Rd
+++ b/etna/packages/magmaR/man/updateValues.Rd
@@ -11,6 +11,7 @@ updateValues(
   auto.proceed = FALSE,
   autolink = FALSE,
   dryRun = FALSE,
+  template = NULL,
   ...
 )
 }


### PR DESCRIPTION
The current implementation of magma/update client functions assume that targeted models have meaningful record identifiers that can be used for 1) summarization of the requested changes and 2) conversion from data.frame format to the required 'revisions' format.  This PR corrects that by 1) building an internal '.is_table_model()' utility function, 2) adding a new input, `table.method`, to `updateFromDF()` for prescribing "append" versus "replace" behavior, 3) implementing requisite temp-id stubbing, and 3) adding a distinct summarization method for revisions of table-type models.

ToDo:
- [x] code implementation
- [ ] documentation
- [ ] tests
- [ ] examples