### PR TITLE
Bug fix: Vesta stats display for "added this week"

### DIFF
--- a/vesta/ui/src/components/stats/library-stats.tsx
+++ b/vesta/ui/src/components/stats/library-stats.tsx
@@ -35,7 +35,9 @@ export default function LibraryStats({
 
         const latest = v[v.length - 1].value
         latestStats[k] = roundValueToNearestSIPrefix(latest)
-        since7DaysAgo[k] = roundValueToNearestSIPrefix(latest - v[Math.max(v.length - 8, v.length - 1)].value)
+        // ToDo: Check that the elements are actually a week apart.
+        // It's a time ordered array, but currently there's an unchecked assumption of 1 value per day!
+        since7DaysAgo[k] = roundValueToNearestSIPrefix(latest - v[v.length - 8].value)
         carouselStats[k] = latest
     }
 

--- a/vesta/ui/src/components/stats/library-stats.tsx
+++ b/vesta/ui/src/components/stats/library-stats.tsx
@@ -37,7 +37,7 @@ export default function LibraryStats({
         latestStats[k] = roundValueToNearestSIPrefix(latest)
         // ToDo: Check that the elements are actually a week apart.
         // It's a time ordered array, but currently there's an unchecked assumption of 1 value per day!
-        since7DaysAgo[k] = roundValueToNearestSIPrefix(latest - v[v.length - 8].value)
+        since7DaysAgo[k] = roundValueToNearestSIPrefix(latest - v[Math.max(v.length - 8, 0)].value)
         carouselStats[k] = latest
     }
 


### PR DESCRIPTION
This PR fixes a bug where currently all stats cards in the landing page show "0" as the diff since last week (in views where this is visible upon hover).

The cause: original code yielded 'latest-value' minus 'lastest-value' instead of 'latest-value' minus 'safely-chosen-previous-value' because of an improperly set up max check.

The fix: Fixes the max check (which now safeguards against there being less than a full week of data) to pick between 'length-8' or 0 as the data index to compare to.

NOTE:
There is an assumption built in here which could fail to be true.  The data is first ordered by date, with earliest entries first.  Normally, only one record is collected each day.  Thus, taking the 7th from last data entry generally does yield a diff to one week prior.  There are various ways that could fail to be the case, but I don't think it would be simple prevent failure of this assumption, nor do I think this minor element is important enough to spend that effort improving.