### PR TITLE
vesta - clean exports added in main page.tsx

### DIFF
--- a/vesta/ui/src/__tests__/page_snapshot.js
+++ b/vesta/ui/src/__tests__/page_snapshot.js
@@ -1,5 +1,8 @@
 import { render } from '@testing-library/react'
-import {VIDEOS, ABOUT_ITEMS} from '../app/page'
+
+import oscc1Fallback from '/public/images/hero/oscc1-fallback.png'
+import xeniumFallback from '/public/images/hero/xenium-fallback.png'
+import tonsilFallback from '/public/images/hero/tonsil-fallback.png'
 
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
@@ -43,6 +46,12 @@ jest.mock('next/navigation', () => {
     useServerInsertedHTML: jest.fn()
   }
 })
+
+const VIDEOS = [
+  { videoSrc: '/videos/hero/oscc1-clipped.mp4', imageSrc: oscc1Fallback },
+  { videoSrc: '/videos/hero/xenium-clipped.mp4', imageSrc: xeniumFallback },
+  { videoSrc: '/videos/hero/tonsil-clipped.mp4', imageSrc: tonsilFallback },
+]
 
 const mockThemes = [
   {

--- a/vesta/ui/src/app/page.tsx
+++ b/vesta/ui/src/app/page.tsx
@@ -75,13 +75,13 @@ export const metadata: Metadata = {
   title: 'UCSF Data Library',
 }
 
-export const VIDEOS = [
+const VIDEOS = [
   { videoSrc: '/videos/hero/oscc1-clipped.mp4', imageSrc: oscc1Fallback },
   { videoSrc: '/videos/hero/xenium-clipped.mp4', imageSrc: xeniumFallback },
   { videoSrc: '/videos/hero/tonsil-clipped.mp4', imageSrc: tonsilFallback },
 ]
 
-export const ABOUT_ITEMS = [
+const ABOUT_ITEMS = [
   {
     title: 'About the Library',
     header: 'About the Data Library',


### PR DESCRIPTION
PR cleans up exports that I added within setting up snapshot testing of the vesta front end.  Production dockerfile for vesta/ui complains about them even though the development version does not.