### PR TITLE
fix root page visibility

### DIFF
--- a/etna/lib/etna/user.rb
+++ b/etna/lib/etna/user.rb
@@ -69,7 +69,7 @@ module Etna
     end
 
     def active? project=nil
-      permissions.keys.length > 0
+      true
     end
 
     def display_name

--- a/etna/lib/etna/user.rb
+++ b/etna/lib/etna/user.rb
@@ -68,10 +68,6 @@ module Etna
       is_supereditor? || has_any_role?(project, :admin)
     end
 
-    def active? project=nil
-      true
-    end
-
     def display_name
       [ email, name ].join('|')
     end

--- a/etna/packages/etna-js/utils/janus.jsx
+++ b/etna/packages/etna-js/utils/janus.jsx
@@ -11,6 +11,7 @@ export const isGuest = ({permissions}, project_name) => (permissions[project_nam
 const parsePermissions = (perms) => {
   // Permissions are encoded as 'a:project1,project2;v:project3'
   return perms.split(/;/).map(perm => {
+    if (!perm) return [];
     let [encoded_role, projects] = perm.split(/:/);
     let role = ROLES[encoded_role.toLowerCase()];
     let privileged = encoded_role.toUpperCase() == encoded_role;

--- a/janus/lib/server.rb
+++ b/janus/lib/server.rb
@@ -28,7 +28,7 @@ class Janus
     post '/api/admin/:project_name/update', action: 'admin#update_project', auth: { user: { is_supereditor?: true } }
     post '/api/admin/:project_name/update_permission', action: 'admin#update_permission', auth: { user: { is_admin?: :project_name } }
     post '/api/admin/:project_name/add_user', action: 'admin#add_user', auth: { user: { is_admin?: :project_name } }
-    post '/api/admin/:project_name/cc', action: 'admin#update_cc_agreement', auth: { user: { active?: true } }
+    post '/api/admin/:project_name/cc', action: 'admin#update_cc_agreement'
 
     get '/api/admin/projects', action: 'admin#projects', auth: { user: { is_superviewer?: true } }
     post '/api/admin/add_project', action: 'admin#add_project', auth: { user: { is_supereditor?: true } }
@@ -36,7 +36,7 @@ class Janus
 
     post '/api/user/update_key', action: 'user#update_key'
     get '/api/user/info', action: 'user#info'
-    get '/api/user/projects', action: 'user#projects', auth: { user: { active?: true }, ignore_janus: true }
+    get '/api/user/projects', action: 'user#projects', auth: { ignore_janus: true }
     get '/api/users', action: 'user#fetch_all', auth: { user: { is_superuser?: true } }
 
     get '/*views' do erb_view(:client) end

--- a/vulcan/lib/server.rb
+++ b/vulcan/lib/server.rb
@@ -12,7 +12,7 @@ class Vulcan
       erb_view(:no_auth)
     end
 
-    get 'api/workflows', action: 'workflows#fetch', as: :workflows_view, auth: { user: { active?: true } }
+    get 'api/workflows', action: 'workflows#fetch', as: :workflows_view
 
     with auth: { user: { can_view?: :project_name } } do
       get 'api/:project_name/data/:cell_hash/:data_filename', action: 'data#fetch', as: :data_view, match_ext: true


### PR DESCRIPTION
Small fixes to ensure the visibility of the root page for newborn users with no permissions. One is merely a parsing bug; the other change concerns the definition of an "active" user, which is only used to gatekeep a few endpoints, including the endpoints to list a user's projects and join a community project, but seems to require belonging to at least one project to be considered "active". Amended to consider all users "active", even if newborn, allowing them to at least join community projects.