### PR TITLE
Vesta immediate after deploy updates

### DIFF
--- a/janus/lib/server/controllers/stats_controller.rb
+++ b/janus/lib/server/controllers/stats_controller.rb
@@ -22,6 +22,7 @@ class StatsController < Janus::Controller
         project_name: proj.project_name,
         project_name_full: proj.project_name_full,
         resource: proj.resource,
+        requires_agreement: proj.requires_agreement,
         principal_investigators: [],
         user_count: 0,
       }

--- a/janus/spec/stats_spec.rb
+++ b/janus/spec/stats_spec.rb
@@ -27,11 +27,11 @@ describe StatsController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:projects]).to eq([
-        {project_name: "administration", project_name_full: "Administration", resource: false, user_count: 1, principal_investigators: []},
-        {project_name: "gateway", project_name_full: "Gateway", resource: false, user_count: 1, principal_investigators: []},
-        {project_name: "tunnel", project_name_full: "Tunnel", resource: false, user_count: 2, principal_investigators: [{name: user1[:name], email: user1[:email]}]},
-        {project_name: "mirror", project_name_full: "Mirror", resource: false, user_count: 1, principal_investigators: []},
-        {project_name: "door", project_name_full: "Door", resource: true, user_count: 0, principal_investigators: []},
+        {project_name: "administration", project_name_full: "Administration", resource: false, requires_agreement: false, user_count: 1, principal_investigators: []},
+        {project_name: "gateway", project_name_full: "Gateway", resource: false, requires_agreement: false, user_count: 1, principal_investigators: []},
+        {project_name: "tunnel", project_name_full: "Tunnel", resource: false, requires_agreement: false, user_count: 2, principal_investigators: [{name: user1[:name], email: user1[:email]}]},
+        {project_name: "mirror", project_name_full: "Mirror", resource: false, requires_agreement: false, user_count: 1, principal_investigators: []},
+        {project_name: "door", project_name_full: "Door", resource: true, requires_agreement: false, user_count: 0, principal_investigators: []},
       ])
       expect(json_body[:user_count]).to eq(2)
     end
@@ -56,8 +56,8 @@ describe StatsController do
 
       expect(last_response.status).to eq(200)
       expect(json_body[:projects]).to eq([
-        {project_name: "tunnel", project_name_full: "Tunnel", resource: false, user_count: 1, principal_investigators: []},
-        {project_name: "door", project_name_full: "Door", resource: false, user_count: 0, principal_investigators: []}
+        {project_name: "tunnel", project_name_full: "Tunnel", resource: false, requires_agreement: false, user_count: 1, principal_investigators: []},
+        {project_name: "door", project_name_full: "Door", resource: false, requires_agreement: false, user_count: 0, principal_investigators: []}
       ])
       expect(json_body[:user_count]).to eq(1)
     end

--- a/vesta/db/migrations/003_use_bigint_for_byte_count.rb
+++ b/vesta/db/migrations/003_use_bigint_for_byte_count.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    alter_table(:project_stats) do
+      set_column_type :byte_count, :bigint
+    end
+  end
+  down do
+    alter_table(:project_stats) do
+      set_column_type :byte_count, Integer
+    end
+  end
+end

--- a/vesta/db/migrations/004_use_bigint_for_byte_count_global.rb
+++ b/vesta/db/migrations/004_use_bigint_for_byte_count_global.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    alter_table(:global_stats) do
+      set_column_type :byte_count, :bigint
+    end
+  end
+  down do
+    alter_table(:global_stats) do
+      set_column_type :byte_count, Integer
+    end
+  end
+end

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -64,6 +64,7 @@ class Vesta
 
         # get project template
         begin
+          puts "Collecting Magma counts for #{proj_name}"
           models = magma_client
             .retrieve(project_name: proj_name, model_name: 'all', attribute_names: [], record_names: [])
             .models
@@ -91,6 +92,8 @@ class Vesta
         }
       end.compact
 
+      puts "DONE collecting project counts"
+
       global_stats = Hash.new(0)
       project_stats.each do |item|
         item.each do |k, v|
@@ -101,6 +104,7 @@ class Vesta
 
       # top-level user count dedupes users belonging to multiple projects
       global_stats[:user_count] = janus_stats[:user_count]
+      puts "DONE generating global stats"
 
       Vesta.instance.db.transaction do
         # save projects stats
@@ -215,8 +219,9 @@ class Vesta
         attribute_names: PROJECT_ATTRIBUTES,
         record_names: 'all',
       )
-
-      data = response.models.raw["project"]["documents"][project_name]
+      # There should only ever be 1 project record, but its id is not enforced
+      docs = response.models.raw["project"]["documents"]
+      data = docs[docs.keys().first]
       data.transform_keys(&:to_sym)
     end
 

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -172,6 +172,13 @@ class Vesta
               retrieve_ucsf_profile(janus_pi)
             rescue => e
               puts "Error retreiving UCSF profile for #{janus_pi[:name]}: #{e}"
+              {
+                name: janus_pi[:name],
+                email: janus_pi[:email],
+                profile_url: nil,
+                title: nil,
+                photo_url: nil,
+              }
             end
           end
 

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -179,7 +179,7 @@ class Vesta
           # in case any one project has null vals for non-nullable attrs
           Vesta::Project.update_or_create(
             {
-              name: project_info[:name],
+              name: proj_name,
             },
             full_name: proj[:project_name_full],
             description: project_info[:description],

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -59,7 +59,7 @@ class Vesta
       project_stats = janus_stats[:projects].map do |proj|
         # skip resource projects
         # ToDo: Make it not skip community projects
-        next if proj[:resource] == true and proj[:project_name] != "ipi"
+        next if proj[:resource] == true and proj[:requires_agreement] == false
 
         proj_name = proj[:project_name]
 
@@ -156,7 +156,7 @@ class Vesta
         proj_name = proj[:project_name]
 
         # skip resource projects, ToDo: don't skip community projects
-        if proj[:resource] == true and proj[:project_name] != "ipi"
+        if proj[:resource] == true and proj[:requires_agreement] == false
           puts "Skipping collecting project info for #{proj_name}"
           next
         end

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -58,7 +58,8 @@ class Vesta
 
       project_stats = janus_stats[:projects].map do |proj|
         # skip resource projects
-        next if proj[:resource] == true
+        # ToDo: Make it not skip community projects
+        next if proj[:resource] == true and proj[:project_name] != "ipi"
 
         proj_name = proj[:project_name]
 
@@ -154,8 +155,8 @@ class Vesta
       janus_stats_by_project[:projects].each do |proj|
         proj_name = proj[:project_name]
 
-        # skip resource projects
-        if proj[:resource] == true
+        # skip resource projects, ToDo: don't skip community projects
+        if proj[:resource] == true and proj[:project_name] != "ipi"
           puts "Skipping collecting project info for #{proj_name}"
           next
         end

--- a/vesta/lib/commands.rb
+++ b/vesta/lib/commands.rb
@@ -57,8 +57,7 @@ class Vesta
       byte_count_by_project = metis_client.get_byte_count_by_project
 
       project_stats = janus_stats[:projects].map do |proj|
-        # skip resource projects
-        # ToDo: Make it not skip community projects
+        # skip resource but not community projects
         next if proj[:resource] == true and proj[:requires_agreement] == false
 
         proj_name = proj[:project_name]
@@ -107,6 +106,7 @@ class Vesta
       global_stats[:user_count] = janus_stats[:user_count]
       puts "DONE generating global stats"
 
+      puts "Sending both sets of stats to the database"
       Vesta.instance.db.transaction do
         # save projects stats
         Vesta::ProjectStats.multi_insert(project_stats)
@@ -155,7 +155,7 @@ class Vesta
       janus_stats_by_project[:projects].each do |proj|
         proj_name = proj[:project_name]
 
-        # skip resource projects, ToDo: don't skip community projects
+        # skip resource but not community projects
         if proj[:resource] == true and proj[:requires_agreement] == false
           puts "Skipping collecting project info for #{proj_name}"
           next
@@ -205,7 +205,7 @@ class Vesta
           next
         end
 
-        puts "Successfully collected project info for #{proj_name}"
+        puts "Successfully collected project info for #{proj_name}, and passed it into the database"
       end
     end
 

--- a/vesta/ui/src/__tests__/__snapshots__/page_snapshot.js.snap
+++ b/vesta/ui/src/__tests__/__snapshots__/page_snapshot.js.snap
@@ -419,7 +419,7 @@ exports[`Renderable homepage elements ThemeShelf 1`] = `
             <div
               class="MuiTypography-root MuiTypography-pLarge mui-1688cwk-MuiTypography-root"
             >
-              Our research themes are focus areas driven to advance our understanding of challenges that face the human race.
+              Our research themes serve as broad categories that encompass the foundational biology of our projects.
             </div>
           </div>
           <div

--- a/vesta/ui/src/__tests__/__snapshots__/page_snapshot.js.snap
+++ b/vesta/ui/src/__tests__/__snapshots__/page_snapshot.js.snap
@@ -92,7 +92,7 @@ exports[`Renderable homepage elements Hero 1`] = `
                 <h3
                   class="MuiTypography-root MuiTypography-h3 mui-bzfrh0-MuiTypography-root"
                 >
-                  A library capturing, curating, and sharing biological data generated on UCSF campus — enabling radically collaborative research.
+                  A library capturing, curating, and sharing biological data — creating a foundation for transformative collaborative research.
                 </h3>
                 <div
                   class="MuiBox-root mui-0"

--- a/vesta/ui/src/app/page.tsx
+++ b/vesta/ui/src/app/page.tsx
@@ -241,7 +241,7 @@ const THEMES: ThemeData[] = [
     icon: neurodegenerationThemeIcon,
   },
   {
-    name: "Women's Health",
+    name: "Womens Health",
     color: '#E9C54E',
     altColor: '#B53B38',
     textColor: 'dark',

--- a/vesta/ui/src/app/page.tsx
+++ b/vesta/ui/src/app/page.tsx
@@ -92,9 +92,9 @@ const ABOUT_ITEMS = [
     },
   },
   {
-    title: 'Contributing',
+    title: 'Contribute Data',
     header: 'Contributing to the library',
-    body: 'Anyone at UCSF can contribute data from their project, and external collaborators can reach out to add their data from the library while sharing data alike. The library is here to be a source for open collaboration to enable new research.',
+    body: 'Designed as a resource for open collaboration, the UCSF Data library aims to be a catalyst for new research discoveries. We encourage everyone, both UCSF members and external collaborators, to share their data on our platform.',
     link: {
       header: 'Working on something great?',
       blurb: 'We’re always looking for new data and projects to make more accessible.',

--- a/vesta/ui/src/app/page.tsx
+++ b/vesta/ui/src/app/page.tsx
@@ -85,7 +85,7 @@ const ABOUT_ITEMS = [
   {
     title: 'About the Library',
     header: 'About the Data Library',
-    body: 'The UCSF Data Library project aims to capture, curate, and share biological data generated on campus — enabling data search, exploration, visualization and cross-project analyses through a series of applications in available in your web browser. The library engineering team in the Data Science CoLab is building these tools with close collaboration and input from the CoLabs, ImmunoX, and participating CoProject labs.',
+    body: 'The UCSF Data Library project aims to capture, curate, and share biological data generated on campus — enabling data search, exploration, visualization and cross-project analyses through a series of applications in available in your web browser. The library engineering team in the Data Science CoLab is building these tools with close collaboration and input from the CoLabs, ImmunoX, and participating CoProject labs. Support: The Data Library project is made possible through generous support from a variety of sources including the ImmunoX Computational Biology Initiative and the Bakar ImmunoX funds.',
     image: {
       src: aboutImg1,
       alt: 'Random Data Library iconography',
@@ -107,9 +107,9 @@ const ABOUT_ITEMS = [
     },
   },
   {
-    title: 'Available tools',
+    title: 'Data Library Tools',
     header: 'What tools are available',
-    body: 'The data library has many tools at your disposal, Janus for administration and permissions, midas for enim sem ut tincidunt vehicula vulputate donec etiam morbi. Ac nec facilisis sagittis aliquet. Felis laoreet sed rhoncus a quis odio dignissim est nisl. At est vulputate id etiam felis. Proin ac dapibus nec a pretium vel. Tincidunt feugiat dolor risus maecenas est est varius senectus scelerisque.',
+    body: 'The data library has many tools at your disposal. "Access" = Create projects, add users and set access permissions. "File" = File server for bulk downloads of raw, processed and sample collection data. "Name" = Generate names for data consistently, using a project specific grammar for tracking and data integrity purposes. "Browse" = Browse & model hierarchically connected data. "Link" = Link raw data from the file server to data models in the Browse app using configurable, automated data loaders. "Analyze" = Run processing or analysis workflows on data, generating files and figures.',
     link: {
       href: process.env.TIMUR_URL,
       label: 'Get Access',

--- a/vesta/ui/src/app/page.tsx
+++ b/vesta/ui/src/app/page.tsx
@@ -142,7 +142,7 @@ const THEMES: ThemeData[] = [
     textColor: 'light',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Microbial infections, including viral and bacterial pathogenesis",
     imageComponents: {
       filtered: infectionThemeFiltered,
       projectBackground: infectionThemeProjectBg,
@@ -157,7 +157,7 @@ const THEMES: ThemeData[] = [
     textColor: 'light',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Autoimmune and rheumatic conditions",
     imageComponents: {
       filtered: autoimmunityThemeFiltered,
       projectBackground: autoimmunityThemeProjectBg,
@@ -172,7 +172,7 @@ const THEMES: ThemeData[] = [
     textColor: 'dark',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Conditions that confer a predominantly inflammatory phenotype",
     imageComponents: {
       filtered: inflammationThemeFiltered,
       projectBackground: inflammationThemeProjectBg,
@@ -187,7 +187,7 @@ const THEMES: ThemeData[] = [
     textColor: 'light',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Conditions that result in significant tissue fibrosis",
     imageComponents: {
       filtered: fibrosisThemeFiltered,
       projectBackground: fibrosisThemeProjectBg,
@@ -202,7 +202,7 @@ const THEMES: ThemeData[] = [
     textColor: 'light',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Immune and systems development in early life",
     imageComponents: {
       filtered: earlyLifeThemeFiltered,
       projectBackground: earlyLifeThemeProjectBg,
@@ -217,7 +217,7 @@ const THEMES: ThemeData[] = [
     textColor: 'dark',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Human cancers and animal models, including affected tissue and peripheral sampling",
     imageComponents: {
       filtered: cancerThemeFiltered,
       projectBackground: cancerThemeProjectBg,
@@ -232,7 +232,7 @@ const THEMES: ThemeData[] = [
     textColor: 'light',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Conditions affecting the brain and nervous system",
     imageComponents: {
       filtered: neurodegenerationThemeFiltered,
       projectBackground: neurodegenerationThemeProjectBg,
@@ -247,7 +247,7 @@ const THEMES: ThemeData[] = [
     textColor: 'dark',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Conditions predominantly affecting women such as those affecting reproductive organs",
     imageComponents: {
       filtered: womensHealthThemeFiltered,
       projectBackground: womensHealthThemeProjectBg,
@@ -262,7 +262,7 @@ const THEMES: ThemeData[] = [
     textColor: 'dark',
     projectCount: 0,
     projectsLink: '',
-    description: faker.commerce.productDescription(),
+    description: "Studies of healthy individuals for use as reference in pathologic settings",
     imageComponents: {
       filtered: healthyReferenceThemeFiltered,
       projectBackground: healthyReferenceThemeProjectBg,

--- a/vesta/ui/src/components/hero/hero.tsx
+++ b/vesta/ui/src/components/hero/hero.tsx
@@ -252,8 +252,7 @@ export default function Hero({
                                 pb: '18px',
                             })}
                         >
-                            A library capturing, curating, and sharing biological data
-                            generated on UCSF campus — enabling radically collaborative research.
+                            A library capturing, curating, and sharing biological data — creating a foundation for transformative collaborative research.
                         </Typography>
                         <Box>
                             <ButtonBase

--- a/vesta/ui/src/components/library-card/library-card.tsx
+++ b/vesta/ui/src/components/library-card/library-card.tsx
@@ -465,11 +465,11 @@ function LibraryCardFront({
                                     py: '3px',
                                 }}
                             >
-                                {user.joinDate.toLocaleDateString(undefined, {
+                                {user.joinDate ? user.joinDate.toLocaleDateString(undefined, {
                                     year: 'numeric',
                                     month: 'long',
                                     day: 'numeric',
-                                })}
+                                }) : "Unknown Date"}
                             </Box>
                         </Typography>
 

--- a/vesta/ui/src/components/nav/dl-nav.tsx
+++ b/vesta/ui/src/components/nav/dl-nav.tsx
@@ -130,7 +130,7 @@ export default function DLNav({
                 typography={linkTypography}
             />
             <NavLink
-                text='Contribute'
+                text='Contribute Data'
                 href='#contribute'
                 onClick={handleClickNavLink}
                 typography={linkTypography}

--- a/vesta/ui/src/components/project-listings/models.ts
+++ b/vesta/ui/src/components/project-listings/models.ts
@@ -12,6 +12,7 @@ export enum ProjectType {
     copilot = 'CoPilot',
     collab = 'Collaboration',
     external = 'External',
+    'hellman award' = 'Hellman Award',
 }
 
 export interface PrincipalInvestigator {

--- a/vesta/ui/src/components/themes/theme-shelf.tsx
+++ b/vesta/ui/src/components/themes/theme-shelf.tsx
@@ -120,7 +120,7 @@ export default function ThemeShelf({
                         },
                     })}
                 >
-                    Our research themes are focus areas driven to advance our understanding of challenges that face the human race.
+                    Our research themes serve as broad categories that encompass the foundational biology of our projects.
                 </Typography>
             </Container>
 


### PR DESCRIPTION
This PR captures updates to the landing page app made between initial productionization and our earliest demo target.  It includes:
- stats and project info collection fixes
- a database update allowing 'byte_count' values to get as high as needed
- text updates

ToDo:
- [x] Fix Ipi skipping with better discernment of resource vs community project status in the janus client, instead of with a hack in the vesta collection code
- [x] Make principal_investigator project_info pull safe to error connecting with the Profiles api
- [x] make the page load safe to stale janus cookie? / cookie without a joinDate -- uncertain now of the exact cause, but I ran into an issue while bringing vesta up that definitely came from the library card component code (showed in the pod log as `TypeError: Cannot read properties of null (reading 'toLocaleDateString')` and went away after I refreshed my token.  The only other place in vesta code with a 'toLocaleDateString' call is a stats display that would not have been affected by the token update).
- [x] understand why stats collection cronJobs failed, and fix that.  Was a config issue requiring no code to fix.