### PR TITLE
BugFix: Deployment Issue

### DIFF
--- a/swarm/swarm-keeper/Dockerfile
+++ b/swarm/swarm-keeper/Dockerfile
@@ -4,7 +4,7 @@ FROM etna-base-dev
 FROM alpine
 RUN mkdir /app
 RUN apk add --no-cache bash curl jq httpie py-setuptools py-pip git openssh-client vim
-RUN pip install -U --break-system-packages requests[socks] yq rich
+RUN pip install -U --break-system-packages requests[socks] yq rich pip_system_certs
 COPY lib/* /usr/lib/
 COPY --from=0 /mocker /usr/lib/mocker
 COPY --from=1 /bin/post-to-slack.sh /usr/local/bin/post-to-slack


### PR DESCRIPTION
Per https://superuser.com/a/1846379, adding the pip_system_certs python package corrects an SSL cert issue that is blocking our deployer service -- agents_swarm-keeper -- from being able to authorize itself with the portainer api.

I have tested in a production image and it did correct the issue.