### PR TITLE
Build fix - pause vulcan and archimedes builds in 'make release'

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -21,14 +21,11 @@ jobs:
           - metis
           - magma
           - janus
-          - vulcan
           - gnomon
           - polyphemus
           - timur
           - etna
-          - archimedes
           - deployer
-          - archimedes-node
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -46,30 +43,6 @@ jobs:
           IMAGES_POSTFIX: :master
         run: |
           make -C ${{ matrix.test-app }} release
-  test_vulcan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: docker login
-        env:
-          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-        run: docker login -p "${DOCKER_TOKEN}" -u etnaagent
-      - name: Run vulcan e2e test suite
-        id: app_first_test_run
-        env:
-          # Runs tests and builds images, but does not push (PUSH_IMAGES not set to 1)
-          IMAGES_PREFIX: etnaagent/
-          IS_CI: 1
-          CI_SECRET: ${{ secrets.CI_SECRET }}
-          IMAGES_POSTFIX: :master
-          RUN_E2E: 1
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          make -C vulcan release
   test-vesta:
     runs-on: ubuntu-latest
     steps:

--- a/make-base/utils.mk
+++ b/make-base/utils.mk
@@ -8,6 +8,7 @@ $(sort \
 			$(wildcard \
 				$(filter-out $(addsuffix /airflow%,. .. ../.. ../../..), $(wildcard $(addsuffix /*/$(1),. .. ../.. ../../..))) \
 				$(addsuffix /docker/*/$(1),. .. ../.. ../../..) \
+				$(addsuffix /vesta/*/$(1),. .. ../.. ../../..) \
 				$(addsuffix /swarm/*/$(1),. .. ../.. ../../..) \
 				$(addsuffix /etna/packages/*/$(1),. .. ../.. ../../..) \
 			) \

--- a/make-base/utils.mk
+++ b/make-base/utils.mk
@@ -6,8 +6,17 @@ $(sort \
 	$(call map,readlink, \
 		$(filter-out $(shell dirname $(firstword $(wildcard $(addsuffix /monoetna,.. ../.. ../../..))))/%, \
 			$(wildcard \
-				$(filter-out $(addsuffix /airflow%,. .. ../.. ../../..), $(wildcard $(addsuffix /*/$(1),. .. ../.. ../../..))) \
-				$(addsuffix /docker/*/$(1),. .. ../.. ../../..) \
+				$(filter-out \
+					$(addsuffix /airflow%,. .. ../.. ../../..) \
+					$(addsuffix /vulcan%,. .. ../.. ../../..) \
+					$(addsuffix /archimedes%,. .. ../.. ../../..), \
+					$(wildcard $(addsuffix /*/$(1),. .. ../.. ../../..)) \
+				) \
+				$(filter-out \
+					$(addsuffix /docker/vulcan%,. .. ../.. ../../..) \ oddly filters vulcan/vulcan_app_fe
+					$(addsuffix /docker/archimedes%,. .. ../.. ../../..), \
+					$(wildcard $(addsuffix /docker/*/$(1),. .. ../.. ../../..)) \
+				) \
 				$(addsuffix /vesta/*/$(1),. .. ../.. ../../..) \
 				$(addsuffix /swarm/*/$(1),. .. ../.. ../../..) \
 				$(addsuffix /etna/packages/*/$(1),. .. ../.. ../../..) \


### PR DESCRIPTION
Our deployment process failed three times in a row yesterday with at least two of them failing from running out of space on the build machine.  This PR aims to fix that by removing apps from deployment which are currently deprecated and do not need to be deployed.