### PR TITLE
Bugfix: Timur map edit to show correct attribute info after reselection

### DIFF
--- a/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
+++ b/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
@@ -51,7 +51,8 @@ export default function EditAttributeModal({
     updatedAttribute,
     validationType,
     validationValue,
-    isArrayValidation
+    isArrayValidation,
+    onSave
   ]);
 
   const reset = useCallback(() => {

--- a/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
+++ b/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
@@ -3,8 +3,6 @@ import React, {useState, useCallback, useEffect} from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-import {useActionInvoker} from 'etna-js/hooks/useActionInvoker';
-
 import ModelActionsModal, { ModelModalParams } from './model_actions_modal';
 import {Attribute} from '../../api/magma_api';
 import {SNAKE_CASE, COMMA_SEP, COMMA_SEP_WITH_SPACES, VALIDATION_TYPES} from '../../utils/edit_map';
@@ -25,6 +23,10 @@ export default function EditAttributeModal({
     attribute.validation ? attribute.validation.value : ''
   );
   const isArrayValidation = 'Array' === validationType;
+
+  useEffect(() => {
+    setUpdatedAttribute({...attribute})
+  }, [attribute])
 
   const handleOnSave = useCallback(() => {
     let params = {
@@ -60,14 +62,14 @@ export default function EditAttributeModal({
     setUpdatedAttribute({...attribute});
     setValidationType( attribute.validation ? attribute.validation.type : '');
     setValidationValue( attribute.validation ? attribute.validation.value : '');
-  }, []);
+  }, [attribute]);
 
   const disabled = !updatedAttribute.attribute_name
 
   const handleOnCancel = useCallback(() => {
     onClose();
     reset();
-  }, []);
+  }, [onClose, reset]);
 
   const updateAttribute = useCallback(
     (updatePairs: [string, string | boolean][]) => {

--- a/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
+++ b/timur/lib/client/jsx/components/model_map/edit_attribute_modal.tsx
@@ -24,10 +24,6 @@ export default function EditAttributeModal({
   );
   const isArrayValidation = 'Array' === validationType;
 
-  useEffect(() => {
-    setUpdatedAttribute({...attribute})
-  }, [attribute])
-
   const handleOnSave = useCallback(() => {
     let params = {
       ...updatedAttribute,
@@ -63,6 +59,10 @@ export default function EditAttributeModal({
     setValidationType( attribute.validation ? attribute.validation.type : '');
     setValidationValue( attribute.validation ? attribute.validation.value : '');
   }, [attribute]);
+
+  useEffect(() => {
+    reset()
+  }, [attribute])
 
   const disabled = !updatedAttribute.attribute_name
 


### PR DESCRIPTION
Bug Description: The Edit Attribute modal of the Timur map page could show the wrong data.  It happened because a few state variables, that fill the UIs of the `Edit` attribute modal, was only set at the time that the Attribute pane was first opened.  If the user clicked one attribute, then clicked a second attribute, and then tried to edit that second attribute without ever shutting and reopening the attribute summary pane, then the info shown would be stale and from the first attribute.

Fix: Adds `attribute` as an update trigger for the `onReset` callback that was also established only initially, then adds a `useEffect` to run `onReset` in order to update all these state variables whenever the selected `attribute` changes.  Also adds update triggers for the `handleOnCancel` callback, and the `handleOnSave` callback.  The remaining `updateAttribute` callback appears to have all required update triggers.