### PR TITLE
vesta - add nav-bar link to legacy site

### DIFF
--- a/vesta/ui/src/components/nav/dl-nav.tsx
+++ b/vesta/ui/src/components/nav/dl-nav.tsx
@@ -135,6 +135,12 @@ export default function DLNav({
                 onClick={handleClickNavLink}
                 typography={linkTypography}
             />
+            <NavLink
+                text='Legacy Version'
+                href={'https://datalibraryarchive.ucsf.edu/'}
+                onClick={handleClickNavLink}
+                typography={linkTypography}
+            />
         </Box>
     )
 }


### PR DESCRIPTION
Adds a link in the nav-bar to the legacy [datalibraryarchive.ucsf.edu](https://datalibraryarchive.ucsf.edu) site