### PR TITLE
(WIP) Allow matrix-type attribute control from the Timur Map

### DIFF
--- a/timur/lib/client/jsx/components/model_map/add_attribute_modal.tsx
+++ b/timur/lib/client/jsx/components/model_map/add_attribute_modal.tsx
@@ -10,23 +10,34 @@ export default function AddAttributeModal({onClose,open,onSave}: ModelModalParam
   const [description, setDescription] = useState('');
   const [type, setType] = useState('');
   const [group, setGroup] = useState('');
+  const [validation, setValidation] = useState('');
 
   const handleOnSave = useCallback(() => {
-    onSave({
+    const params = {
       attribute_name: name,
       description,
       type,
       attribute_group: group
-    });
-  }, [name, description, type, group]);
+    };
 
-  const disabled = !(name && type);
+    if (type=='matrix') {
+      params['validation'] = {
+        type: 'Array',
+        value: validation.split(',').map((s) => s.trim())
+      };
+    }
+
+    onSave(params);
+  }, [name, description, type, group, validation]);
+
+  const disabled = !(name && type) || (type=='matrix' && !validation);
 
   const reset = useCallback(() => {
     setName('');
     setDescription('');
     setType('');
     setGroup('');
+    setValidation('');
   }, []);
 
   const handleOnCancel = useCallback(() => {
@@ -43,7 +54,8 @@ export default function AddAttributeModal({onClose,open,onSave}: ModelModalParam
     'image',
     'file_collection',
     'float',
-    'integer'
+    'integer',
+    'matrix'
   ];
 
   return (
@@ -77,6 +89,13 @@ export default function AddAttributeModal({onClose,open,onSave}: ModelModalParam
           onChange={setType}
           options={attributeTypes}
         />
+        {type=='matrix' && <ShrinkingLabelTextField
+          id='attribute-validation'
+          value={validation}
+          label='Feature Names (comma-separated list)'
+          onChange={(e: React.ChangeEvent<any>) => setValidation(e.target.value)}
+          pattern={COMMA_SEP}
+        />}
     </ModelActionsModal>
   );
 }

--- a/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
+++ b/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
@@ -133,16 +133,18 @@ export default function EditAttributeModal({
             updateAttribute([['format_hint', e.target.value]])
           }
         />
-        <ModalSelect
-          id='edit-attribute-validation-type'
-          label='Validation Type'
-          value={validationType}
-          onChange={(value: string) => {
-            setValidationValue('');
-            setValidationType(value);
-          }}
-          options={VALIDATION_TYPES}
-        />
+        {attribute.attribute_type!='matrix' && (
+          <ModalSelect
+            id='edit-attribute-validation-type'
+            label='Validation Type'
+            value={validationType}
+            onChange={(value: string) => {
+              setValidationValue('');
+              setValidationType(value);
+            }}
+            options={VALIDATION_TYPES}
+          />
+        )}
         {validationType && (
           <ShrinkingLabelTextField
             id='edit-attribute-validation-value'

--- a/timur/lib/client/jsx/utils/edit_map.ts
+++ b/timur/lib/client/jsx/utils/edit_map.ts
@@ -34,7 +34,8 @@ export const REMOVABLE_ATTRIBUTE_TYPES = [
   'integer',
   'file',
   'image',
-  'file_collection'
+  'file_collection',
+  'matrix'
 ];
 
 export const EDITABLE_ATTRIBUTE_TYPES = [


### PR DESCRIPTION
Removes a current hole in modeling capabilities from the Timur map page.

Unfortunately, the current testbox UI is insufficient for the needs of our most common matrix attributes -- gene expression -- as the 20k+ geneids needed for this is an unwieldy string.

Idea for fixing that issue: Add alternative provision method of referencing another attribute's validation-value.