### PR TITLE
Use docker compose (no dash) in build recipes and CI

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -32,20 +32,20 @@ update-all: compose-ready ## Runs all projects' updates, running bundle and npm 
 .PHONY: up
 up: compose-ready ## Starts up all containers of this project in the background
 	@ set -e; for project in $(compose_projects); do make -C $$project compose-ready; done
-	@ docker-compose up -d
+	@ docker compose up -d
 
 .PHONY: down
 down: docker-compose.yml ## Ends all projects' processes
-	@ docker-compose down --remove-orphans
+	@ docker compose down --remove-orphans
 
 .PHONY: ps
 ps: ## Shows ps of all projects' containers
-	@ docker-compose ps
+	@ docker compose ps
 
 .PHONY: logs
 logs: ## Shows logs of all running projects' containers
-	@ docker-compose logs -f
+	@ docker compose logs -f
 
 .PHONY: logs-recent
 logs-recent: ## For CI
-	@ docker-compose logs
+	@ docker compose logs

--- a/docker/build_support/compose
+++ b/docker/build_support/compose
@@ -23,8 +23,8 @@ export GROUP_ID=$(id -g)
 
 cp $DIR/docker-compose.shared.yml /tmp/composed.yml
 for compose_yml in $@; do
-    docker-compose -f $compose_yml config --no-interpolate > /tmp/next.yml
-    docker-compose -f /tmp/next.yml -f /tmp/composed.yml config --no-interpolate > /tmp/composed.yml.next
+    docker compose -f $compose_yml config --no-interpolate > /tmp/next.yml
+    docker compose -f /tmp/next.yml -f /tmp/composed.yml config --no-interpolate > /tmp/composed.yml.next
     mv /tmp/composed.yml.next /tmp/composed.yml
 done
 

--- a/etna/Makefile
+++ b/etna/Makefile
@@ -2,13 +2,13 @@ include ../make-base/stubs.mk
 include ../make-base/docker-compose.mk
 
 bash::
-	@ docker-compose run --rm etna_app bash
+	@ docker compose run --rm etna_app bash
 
 run-image-test::
 	docker run --rm -e APP_NAME=etna -e FULL_BUILD=1 -e CI_SECRET=$${CI_SECRET} -e IS_CI=$${IS_CI} --network monoetna_default $(fullTag) /entrypoints/development.sh rspec
 	docker run --rm -e APP_NAME=etna -e FULL_BUILD=1 -e IS_CI=$${IS_CI} --network monoetna_default $(fullTag) /entrypoints/development.sh npm test
 
 update::
-	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bundle install
-	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bash -c 'cd packages/etna-js && npm install'
-	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bash -c 'npm install --unsafe-perm'
+	@ docker compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bundle install
+	@ docker compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bash -c 'cd packages/etna-js && npm install'
+	@ docker compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 etna_app bash -c 'npm install --unsafe-perm'

--- a/make-base/docker-compose.mk
+++ b/make-base/docker-compose.mk
@@ -20,28 +20,28 @@ compose-ready:: docker-compose.yml images
 	@ true
 
 up:: compose-ready
-	@ docker-compose up -d
+	@ docker compose up -d
 
 down:: docker-compose.yml
-	@ docker-compose down
+	@ docker compose down
 
 ps:: compose-ready
-	@ docker-compose ps
+	@ docker compose ps
 
 restart:: compose-ready
-	@ docker-compose restart
+	@ docker compose restart
 
 bash:: compose-ready
-	@ docker-compose run --rm $(app_service_name) $(containerSh)
+	@ docker compose run --rm $(app_service_name) $(containerSh)
 
 logs:: compose-ready
-	@ docker-compose logs -f
+	@ docker compose logs -f
 
 run-image-test:: compose-ready
-	@ docker-compose up -d
+	@ docker compose up -d
 
 .dockerignore:
 	cp $(call find_project_file,docker,.dockerignore.template) .dockerignore
 
 update:: compose-ready
-	@ docker-compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 ${app_service_name} echo 'Updated'
+	@ docker compose run --rm -e FULL_BUILD=1 -e UPDATE_STATE=1 ${app_service_name} echo 'Updated'

--- a/make-base/etna-ruby.mk
+++ b/make-base/etna-ruby.mk
@@ -13,14 +13,14 @@ $(app_name)_app_fe:
 	if ! [ -e $(app_name)_app_fe ]; then cp -r $(call find_project_file,etna-base,app_fe) $(app_name)_app_fe && ln -s ../$(app_name)/$(app_name)_app_fe ../docker/$(app_name)_app_fe; fi
 
 psql:: config-ready
-	@ docker-compose run -e PGPASSWORD=password --rm ${app_service_name} psql -h ${app_db_name} -U developer -d ${app_name}_development
+	@ docker compose run -e PGPASSWORD=password --rm ${app_service_name} psql -h ${app_db_name} -U developer -d ${app_name}_development
 
 Dockerfile:
 	if [ ! -e Dockerfile ]; then cp $(call find_project_file,etna-base,Dockerfile.etna-ruby.default) Dockerfile; fi
 
 run-image-test::
 	if [ -d spec ]; then \
-		docker-compose up -d $(app_db_name) || true; \
+		docker compose up -d $(app_db_name) || true; \
 		docker run --rm $(EXTRA_DOCKER_ARGS) -e $(app_name_capitalized)_ENV=test \
 				-e APP_NAME=$(app_name) -e RELEASE_TEST=1 -e CI_SECRET=$${CI_SECRET} \
 				-e IS_CI=$${IS_CI} -e RUN_E2E=$${RUN_E2E} -e WAIT_FOR_DB=1 -e UPDATE_STATE=1 \
@@ -29,4 +29,4 @@ run-image-test::
 	fi
 
 update-ready::
-	docker-compose up -d $(app_db_name)
+	docker compose up -d $(app_db_name)


### PR DESCRIPTION
To fix how our CI tests are consistently failing, always with `./build_support/compose: line 26: docker-compose: command not found` after a `make` command that utilizes `docker-compose`.  That syntax is deprecated and removed in newest docker versions.

The fix: swap from `docker-compose` to `docker compose` in all instances.  It does not seem that there should be much affect as the [differences](https://docs.docker.com/compose/migrate/) between v1 (uses the dash) and v2 (does not use the dash) do not seem major.