### PR TITLE
Interval scheduler + ingestion job fixes

### DIFF
--- a/etna/lib/etna/clients/metis/workflows/ingest_metis_data_workflow.rb
+++ b/etna/lib/etna/clients/metis/workflows/ingest_metis_data_workflow.rb
@@ -36,7 +36,7 @@ module Etna
         def copy_file(dest:, src:, &block)
           ingest_filesystem.with_readable(src, "r") do |io|
             metis_filesystem.do_streaming_upload(io, dest, ingest_filesystem.stat(src).size)
-            yield dest, true if block_given?
+            yield src, true if block_given?
           end
         end
       end

--- a/etna/lib/etna/clients/polyphemus/client.rb
+++ b/etna/lib/etna/clients/polyphemus/client.rb
@@ -78,11 +78,12 @@ module Etna
         json
       end
 
-      def get_previous_state(project_name, config_id, version_number, state: [])
+      def get_previous_state(project_name, config_id, version_number, state: [], collect: false)
         json = nil
         @etna_client.post("/api/workflows/#{project_name}/run/previous/#{config_id}",
           version_number: version_number,
-          state: state
+          state: state,
+          collect: collect
         ) do |res|
           json = JSON.parse(res.body)
         end

--- a/polyphemus/lib/client/jsx/workflow/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/workflow/run-pane.tsx
@@ -54,8 +54,10 @@ type SelectValue = {
   description: string;
 };
 
+type ParamType = 'select' | 'options' | 'boolean' | 'integer' | 'string' | 'datetime';
+
 type ComplexParam = {
-  type: string;
+  type: ParamType;
   values?: SelectValue[];
   valuesFrom?: string;
   description?: string;
@@ -71,15 +73,17 @@ type ParamComponent = {
 };
 
 const SelectParam = ({value, options,name,update,config}:ParamComponent) => {
-  const opts = options.values;
-  const defaultValue = options.default;
+  const { values, default: defaultValue } = options;
+
+  if (!values) return null;
+
   return (
     <Select
       value={value ? value : defaultValue ? defaultValue : ''}
       onChange={(e) => update(name, e.target.value as string)}
     >
       {
-        opts.map( opt =>
+        values.map( opt =>
           <MenuItem key={opt.value} value={opt.value}>
             {`${opt.value}${opt.description ? ` - ${opt.description}` : ''}`}
           </MenuItem>

--- a/polyphemus/lib/client/jsx/workflow/run-pane.tsx
+++ b/polyphemus/lib/client/jsx/workflow/run-pane.tsx
@@ -49,32 +49,30 @@ const useStyles = makeStyles((theme) => ({
 
 type Value = undefined | string | boolean | number;
 
-type SelectParam = {
+type SelectValue = {
   value: string;
   description: string;
 };
 
 type ComplexParam = {
   type: string;
-  values?: SelectParam[];
+  values?: SelectValue[];
   valuesFrom?: string;
   description?: string;
   default?: string;
 };
 
-const DefaultSelect = ({
-  value,
-  opts=[],
-  defaultValue,
-  name,
-  update
-}: {
+type ParamComponent = {
   value: Value;
-  opts?: SelectParam[];
-  defaultValue: string | undefined;
+  options: ComplexParam;
   name: string;
-  update: (name: string, value: string | boolean) => void;
-}) => {
+  update: (name: string, value: Value) => void;
+  config: any;
+};
+
+const SelectParam = ({value, options,name,update,config}:ParamComponent) => {
+  const opts = options.values;
+  const defaultValue = options.default;
   return (
     <Select
       value={value ? value : defaultValue ? defaultValue : ''}
@@ -91,78 +89,108 @@ const DefaultSelect = ({
   );
 };
 
+const OptionsParam = ({value, options,name,update,config}:ParamComponent) => {
+  const { values, valuesFrom } = options;
+  let onChange: (e: any, v: string[]) => void;
+  let fillValues: string[];
+
+  if (valuesFrom === 'model_names') {
+    fillValues = ['all'].concat(Object.keys(config).sort());
+    onChange = (e, v) => update(name, v.includes('all') ? 'all' : v.join(','));
+  } else if (values) {
+    fillValues = values.map(v => v.value);
+    onChange = (e, v) => update(name, v.join(','));
+  } else {
+    return null;
+  }
+
+  return (
+    <Autocomplete
+      multiple
+      fullWidth
+      id={name}
+      options={fillValues}
+      value={'' === value ? [] : (value as string)?.split(',') || []}
+      renderInput={(params) => <TextField {...params} variant='standard' />}
+      onChange={onChange}
+    />
+  );
+}
+
+const StringParam = ({value, options,name,update,config}:ParamComponent) => {
+  return (
+    <TextField
+      size='small'
+      placeholder={options.description}
+      fullWidth
+      value={value == undefined ? '' : value}
+      onChange={(e) => update(name, e.target.value)}
+    />
+  );
+}
+
+const BooleanParam = ({value, options,name,update,config}:ParamComponent) => {
+  return (
+    <Switch
+      size='small'
+      checked={value == undefined ? false : (value as boolean)}
+      onChange={(e) => update(name, e.target.checked)}
+    />
+  );
+}
+
+const IntegerParam = ({value, options,name,update,config}:ParamComponent) => {
+  return (
+    <TextField
+      size='small'
+      type='number'
+      placeholder={options.description}
+      fullWidth
+      value={value == undefined ? '' : value}
+      onChange={(e) => update(name, parseInt(e.target.value))}
+    />
+  );
+}
+
+const DateTimeParam = ({value, options,name,update,config}:ParamComponent) => {
+  return (
+    <TextField
+      size='small'
+      type='datetime-local'
+      placeholder={options.description}
+      fullWidth
+      value={value == undefined ? '' : value}
+      onChange={(e) => { console.log({ v: e.target.value}); update(name, e.target.value)} }
+    />
+  );
+}
+
+const PARAMS = {
+  select: SelectParam,
+  options: OptionsParam,
+  boolean: BooleanParam,
+  integer: IntegerParam,
+  string: StringParam,
+  datetime: DateTimeParam,
+}
+
 const Param = ({
   value,
   options,
   name,
   update,
   config
-}: {
-  value: Value;
-  options: ComplexParam;
-  name: string;
-  update: (name: string, value: Value) => void;
-  config: any;
-}) => {
-  if (options.type === 'options') {
-    const { values, valuesFrom } = options;
-    let onChange: (e: any, v: string[]) => void;
-    let fillValues: string[];
+}: ParamComponent) => {
+  if (options.type in PARAMS) {
+    const Component = PARAMS[options.type];
 
-    if (valuesFrom === 'model_names') {
-      fillValues = ['all'].concat(Object.keys(config).sort());
-      onChange = (e, v) => update(name, v.includes('all') ? 'all' : v.join(','));
-    } else if (values) {
-      fillValues = values.map(v => v.value);
-      onChange = (e, v) => update(name, v.join(','));
-    } else {
-      return null;
-    }
-
-    return (
-      <Autocomplete
-        multiple
-        fullWidth
-        id={name}
-        options={fillValues}
-        value={'' === value ? [] : (value as string)?.split(',') || []}
-        renderInput={(params) => <TextField {...params} variant='standard' />}
-        onChange={onChange}
-      />
-    );
-  } else if (options.type === 'select') {
-    return (
-      <DefaultSelect value={value} opts={options.values} name={name} update={update} defaultValue={options.default} />
-    );
-  } else if (options.type == 'string') {
-    return (
-      <TextField
-        size='small'
-        placeholder={options.description}
-        fullWidth
-        value={value == undefined ? '' : value}
-        onChange={(e) => update(name, e.target.value)}
-      />
-    );
-  } else if (options.type == 'boolean') {
-    return (
-      <Switch
-        size='small'
-        checked={value == undefined ? false : (value as boolean)}
-        onChange={(e) => update(name, e.target.checked)}
-      />
-    );
-  } else if (options.type == 'integer') {
-    return (
-      <TextField
-        size='small'
-        type='number'
-        placeholder={options.description}
-        fullWidth
-        value={value == undefined ? '' : value}
-        onChange={(e) => update(name, parseInt(e.target.value))}
-      />
-    );
+    return <Component
+      value={value}
+      options={options}
+      name={name}
+      update={update}
+      config={config}
+    />;
   }
 
   return null;

--- a/polyphemus/lib/data_eng/jobs/sftp_config.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_config.rb
@@ -1,0 +1,92 @@
+module WithSftpConfig
+  def project_name
+    config['project_name']
+  end
+
+  def workflow_config_id
+    config['config_id']
+  end
+
+  def workflow_version
+    config['version_number']
+  end
+
+  def magic_string
+    config['config']['magic_string']
+  end
+
+  def name_regex
+    Regexp.new("#{magic_string}(-|_)")
+  end
+
+  def file_regex
+    Regexp.new("#{magic_string}(-|_).*")
+  end
+
+  def initial_start_scan_time
+    runtime_config['config']['initial_start_scan_time']
+  end
+
+  def override_interval
+    runtime_config['config']['override_interval']
+  end
+
+  def deposit_root_path
+    # Mandatory params
+    ::File.join('/', config['config']['deposit_root_path'] || '')
+  end
+
+  def deposit_host
+    config["secrets"]["sftp_deposit_host"]
+  end
+
+  def deposit_user
+    config["secrets"]["sftp_deposit_user"]
+  end
+
+  def deposit_password
+    config["secrets"]["sftp_deposit_password"]
+  end
+
+  def override_root_path
+    runtime_config['config']['override_root_path'].yield_self do |path|
+      path == '' ? nil : path
+    end
+  end
+
+  def raw_ingest_root_path
+    config['config']['ingest_root_path']
+  end
+
+  def ingest_root_path
+    override_root_path || raw_ingest_root_path
+  end
+
+  def ingest_host
+    config["secrets"]["sftp_ingest_host"]
+  end
+
+  def ingest_user
+    config["secrets"]["sftp_ingest_user"]
+  end
+
+  def ingest_password
+    config["secrets"]["sftp_ingest_password"]
+  end
+
+  def metis_root_path
+    config['config']['metis_root_path']
+  end
+
+  def bucket_name
+    config['config']['bucket_name']
+  end
+
+  def notification_channel
+    config["config"]["notification_channel"]
+  end
+
+  def notification_webhook_url
+    config["secrets"]["notification_webhook_url"]
+  end
+end

--- a/polyphemus/lib/data_eng/jobs/sftp_deposit_uploader.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_deposit_uploader.rb
@@ -69,7 +69,11 @@ class SftpDepositUploaderJob < Polyphemus::ETLJob
       raise "Run #{run_id} not found"
     end
 
-    context[:files_to_update] = (run.dig("state","files_to_update") || []).map(&:symbolize_keys) 
+    context[:files_to_ignore] = fetch_successful_files
+
+    context[:files_to_update] = (run.dig("state","files_to_update") || []).map(&:symbolize_keys).reject do |file|
+      context[:files_to_ignore].include?(file[:path])
+    end
 
     if context[:files_to_update].empty?
       logger.info("No new files to upload...")
@@ -98,7 +102,7 @@ class SftpDepositUploaderJob < Polyphemus::ETLJob
           remote_filename: sftp_path,
           local_filename: deposit_path
         )
-        context[:successful_files] << deposit_path
+        context[:successful_files] << sftp_path
       rescue Etna::RemoteSSH::RemoteSSHError => e
         logger.warn("Failed to upload to deposit host #{deposit_host}: #{sftp_path}. Error: #{e.message}")
         context[:failed_files] << sftp_path 
@@ -114,28 +118,49 @@ class SftpDepositUploaderJob < Polyphemus::ETLJob
 
     msg += "\n" 
 
-    if context[:successful_files].any?
+    state = {}
+
+    if context[:successful_files]&.any?
       msg += "Uploaded #{context[:successful_files].size} files:\n" +
         context[:successful_files].join("\n")
+
+      state[:deposit_successful_files] = context[:successful_files]
     end
 
-    if context[:failed_files].any?
+    if context[:failed_files]&.any?
       msg += "Failed #{context[:failed_files].size} files:\n" +
         context[:failed_files].join("\n")
-
-      polyphemus_client.update_run(project_name, run_id, {
-        state: {
-          deposit_num_failed_files: context[:failed_files].size
-        },
-      })
 
       logger.warn("Found #{context[:failed_files].size} failed files")
 
       context[:failed_files].each do |file_path|
         logger.warn(file_path)
       end
+
+      state[:deposit_num_failed_files] = context[:failed_files].size
     end
     
+    unless state.empty?
+      polyphemus_client.update_run(project_name, run_id, { state: state })
+    end
+
     notify_slack(msg, channel: notification_channel, webhook_url: notification_webhook_url)
+  end
+
+  private
+
+  def fetch_successful_files
+    begin
+      response = polyphemus_client.get_previous_state(
+        project_name,
+        workflow_config_id,
+        state: [:deposit_successful_files],
+        collect: true
+      )
+      return Set.new((response["deposit_successful_files"] || []).flatten)
+    rescue Etna::Error => e
+      logger.warn("Error fetching previous state")
+      raise e
+    end
   end
 end

--- a/polyphemus/lib/data_eng/jobs/sftp_deposit_uploader.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_deposit_uploader.rb
@@ -1,63 +1,19 @@
 require_relative 'etl_job'
-require_relative 'common'
+require_relative 'sftp_config'
 
 class SftpDepositUploaderJob < Polyphemus::ETLJob
   include WithEtnaClients
   include WithSlackNotifications
   include WithLogger
+  include WithSftpConfig
 
   DEPOSIT_FAILED_FILES_CSV = "deposit_failed_files.csv"
-
-  def project_name
-    config['project_name']
-  end
-
-  def workflow_config_id
-    config['config_id']
-  end
-
-  def workflow_version
-    config['version_number']
-  end
-
-  def magic_string
-    config['config']['magic_string']
-  end
-
-  def name_regex
-    Regexp.new("#{magic_string}(-|_)")
-  end
-
-  def deposit_root_path
-    # Mandatory params
-    ::File.join('/', config['config']['deposit_root_path'] || '')
-  end
-
-  def deposit_host
-    config["secrets"]["sftp_deposit_host"]
-  end
-
-  def ingest_host
-    config["secrets"]["sftp_ingest_host"]
-  end
-
-  def ingest_host
-    config["secrets"]["sftp_ingest_host"]
-  end
-
-  def notification_channel
-    config["config"]["notification_channel"]
-  end
-
-  def notification_webhook_url
-    config["secrets"]["notification_webhook_url"]
-  end
 
   def remote_ssh
     @remote_ssh ||= Etna::RemoteSSH.new(
       host: deposit_host,
-      username: config["secrets"]["sftp_deposit_user"],
-      password: config["secrets"]["sftp_deposit_password"],
+      username: deposit_user,
+      password: deposit_password,
       root: deposit_root_path
     )
   end
@@ -96,8 +52,8 @@ class SftpDepositUploaderJob < Polyphemus::ETLJob
 
       begin
         remote_ssh.lftp_get(
-          username: config["secrets"]["sftp_ingest_user"],
-          password: config["secrets"]["sftp_ingest_password"],
+          username: ingest_user,
+          password: ingest_password,
           host: ingest_host,
           remote_filename: sftp_path,
           local_filename: deposit_path
@@ -157,7 +113,14 @@ class SftpDepositUploaderJob < Polyphemus::ETLJob
         state: [:deposit_successful_files],
         collect: true
       )
-      return Set.new((response["deposit_successful_files"] || []).flatten)
+      files = (response["deposit_successful_files"] || []).flatten.map do |filename|
+        override_root_path ? [
+          filename,
+          filename.sub(/^#{raw_ingest_root_path}/, override_root_path)
+        ] : filename
+      end.flatten
+
+      return Set.new(files)
     rescue Etna::Error => e
       logger.warn("Error fetching previous state")
       raise e

--- a/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
@@ -100,7 +100,6 @@ class SftpFileDiscoveryJob < Polyphemus::ETLJob
       response = polyphemus_client.get_previous_state(
         project_name,
         workflow_config_id,
-        workflow_version,
         state: [:end_time]
       )
       response["end_time"].to_i

--- a/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
@@ -1,54 +1,23 @@
 require_relative 'etl_job'
-require_relative 'common'
+require_relative 'sftp_config'
 require_relative '../clients/sftp_client'
 
 class SftpFileDiscoveryJob < Polyphemus::ETLJob
   include WithEtnaClients
   include WithLogger
+  include WithSftpConfig
 
   private
-
-  def project_name
-    config['project_name']
-  end
-
-  def workflow_config_id
-    config['config_id']
-  end
-
-  def workflow_version
-    config['version_number']
-  end
-
-  def magic_string
-    config['config']['magic_string']
-  end
-
-  def file_regex
-    Regexp.new("#{magic_string}(-|_).*")
-  end
-
-  def ingest_root_path
-    config['config']['ingest_root_path']
-  end
 
   def restart_scan?
     !!initial_start_scan_time
   end
 
-  def initial_start_scan_time
-    runtime_config['config']['initial_start_scan_time']
-  end
-
-  def override_interval
-    runtime_config['config']['override_interval']
-  end
-
   def sftp_client
     @sftp_client ||= SFTPClient.new(
-      config["secrets"]["sftp_ingest_host"],
-      config["secrets"]["sftp_ingest_user"],
-      config["secrets"]["sftp_ingest_password"],
+      ingest_host,
+      ingest_user,
+      ingest_password
     )
   end
 

--- a/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_file_discovery.rb
@@ -91,9 +91,9 @@ class SftpFileDiscoveryJob < Polyphemus::ETLJob
 
   def fetch_last_scan
     if restart_scan?
-      logger.info("Restarting scan... at #{Time.at(initial_start_scan_time).strftime('%Y-%m-%d %H:%M:%S')}")
+      logger.info("Restarting scan... at #{initial_start_scan_time}")
 
-      return initial_start_scan_time
+      return DateTime.parse(initial_start_scan_time).to_i
     end
 
     begin

--- a/polyphemus/lib/data_eng/jobs/sftp_metis_uploader.rb
+++ b/polyphemus/lib/data_eng/jobs/sftp_metis_uploader.rb
@@ -62,7 +62,11 @@ class SftpMetisUploaderJob < Polyphemus::ETLJob
 
     raise "Run #{run_id} not found" unless run
 
-    context[:files_to_update] = (run.dig("state","files_to_update") || []).map(&:symbolize_keys) 
+    context[:files_to_ignore] = fetch_successful_files
+
+    context[:files_to_update] = (run.dig("state","files_to_update") || []).map(&:symbolize_keys).reject do |file|
+      context[:files_to_ignore].include?(file[:path])
+    end
 
     if context[:files_to_update].empty?
       logger.info("No new files to upload...")
@@ -99,6 +103,8 @@ class SftpMetisUploaderJob < Polyphemus::ETLJob
       logger: nil,
     )
 
+    logger.info("Uploading #{context[:files_to_update].size} to metis at #{metis_root_path}")
+
     workflow.copy_files(context[:files_to_update].map do |file|
       [ file[:path], file[:path].gsub(name_regex, '') ]
     end) do |filename, success|
@@ -119,29 +125,50 @@ class SftpMetisUploaderJob < Polyphemus::ETLJob
 
     msg += "\n" 
 
-    if context[:successful_files].any?
+    state = {}
+
+    if context[:successful_files]&.any?
       msg += "Uploaded #{context[:successful_files].size} files:\n" +
         context[:successful_files].join("\n")
+
+      state[:metis_successful_files] = context[:successful_files]
     end
 
-    if context[:failed_files].any?
+    if context[:failed_files]&.any?
       msg += "Failed #{context[:failed_files].size} files:\n" +
         context[:failed_files].join("\n")
-
-      polyphemus_client.update_run(project_name, run_id, {
-        state: {
-          metis_num_failed_files: context[:failed_files].size
-        },
-      })
 
       logger.warn("Found #{context[:failed_files].size} failed files")
 
       context[:failed_files].each do |file_path|
         logger.warn(file_path)
       end
+
+      state[:metis_num_failed_files] = context[:failed_files].size
     end
     
+    unless state.empty?
+      polyphemus_client.update_run(project_name, run_id, { state: state })
+    end
+
     notify_slack(msg, channel: notification_channel, webhook_url: notification_webhook_url)
+  end
+
+  private
+
+  def fetch_successful_files
+    begin
+      response = polyphemus_client.get_previous_state(
+        project_name,
+        workflow_config_id,
+        state: [:metis_successful_files],
+        collect: true
+      )
+      return Set.new((response["metis_successful_files"] || []).flatten)
+    rescue Etna::Error => e
+      logger.warn("Error fetching previous state")
+      raise e
+    end
   end
 end
 

--- a/polyphemus/lib/data_eng/workflow_manifests/ingestion.rb
+++ b/polyphemus/lib/data_eng/workflow_manifests/ingestion.rb
@@ -28,6 +28,11 @@ class Polyphemus
               type: 'integer',
               description: 'Span in seconds, defaults to current time',
               default: nil
+            },
+            override_root_path: {
+              type: 'string',
+              description: 'Override current ingest root path',
+              default: nil
             }
           },
           secrets: [

--- a/polyphemus/lib/data_eng/workflow_manifests/ingestion.rb
+++ b/polyphemus/lib/data_eng/workflow_manifests/ingestion.rb
@@ -20,7 +20,7 @@ class Polyphemus
           },
           runtime_params: {
             initial_start_scan_time: {
-              type: 'integer', # unix timestamp
+              type: 'datetime',
               description: 'Scan start time, defaults to last completion',
               default: nil
             },

--- a/polyphemus/lib/models/runtime_configs.rb
+++ b/polyphemus/lib/models/runtime_configs.rb
@@ -32,7 +32,7 @@ class Polyphemus
     end
     
     def disabled?
-      disabled || run_interval.nil? || run_interval == 0
+      disabled || run_interval.nil? || run_interval <= 0
     end
 
     def should_run?

--- a/polyphemus/lib/models/runtime_configs.rb
+++ b/polyphemus/lib/models/runtime_configs.rb
@@ -5,41 +5,48 @@ class Polyphemus
 
     # TODO: maybe move the scheduling logic to CronWorkflows
     def self.eligible_runtime_configs
-
-      eligible_runtime_configs = []
-
-      # Get all runtime configs where interval is not null/none - runtime configs initiated as empty when configs are created
-      runtime_configs = self.exclude(disabled: true).exclude(run_interval: nil).all
-
-      runtime_configs.select do |runtime_config|
-     
-        config = Polyphemus::Config.current.where(
-          config_id: runtime_config.config_id,
-        ).first
-
-        run = Polyphemus::Run.where(
-            config_id: config.config_id,
-        ).order(:created_at).last
-        
-        next unless run&.orchestrator_metadata
-        
-        if run.is_finished?
-          if run.is_succeeded?
-            # Check if enough time has elapsed since last run based on interval
-            time_since_last_run = Time.now - DateTime.parse(run.finished_at).to_time
-            if time_since_last_run >= runtime_config.run_interval
-              eligible_runtime_configs << runtime_config
-            end
-          end
-        end
-      end
-      eligible_runtime_configs
+      # Get all runtime configs where interval is not null/none - runtime
+      # configs initiated as empty when configs are created
+      self.exclude(disabled: true)
+        .exclude(run_interval: nil)
+        .exclude(run_interval: 0)
+        .all.select(&:should_run?)
     end
 
     def self.for_config(config_id)
       Polyphemus::RuntimeConfig.where(
         config_id: config_id
-      ).first || nil
+      ).first
+    end
+
+    def workflow_config
+      @workflow_config ||= Polyphemus::Config.current.where(
+        config_id: config_id,
+      ).first
+    end
+
+    def last_run
+      Polyphemus::Run.where(
+        config_id: config_id,
+      ).order(:created_at).last
+    end
+    
+    def disabled?
+      disabled || run_interval.nil? || run_interval == 0
+    end
+
+    def should_run?
+      return false if disabled?
+
+      run = last_run
+      
+      return true if !run
+
+      if run.is_finished? && run.is_succeeded?
+        time_since_last_run = Time.now - DateTime.parse(run.finished_at).to_time
+
+        return time_since_last_run >= run_interval
+      end
     end
   end
 end

--- a/polyphemus/lib/polyphemus.rb
+++ b/polyphemus/lib/polyphemus.rb
@@ -16,6 +16,7 @@ class Polyphemus
     return if @db
     @db = Sequel.connect(config(:db))
     @db.extension :connection_validator
+    Sequel.extension :pg_json_ops
     @db.extension :pg_json
     @db.pool.connection_validation_timeout = -1
   end

--- a/polyphemus/lib/polyphemus/controllers/log_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/log_controller.rb
@@ -69,7 +69,7 @@ class LogController < Polyphemus::Controller
 
     logs = Polyphemus::Log.where(
       query
-    ).limit(100).all
+    ).order(Sequel.desc(:created_at)).limit(100).all
 
     success_json(logs: logs.map(&:to_report))
   end

--- a/polyphemus/spec/data_eng/sftp_deposit_uploader_job_spec.rb
+++ b/polyphemus/spec/data_eng/sftp_deposit_uploader_job_spec.rb
@@ -5,7 +5,7 @@ describe SftpDepositUploaderJob do
   end
 
   let(:config) {
-    config = {
+    {
       "project_name" => "labors",
       "secrets" => {
         "sftp_ingest_host" => "some-sftp-host", 
@@ -27,7 +27,6 @@ describe SftpDepositUploaderJob do
       "config_id" => "1",
       "version_number" => "1"
     }
-    config
   }
 
   # TODO: eventually add mutliple files to test with, but running into stubbing and streaming errors
@@ -76,24 +75,48 @@ describe SftpDepositUploaderJob do
     before do
       stub_initial_sftp_connection
       stub_initial_ssh_connection
-      stub_polyphemus_get_run(config["project_name"], run_id, run_record)
       fake_stream = StringIO.new("fake file content")
       stub_sftp_client_download_as_stream(return_io: fake_stream)
-      stub_polyphemus_update_run(config["project_name"], run_id, captured_requests)
       stub_slack(config["secrets"]["notification_webhook_url"])
+      stub_polyphemus_get_run(config["project_name"], run_id, run_record)
+      stub_polyphemus_update_run(config["project_name"], run_id, captured_requests)
+      stub_polyphemus_get_last_state(
+        config["project_name"],
+        config["config_id"],
+        {}
+      )
     end 
 
     it 'successfully uploads files' do
       stub_remote_ssh_mkdir_p
       stub_remote_ssh_file_upload(success: true)
 
-      stub_polyphemus_update_run(config["project_name"], run_id, captured_requests)
-
       job = create_job(config, runtime_config)
       context = job.execute
 
       expect(context[:failed_files]).to be_empty
-      expect(captured_requests).to be_empty
+      expect(captured_requests.first[:state]).to eq(
+        deposit_successful_files: [ sftp_files.first[:path] ]
+      )
+    end
+
+    it 'skips already uploaded files' do
+      stub_remote_ssh_mkdir_p
+      stub_remote_ssh_file_upload(success: true)
+
+      stub_polyphemus_get_last_state(
+        config["project_name"],
+        config["config_id"],
+        {
+          deposit_successful_files: [ [ sftp_files.first[:path] ] ]
+        }
+      )
+
+      job = create_job(config, runtime_config)
+      context = job.execute
+
+      expect(context[:files_to_update]).to be_empty
+      expect(captured_requests).to eq([])
     end
 
     it 'fails to upload files' do
@@ -107,7 +130,9 @@ describe SftpDepositUploaderJob do
       job = create_job(config, runtime_config)
       context = job.execute
 
-      expect(captured_requests[0][:state][:deposit_num_failed_files]).to eq(1)
+      expect(captured_requests[0][:state]).to eq(
+        deposit_num_failed_files: 1
+      )
     end
   end
 end

--- a/polyphemus/spec/data_eng/sftp_file_discovery_job_spec.rb
+++ b/polyphemus/spec/data_eng/sftp_file_discovery_job_spec.rb
@@ -68,13 +68,13 @@ describe SftpFileDiscoveryJob do
       runtime_config = {
         "config" => {
           "override_interval" => 864000, # 10 days
-          "initial_start_scan_time" => 1672531200, #Jan 1, 2023
+          "initial_start_scan_time" => '2023-01-01T00:00:00'
         }
       }
       job = create_job(config, runtime_config)
       job.execute
-      expect(captured_requests[0][:state][:start_time]).to eq(runtime_config["config"]["initial_start_scan_time"])
-      expect(captured_requests[0][:state][:end_time]).to eq(runtime_config["config"]["initial_start_scan_time"] + runtime_config["config"]["override_interval"])
+      expect(captured_requests[0][:state][:start_time]).to eq(DateTime.parse(runtime_config["config"]["initial_start_scan_time"]).to_i)
+      expect(captured_requests[0][:state][:end_time]).to eq(DateTime.parse(runtime_config["config"]["initial_start_scan_time"]).to_i + runtime_config["config"]["override_interval"])
     end
 
     it 'sets the end time to the current time if no interval is provided' do
@@ -84,12 +84,12 @@ describe SftpFileDiscoveryJob do
       runtime_config = {
         "config" => {
           "interval" => nil,
-          "initial_start_scan_time" => 1672531200, #Jan 1, 2023
+          "initial_start_scan_time" => '2023-01-01T00:00:00'
         }
       }
       job = create_job(config, runtime_config)
       job.execute
-      expect(captured_requests[0][:state][:start_time]).to eq(runtime_config["config"]["initial_start_scan_time"])
+      expect(captured_requests[0][:state][:start_time]).to eq(DateTime.parse(runtime_config["config"]["initial_start_scan_time"]).to_i)
       expect(captured_requests[0][:state][:end_time]).to be_within(5).of(Time.now.to_i)
     end
 
@@ -102,7 +102,7 @@ describe SftpFileDiscoveryJob do
       {
         "config" => {
           "interval" => 864000, # 10 days
-          "initial_start_scan_time" => 1672531200, #Jan 1, 2023
+          "initial_start_scan_time" => '2023-01-01T00:00:00'
         }
       }
     }

--- a/polyphemus/spec/data_eng/sftp_file_discovery_job_spec.rb
+++ b/polyphemus/spec/data_eng/sftp_file_discovery_job_spec.rb
@@ -136,7 +136,11 @@ describe SftpFileDiscoveryJob do
     }
 
     before do
-      stub_polyphemus_get_last_state(config["project_name"], config["config_id"], config["version_number"], last_state)
+      stub_polyphemus_get_last_state(
+        config["project_name"],
+        config["config_id"],
+        last_state
+      )
       stub_initial_sftp_connection
       stub_sftp_search_files(sftp_files)
     end

--- a/polyphemus/spec/helpers/notifications_spec.rb
+++ b/polyphemus/spec/helpers/notifications_spec.rb
@@ -4,14 +4,36 @@ describe WithSlackNotifications do
   end
 
   let(:url) {Polyphemus.instance.config(:slack_webhook_url)}
+  let(:msg) {
+    "Hail the storm-footed, golden-winged daughter of Thaumas\n" +
+    "Shining in the raiment of her radiant spectrum"
+  }
 
   it 'sends a mesage to slack' do
     stub_slack
-    msg = 'Hail the storm-footed, golden-winged daughter of Thaumas'
 
     TestNotifier.new.notify_slack( msg, channel: '#agora')
     expect(WebMock).to have_requested(:post, url).with(
       body: hash_including(text: msg)
     )
+  end
+
+  context "message size" do
+    before do
+      WithSlackNotifications.send(:remove_const,:MESSAGE_SIZE)
+      WithSlackNotifications.const_set(:MESSAGE_SIZE, 80)
+    end
+
+    after do
+      WithSlackNotifications.send(:remove_const,:MESSAGE_SIZE)
+      WithSlackNotifications.const_set(:MESSAGE_SIZE, 8000)
+    end
+
+    it 'splits a large message into several' do
+      stub_slack
+
+      TestNotifier.new.notify_slack( msg, channel: '#agora')
+      expect(WebMock).to have_requested(:post, url).times(2)
+    end
   end
 end

--- a/polyphemus/spec/models/runtime_configs_spec.rb
+++ b/polyphemus/spec/models/runtime_configs_spec.rb
@@ -7,74 +7,87 @@ describe Polyphemus::RuntimeConfig do
   end
 
   before do
-    config_1 = Polyphemus::Config.create(
-      project_name: 'labors',
-      workflow_name: 'my-cat-ingestion',
-      workflow_type: 'cat-ingestion',
-      config_id: Polyphemus::Config.next_id,
-      version_number: 1,
-      config: {},
-      secrets: {},
-    )
-    runtime_config_1 = Polyphemus::RuntimeConfig.create(
-      config_id: config_1.config_id,
+    Timecop.freeze('2025-01-16T12:30:00Z')
+    create_workflow(
+      workflow_name: 'ready-workflow',
       run_interval: 1000,
-      config: some_config
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:10:00Z',
     )
 
-    Polyphemus::Run.create(
-      run_id: "hello-there-1",
-      config_id: config_1.config_id,
-      version_number: config_1.version_number,
-      name: 'my-cat-ingestion-1000',
-      orchestrator_metadata: {
-        'startedAt' => '2025-01-16T12:00:00Z',
-        "nodes" => {
-          "step-node" => {
-            'finishedAt' => '2025-01-16T12:20:00Z',
-            'type' => 'Steps',
-            'phase' => 'Succeeded'
-          }
-        }
-      }
+    create_workflow(
+      workflow_name: 'running-workflow',
+      run_interval: 1000,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: nil,
+      status: 'Running'
     )
 
-    config_2 = Polyphemus::Config.create(
-      project_name: 'labors',
-      workflow_name: 'my-cat-ingestion-2',
-      workflow_type: 'cat-ingestion',
-      config_id: Polyphemus::Config.next_id,
-      version_number: 1,
-      config: {},
-      secrets: {},
+    create_workflow(
+      workflow_name: 'pending-workflow',
+      run_interval: 1000_000,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:10:00Z',
     )
 
-    runtime_config_2 = Polyphemus::RuntimeConfig.create(
-      config_id: config_2.config_id,
+    create_workflow(
+      workflow_name: 'failed-workflow',
+      run_interval: 1000,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:20:00Z',
+      status: "Failed"
+    )
+
+    fixed_config, *_ = create_workflow(
+      workflow_name: 'fixed-workflow',
+      run_interval: 1000,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:05:00Z',
+      status: "Failed"
+    )
+    create_run(fixed_config, 1001,
+      run_start: '2025-01-16T12:06:00Z',
+      run_stop: '2025-01-16T12:08:00Z',
+      status: 'Succeeded'
+    )
+
+    create_workflow(
+      workflow_name: 'ignored-workflow',
+      run_interval: 0,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:10:00Z',
+    )
+
+    create_workflow(
+      workflow_name: 'ignored-workflow-2',
+      run_interval: nil,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:10:00Z',
+    )
+
+    create_workflow(
+      workflow_name: 'disabled-workflow',
+      run_interval: 100000,
+      disabled: true,
+      run_start: '2025-01-16T12:00:00Z',
+      run_stop: '2025-01-16T12:10:00Z',
+    )
+
+    create_workflow(
+      workflow_name: 'new-workflow',
       run_interval: 1000
     )
+  end
 
-    Polyphemus::Run.create(
-      run_id: "hello-there-2",
-      config_id: config_2.config_id,
-      version_number: config_2.version_number,
-      name: 'my-cat-ingestion-2000',
-      orchestrator_metadata: {
-        'startedAt' => '2025-01-16T12:00:00Z',
-        "nodes" => {
-          "step-node" => {
-            'finishedAt' => '2025-01-16T12:10:00Z',
-            'type' => 'Steps',
-            'phase' => 'Succeeded'
-          }
-        }
-      }
-    )
-
+  after do
+    Timecop.return
   end
 
   it 'correctly returns configs eligible for scheduling' do
-      eligible_runtime_configs = Polyphemus::RuntimeConfig.eligible_runtime_configs
-      expect(eligible_runtime_configs[0].config).to eq(some_config)
+    eligible_runtime_configs = Polyphemus::RuntimeConfig.eligible_runtime_configs
+    expect(eligible_runtime_configs.length).to eq(3)
+    expect(eligible_runtime_configs.map(&:workflow_config).map(&:workflow_name)).to match_array(
+      ["ready-workflow", "new-workflow", "fixed-workflow"]
+    )
   end
 end

--- a/polyphemus/spec/spec_helper.rb
+++ b/polyphemus/spec/spec_helper.rb
@@ -142,6 +142,10 @@ FactoryBot.define do
   factory :log, class: Polyphemus::Log do
      to_create(&:save)
   end
+
+  factory :run, class: Polyphemus::Run do
+     to_create(&:save)
+  end
 end
 
 def json_body

--- a/polyphemus/spec/spec_helper.rb
+++ b/polyphemus/spec/spec_helper.rb
@@ -139,11 +139,11 @@ FactoryBot.define do
      to_create(&:save)
   end
 
-  factory :log, class: Polyphemus::Log do
+  factory :run, class: Polyphemus::Run do
      to_create(&:save)
   end
 
-  factory :run, class: Polyphemus::Run do
+  factory :log, class: Polyphemus::Log do
      to_create(&:save)
   end
 end
@@ -634,12 +634,70 @@ def create_metis_file(file_name, file_path, file_hash: SecureRandom.hex, updated
   })
 end
 
+def create_run(config_o, run_num, status:, run_start:,run_stop:)
+  create(:run, {
+    config_id: config_o.config_id,
+    run_id: SecureRandom.hex,
+    name: "#{config_o.workflow_name}-#{run_num}",
+    version_number: config_o.version_number,
+    created_at: run_start || Time.now,
+    orchestrator_metadata: status == 'Running' ? nil : {
+      'startedAt' => run_start,
+      "nodes" => {
+        "step-node" => {
+          'finishedAt' => run_stop,
+          'type' => 'Steps',
+          'phase' => status
+        }
+      }
+    }
+  })
+end
+
+def create_config(params)
+  create(
+    :config,
+    {
+      project_name: 'labors',
+      config_id: Polyphemus::Config.next_id,
+      workflow_type: 'test',
+      version_number: 1,
+      config: {},
+      secrets: {}
+    }.merge(params)
+  )
+end
+
+def create_workflow(workflow_name:, run_interval:, runtime_config: {}, run_start: nil, run_stop: nil, disabled: false, status: 'Succeeded')
+  config_o = create_config(
+    workflow_name: workflow_name,
+    workflow_type: 'test'
+  )
+  runtime_config_o = create( :runtime_config,
+    config_id: config_o.config_id,
+    config: runtime_config,
+    run_interval: run_interval,
+    disabled: disabled
+  )
+
+  if run_start
+    run_o = create_run(
+      config_o, 1000,
+      status: status,
+      run_start: run_start,
+      run_stop: run_stop
+    )
+  end
+
+  return config_o, runtime_config_o, run_o
+end
+
 ## Polyphemus V2
 
 class TestManifest < Polyphemus::WorkflowManifest
     def self.as_json
     {
-      name: 'test-workflow',
+      name: 'test',
       schema: {
         type: 'object',
         properties: {
@@ -659,7 +717,7 @@ class TestManifest < Polyphemus::WorkflowManifest
 end
 
 # Polyphemus API Stubs
-def stub_polyphemus_get_last_state(project_name, config_id, version_number, last_state)
+def stub_polyphemus_get_last_state(project_name, config_id, last_state)
   stub_request(:post, "#{POLYPHEMUS_HOST}/api/workflows/#{project_name}/run/previous/#{config_id}")
     .to_return({
       status: 200,

--- a/polyphemus/spec/workflow_controller_spec.rb
+++ b/polyphemus/spec/workflow_controller_spec.rb
@@ -12,16 +12,15 @@ describe WorkflowController do
   let(:run_id) { "argo_run_id_22" }
 
   def create_workflow_with_configs
-    auth_header(:editor)
-    json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
-    expect(last_response.status).to eq(200)
-    some_config = { "test_key" => 'update 1' }
-    json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+    create(:config,
+      project_name: 'labors',
+      secrets: {},
+      config_id: 1,
+      version_number: 2,
       workflow_name: 'my workflow name',
       workflow_type: 'test-workflow',
-      config: some_config
+      config: { "test_key" => 'update 1' }
     )
-    expect(last_response.status).to eq(200)
   end
 
   context 'config creation' do
@@ -51,7 +50,7 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       expect(Polyphemus::RuntimeConfig.count).to eq(1)
-      expect(Polyphemus::RuntimeConfig.last.config_id).to eq(json_body[:config_id])
+      expect(Polyphemus::RuntimeConfig.last.config_id).to eq(config_id)
     end
   end
 
@@ -62,7 +61,7 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_config = { 'test_key' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: some_config
@@ -72,20 +71,20 @@ describe WorkflowController do
       # Contains the updated config
       expect(first_config.config).to eq(some_config)
       # Contains the same config_id
-      expect(first_config.config_id).to eq(json_body[:config_id])
+      expect(first_config.config_id).to eq(config_id)
       # Contains a new version number
       expect(first_config.version_number).to eq(2)
 
 
       another_config = { 'test_key' => 'update 2' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: another_config
       )
       expect(last_response.status).to eq(200)
       second_config = Polyphemus::Config.last
-      expect(second_config.config_id).to eq(json_body[:config_id])
+      expect(second_config.config_id).to eq(config_id)
       expect(second_config.config).to eq(another_config)
       expect(second_config.version_number).to eq(3)
       expect(second_config.updated_at).to_not eq(first_config.updated_at)
@@ -97,7 +96,7 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_config = { 'not a valid key' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: some_config
@@ -110,7 +109,7 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_secret = { 'test_secret' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         secrets: some_secret
@@ -121,14 +120,14 @@ describe WorkflowController do
       expect(the_config.version_number).to eq(1)
 
       another_secret = { 'test_secret' => 'update 2' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         secrets: another_secret
       )
       expect(last_response.status).to eq(200)
       updated_config = Polyphemus::Config.last
-      expect(updated_config.config_id).to eq(json_body[:config_id])
+      expect(updated_config.config_id).to eq(config_id)
       expect(updated_config.secrets).to eq(another_secret)
       expect(updated_config.version_number).to eq(1)
       expect(updated_config.created_at).to eq(the_config.created_at)
@@ -140,7 +139,7 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_secret = { 'not_a_secret' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         secrets: some_secret
@@ -159,14 +158,14 @@ describe WorkflowController do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_config = { 'test_key' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: some_config
       )
       expect(last_response.status).to eq(200)
       another_config = { 'test_key' => 'update 2' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: another_config
@@ -176,14 +175,14 @@ describe WorkflowController do
 
     it 'returns the most recent config when version is not specified' do
       auth_header(:editor)
-      get("/api/workflows/labors/configs/#{json_body[:config_id]}")
+      get("/api/workflows/labors/configs/#{config_id}")
       expect(last_response.status).to eq(200)
       expect(json_body[:version_number]).to eq(3)
     end
 
     it 'returns a config by id and version' do
       auth_header(:editor)
-      get("/api/workflows/labors/configs/#{json_body[:config_id]}?version=1")
+      get("/api/workflows/labors/configs/#{config_id}?version=1")
       expect(last_response.status).to eq(200)
       expect(json_body[:version_number]).to eq(1)
     end
@@ -259,20 +258,20 @@ context '#revisions' do
       json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
       expect(last_response.status).to eq(200)
       some_config = { 'test_key' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: some_config
       )
       expect(last_response.status).to eq(200)
       another_config = { 'test_key' => 'update 2' }
-      json_post("/api/workflows/labors/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
         workflow_type: 'test-workflow',
         config: another_config
       )
       auth_header(:editor)
-      get("/api/workflows/labors/revisions/#{json_body[:config_id]}")
+      get("/api/workflows/labors/revisions/#{config_id}")
       expect(last_response.status).to eq(200)
       expect(json_body.length).to eq(3)
       expect(json_body[0][:version_number]).to eq(3)
@@ -282,15 +281,13 @@ context '#revisions' do
   end
 
   context 'run updates' do
-    before do
-      create_workflow_with_configs
-    end
+    let(:config_id) { create_workflow_with_configs.config_id }
 
     it 'creates the run when it does not exist' do
       auth_header(:editor)
       the_state = {"some_state" => "wooo!"}
       json_post("/api/workflows/labors/run/update/#{run_id}",
-        config_id: json_body[:config_id],
+        config_id: config_id,
         version_number: 2,
         name: "test-workflow-1999",
         state: the_state
@@ -309,7 +306,7 @@ context '#revisions' do
 
       # Create initial run
       json_post("/api/workflows/labors/run/update/#{run_id}",
-        config_id: json_body[:config_id],
+        config_id: config_id,
         version_number: 2,
         name: "test-workflow-1999",
         state: the_state
@@ -337,7 +334,7 @@ context '#revisions' do
 
       # Create run metadata with initial output
       json_post("/api/workflows/labors/run/update/#{run_id}",
-        config_id: json_body[:config_id],
+        config_id: config_id,
         version_number: 2,
         name: "test-workflow-1999",
         output: initial_output
@@ -356,9 +353,8 @@ context '#revisions' do
   end
 
   context 'retrieve the workflow state' do
-    before do
-      create_workflow_with_configs
-    end
+    let(:config_id) { create_workflow_with_configs.config_id }
+
     it 'raises and error when a workflow has not been run yet' do
       auth_header(:editor)
       get("/api/workflows/labors/run/#{run_id}")
@@ -370,7 +366,7 @@ context '#revisions' do
       auth_header(:editor)
       the_state = {:some_state => "ya_hooo!"}
       json_post("/api/workflows/labors/run/update/#{run_id}",
-        config_id: json_body[:config_id],
+        config_id: config_id,
         version_number: 2,
         name: "test-workflow-1999",
         state: the_state
@@ -383,22 +379,23 @@ context '#revisions' do
   end
 
   context 'retrieve the previous workflow state' do
+    let(:config_id) { create_workflow_with_configs.config_id }
+
     before do
-      create_workflow_with_configs
-      # Create a new run
-      auth_header(:editor)
       the_state = {:some_state => "ya_hooo!", :another_state => "woohoo!"}
-      json_post("/api/workflows/labors/run/update/#{run_id}",
-        config_id: json_body[:config_id],
-        version_number: 2,
+      create(:run, 
+        run_id: run_id,
         name: "test-workflow-1999",
-        state: the_state
+        config_id: config_id,
+        version_number: 2,
+        state: the_state,
+        created_at: Time.now
       )
     end
 
     it 'returns the specific state when a state is specified' do
       state_to_retrieve = [:some_state]
-      post("/api/workflows/labors/run/previous/#{json_body[:config_id]}",
+      post("/api/workflows/labors/run/previous/#{config_id}",
         version_number: 2,
         state: state_to_retrieve
       )
@@ -406,8 +403,27 @@ context '#revisions' do
       expect(json_body).to eq(:some_state => "ya_hooo!")
     end
 
+    it 'returns all previous states available' do
+      state_to_retrieve = [:some_state]
+      post("/api/workflows/labors/run/previous/#{config_id}",
+        version_number: 2,
+        state: state_to_retrieve
+      )
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(:some_state => "ya_hooo!")
+    end
+
+    it 'returns a previous state across version changes' do
+    end
+
+    it 'returns a previous state even if the last state was nil' do
+    end
+
+    it 'returns a previous state if the last state was present but lacking the requested keys' do
+    end
+
     it 'raises an error when a state is not found' do
-      post("/api/workflows/labors/run/previous/#{json_body[:config_id]}",
+      post("/api/workflows/labors/run/previous/#{config_id}",
         version_number: 2,
         state: [:some_state_that_doesnt_exist, :another_state_that_doesnt_exist]
       )
@@ -418,13 +434,11 @@ context '#revisions' do
   end
 
   context 'runtime configs updates' do
-    before do
-      create_workflow_with_configs
-    end
+    let(:config_id) { create_workflow_with_configs.config_id }
 
     it 'updates existing runtime config' do
       config = {:commit  => true }
-      json_post("/api/workflows/labors/runtime_configs/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: config,
         run_interval: 60, 
         disabled: true
@@ -433,7 +447,7 @@ context '#revisions' do
 
       # Update metadata
       new_config = {:commit  => false}
-      json_post("/api/workflows/labors/runtime_configs/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: new_config,
         run_interval: 120
       )
@@ -445,7 +459,7 @@ context '#revisions' do
 
     it 'raises an error when the runtime config is invalid' do
       config = {:not_a_valid_param  => "not a boolean" }
-      json_post("/api/workflows/labors/runtime_configs/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: config,
       )
       expect(last_response.status).to eq(422)
@@ -455,9 +469,7 @@ context '#revisions' do
   end
 
   context 'retrieving runtime configs' do
-    before do
-      create_workflow_with_configs
-    end
+    let(:config_id) { create_workflow_with_configs.config_id }
 
     it 'raises an error when runtime config does not exist' do
       config_id_that_doesnt_exit = 10000
@@ -468,26 +480,24 @@ context '#revisions' do
 
     it 'retrieves existing run metadata' do
       a_config = {:commit  => true }
-      json_post("/api/workflows/labors/runtime_configs/update/#{json_body[:config_id]}",
+      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: a_config,
         run_interval: 120
       )
       expect(last_response.status).to eq(200)
       
       # Retrieve and verify
-      get("/api/workflows/labors/runtime_configs/#{json_body[:config_id]}")
+      get("/api/workflows/labors/runtime_configs/#{config_id}")
       expect(last_response.status).to eq(200)
       expect(json_body[:config]).to eq(a_config)
     end
   end
 
   context 'running a workflow once' do
-    before do
-      create_workflow_with_configs
-    end
+    let(:config_id) { create_workflow_with_configs.config_id }
 
     it 'successfully runs a workflow' do
-      config = Polyphemus::Config.current.where(project_name: 'labors', config_id: json_body[:config_id]).first
+      config = Polyphemus::Config.current.where(project_name: 'labors', config_id: config_id).first
       
       # Stub argo client command
       workflow_output = "Workflow Name: simple-two-jobs-ktm4g\nWorkflow UID: de6df0ed-b32c-4707-814f-11c323b0687b\n"
@@ -516,7 +526,7 @@ context '#revisions' do
 
     it 'fails when workflow submission fails' do
       # If we don't mock anything this will fail since there is no workflow.yaml for test-workflow.yaml
-      config = Polyphemus::Config.current.where(project_name: 'labors', config_id: json_body[:config_id]).first
+      config = Polyphemus::Config.current.where(project_name: 'labors', config_id: config_id).first
       allow(Open3).to receive(:capture3).and_return(["", "Command failed", double(success?: false)])
       json_post("/api/workflows/labors/runtime_configs/run_once/#{config.config_id}", 
         workflow_type: "test-workflow",

--- a/polyphemus/spec/workflow_controller_spec.rb
+++ b/polyphemus/spec/workflow_controller_spec.rb
@@ -11,29 +11,29 @@ describe WorkflowController do
 
   let(:run_id) { "argo_run_id_22" }
 
-  def create_workflow_with_configs
-    create(:config,
+  def create_workflow_with_configs(params={})
+    create(:config, {
       project_name: 'labors',
       secrets: {},
-      config_id: 1,
+      config_id: Polyphemus::Config.next_id,
       version_number: 2,
       workflow_name: 'my workflow name',
-      workflow_type: 'test-workflow',
+      workflow_type: 'test',
       config: { "test_key" => 'update 1' }
-    )
+    }.merge(params))
   end
 
   context 'config creation' do
     it 'initializes a workflow' do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
 
       expect(last_response.status).to eq(200)
       expect(Polyphemus::Config.count).to eq(1)
       config = Polyphemus::Config.last
 
       expect(config.workflow_name).to eq('my workflow name')
-      expect(config.workflow_type).to eq('test-workflow')
+      expect(config.workflow_type).to eq('test')
       expect(config.config_id).to eq(1)
       expect(config.created_at).to be_within(3.second).of(Time.now)
       expect(config.updated_at).to be_within(3.second).of(Time.now)
@@ -47,39 +47,41 @@ describe WorkflowController do
 
     it 'creates a runtime config when a workflow is created' do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
       expect(last_response.status).to eq(200)
+      expect(Polyphemus::Config.count).to eq(1)
       expect(Polyphemus::RuntimeConfig.count).to eq(1)
-      expect(Polyphemus::RuntimeConfig.last.config_id).to eq(config_id)
+      expect(Polyphemus::RuntimeConfig.last.config_id).to eq(Polyphemus::Config.last.config_id)
     end
   end
 
   context 'config updates' do
+    let(:config_id) { create_workflow_with_configs(version_number: 1).config_id }
 
     it 'correctly updates the config and version number' do
-      auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
-      expect(last_response.status).to eq(200)
       some_config = { 'test_key' => 'update 1' }
+
+      auth_header(:editor)
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config: some_config
       )
+
       expect(last_response.status).to eq(200)
+
+      expect(Polyphemus::Config.count).to eq(2)
+
       first_config = Polyphemus::Config.last
-      # Contains the updated config
       expect(first_config.config).to eq(some_config)
-      # Contains the same config_id
       expect(first_config.config_id).to eq(config_id)
-      # Contains a new version number
       expect(first_config.version_number).to eq(2)
 
 
       another_config = { 'test_key' => 'update 2' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config: another_config
       )
       expect(last_response.status).to eq(200)
@@ -93,12 +95,13 @@ describe WorkflowController do
 
     it 'rejects an invalid config' do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
       expect(last_response.status).to eq(200)
+
       some_config = { 'not a valid key' => 'update 1' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config: some_config
       )
       expect(last_response.status).to eq(422)
@@ -106,12 +109,12 @@ describe WorkflowController do
 
     it 'updates secrets and not the version number' do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
       expect(last_response.status).to eq(200)
       some_secret = { 'test_secret' => 'update 1' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         secrets: some_secret
       )
       expect(last_response.status).to eq(200)
@@ -122,7 +125,7 @@ describe WorkflowController do
       another_secret = { 'test_secret' => 'update 2' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         secrets: another_secret
       )
       expect(last_response.status).to eq(200)
@@ -136,38 +139,40 @@ describe WorkflowController do
 
     it 'rejects unknown secrets' do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
       expect(last_response.status).to eq(200)
       some_secret = { 'not_a_secret' => 'update 1' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         secrets: some_secret
       )
       config = Polyphemus::Config.last
       expect(last_response.status).to eq(422)
-      expect(json_body[:error]).to eq('Secrets for test-workflow must be one of: test_secret')
+      expect(json_body[:error]).to eq('Secrets for test must be one of: test_secret')
       expect(config.secrets).to eq({})
     end
 
   end
 
   context 'retrieve a config' do
+    let(:config_id) { create_workflow_with_configs(version_number: 1).config_id }
+
     before do
       auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
+      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test')
       expect(last_response.status).to eq(200)
       some_config = { 'test_key' => 'update 1' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config: some_config
       )
       expect(last_response.status).to eq(200)
       another_config = { 'test_key' => 'update 2' }
       json_post("/api/workflows/labors/update/#{config_id}",
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config: another_config
       )
       expect(last_response.status).to eq(200)
@@ -194,7 +199,7 @@ describe WorkflowController do
       config = Polyphemus::Config.create(
         project_name: 'labors',
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config_id: Polyphemus::Config.next_id,
         version_number: 1,
         config: {},
@@ -203,7 +208,7 @@ describe WorkflowController do
       config = Polyphemus::Config.create(
         project_name: 'athena',
         workflow_name: 'my 2nd workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config_id: Polyphemus::Config.next_id,
         version_number: 1,
         config: {},
@@ -220,7 +225,7 @@ describe WorkflowController do
       config = Polyphemus::Config.create(
         project_name: 'labors',
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
+        workflow_type: 'test',
         config_id: Polyphemus::Config.next_id,
         version_number: 1,
         config: {},
@@ -236,7 +241,7 @@ describe WorkflowController do
         secrets: {},
       )
       auth_header(:superuser)
-      post('/api/workflows/configs', workflow_type: 'test-workflow')
+      post('/api/workflows/configs', workflow_type: 'test')
       expect(last_response.status).to eq(200)
       expect(json_body[:configs].length).to eq(1)
     end
@@ -252,26 +257,30 @@ describe WorkflowController do
     end
   end
 
-context '#revisions' do
+  context '#revisions' do
     it 'returns previous revisions for a workflow' do
-      auth_header(:editor)
-      json_post('/api/workflows/labors/create', workflow_name: 'my workflow name', workflow_type: 'test-workflow')
-      expect(last_response.status).to eq(200)
-      some_config = { 'test_key' => 'update 1' }
-      json_post("/api/workflows/labors/update/#{config_id}",
-        workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
-        config: some_config
+      config = create_config(
+        workflow_name: 'my workflow name', workflow_type: 'test',
+        version_number: 1
       )
-      expect(last_response.status).to eq(200)
-      another_config = { 'test_key' => 'update 2' }
-      json_post("/api/workflows/labors/update/#{config_id}",
+      create_config(
         workflow_name: 'my workflow name',
-        workflow_type: 'test-workflow',
-        config: another_config
+        workflow_type: 'test',
+        version_number: 2,
+        config_id: config.config_id,
+        config: { 'test_key' => 'update 1' }
       )
+      create_config(
+        workflow_name: 'my workflow name',
+        workflow_type: 'test',
+        config_id: config.config_id,
+        version_number: 3,
+        config: { 'test_key' => 'update 2' }
+      )
+
       auth_header(:editor)
-      get("/api/workflows/labors/revisions/#{config_id}")
+      get("/api/workflows/labors/revisions/#{config.config_id}")
+
       expect(last_response.status).to eq(200)
       expect(json_body.length).to eq(3)
       expect(json_body[0][:version_number]).to eq(3)
@@ -333,6 +342,7 @@ context '#revisions' do
       additional_output = 'A serious error occurred.'
 
       # Create run metadata with initial output
+      auth_header(:editor)
       json_post("/api/workflows/labors/run/update/#{run_id}",
         config_id: config_id,
         version_number: 2,
@@ -342,6 +352,7 @@ context '#revisions' do
       expect(last_response.status).to eq(200)
 
       # Update with additional output
+      auth_header(:editor)
       json_post("/api/workflows/labors/run/update/#{run_id}",
         output: additional_output,
         append_output: true
@@ -349,7 +360,6 @@ context '#revisions' do
       expect(last_response.status).to eq(200)
       expect(json_body[:output]).to eq(initial_output + additional_output)
     end
-
   end
 
   context 'retrieve the workflow state' do
@@ -379,77 +389,107 @@ context '#revisions' do
   end
 
   context 'retrieve the previous workflow state' do
-    let(:config_id) { create_workflow_with_configs.config_id }
+    let(:config_id) {
+      config = create_workflow_with_configs(version_number: 1)
+      config.config_id
+    }
 
-    before do
-      the_state = {:some_state => "ya_hooo!", :another_state => "woohoo!"}
-      create(:run, 
+    def create_run(params)
+      create(:run,  {
         run_id: run_id,
         name: "test-workflow-1999",
         config_id: config_id,
-        version_number: 2,
-        state: the_state,
+        version_number: 1,
+        state: {},
         created_at: Time.now
-      )
+      }.merge(params))
     end
 
     it 'returns the specific state when a state is specified' do
-      state_to_retrieve = [:some_state]
-      post("/api/workflows/labors/run/previous/#{config_id}",
-        version_number: 2,
-        state: state_to_retrieve
-      )
+      create_run(state: { current_labor: "The Nemean Lion"})
+
+      auth_header(:editor)
+      post("/api/workflows/labors/run/previous/#{config_id}", state: [:current_labor])
       expect(last_response.status).to eq(200)
-      expect(json_body).to eq(:some_state => "ya_hooo!")
+      expect(json_body).to eq(:current_labor => "The Nemean Lion")
     end
 
-    it 'returns all previous states available' do
-      state_to_retrieve = [:some_state]
+    it 'returns all previous states available when requested' do
+      create_run(state: { current_labor: "The Nemean Lion" }, created_at: Time.now - 20)
+      create_run(state: { current_labor: "The Lernaean Hydra" }, created_at: Time.now, run_id: "argo_run_state_23")
+      auth_header(:editor)
       post("/api/workflows/labors/run/previous/#{config_id}",
-        version_number: 2,
-        state: state_to_retrieve
+        state: [:current_labor],
+        collect: true
       )
       expect(last_response.status).to eq(200)
-      expect(json_body).to eq(:some_state => "ya_hooo!")
+      expect(json_body).to eq(current_labor: [ "The Lernaean Hydra", "The Nemean Lion"])
     end
 
     it 'returns a previous state across version changes' do
+      create_run(state: { current_labor: "The Nemean Lion"})
+      create_workflow_with_configs(version_number: 2, config_id: config_id)
+
+      auth_header(:editor)
+      post("/api/workflows/labors/run/previous/#{config_id}", state: [:current_labor])
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(:current_labor => "The Nemean Lion")
     end
 
     it 'returns a previous state even if the last state was nil' do
+      create_run(state: { current_labor: "The Nemean Lion" }, created_at: Time.now - 20)
+      create_run(state: nil, created_at: Time.now, run_id: "argo_run_state_23")
+
+      auth_header(:editor)
+      post("/api/workflows/labors/run/previous/#{config_id}", state: [:current_labor])
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(:current_labor => "The Nemean Lion")
     end
 
     it 'returns a previous state if the last state was present but lacking the requested keys' do
+      create_run(state: { current_labor: "The Nemean Lion" }, created_at: Time.now - 20)
+      create_run(state: {}, created_at: Time.now, run_id: "argo_run_state_23")
+
+      auth_header(:editor)
+      post("/api/workflows/labors/run/previous/#{config_id}", state: [:current_labor])
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(:current_labor => "The Nemean Lion")
     end
 
-    it 'raises an error when a state is not found' do
+    it 'returns nil when a state key is not found' do
+      create_run(state: { current_labor: "The Nemean Lion" }, created_at: Time.now - 20)
+      create_run(state: { current_labor: "The Lernaean Hydra" }, created_at: Time.now, run_id: "argo_run_state_23")
+
+      auth_header(:editor)
       post("/api/workflows/labors/run/previous/#{config_id}",
-        version_number: 2,
-        state: [:some_state_that_doesnt_exist, :another_state_that_doesnt_exist]
+        state: [:monster, :current_labor]
       )
-      expect(last_response.status).to eq(404)
-      expect(json_body[:error]).to eq("Requested state keys some_state_that_doesnt_exist, another_state_that_doesnt_exist not found in run.state")
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(current_labor: "The Lernaean Hydra", monster: nil)
     end
-
   end
 
   context 'runtime configs updates' do
-    let(:config_id) { create_workflow_with_configs.config_id }
+    let(:config_id) {
+      config, *_ = create_workflow(
+        workflow_name: 'my-cat-ingestion',
+        run_interval: 0,
+        runtime_config: {commit: true},
+        run_start: '2025-01-16T12:00:00Z',
+        run_stop: '2025-01-16T12:20:00Z'
+      )
+
+      config.config_id
+    }
 
     it 'updates existing runtime config' do
-      config = {:commit  => true }
-      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
-        config: config,
-        run_interval: 60, 
-        disabled: true
-      )
-      expect(last_response.status).to eq(200)
-
       # Update metadata
       new_config = {:commit  => false}
+      auth_header(:editor)
       json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: new_config,
-        run_interval: 120
+        run_interval: 120,
+        disabled: true
       )
       expect(last_response.status).to eq(200)
       expect(json_body[:config]).to eq(new_config)
@@ -459,6 +499,7 @@ context '#revisions' do
 
     it 'raises an error when the runtime config is invalid' do
       config = {:not_a_valid_param  => "not a boolean" }
+      auth_header(:editor)
       json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
         config: config,
       )
@@ -469,27 +510,31 @@ context '#revisions' do
   end
 
   context 'retrieving runtime configs' do
-    let(:config_id) { create_workflow_with_configs.config_id }
+    let(:config_id) { 
+      config, *_ = create_workflow(
+        workflow_name: 'my-cat-ingestion',
+        run_interval: 0,
+        runtime_config: {commit: true},
+        run_start: '2025-01-16T12:00:00Z',
+        run_stop: '2025-01-16T12:20:00Z'
+      )
+
+      config.config_id
+    }
 
     it 'raises an error when runtime config does not exist' do
       config_id_that_doesnt_exit = 10000
+      auth_header(:editor)
       get("/api/workflows/labors/runtime_configs/#{config_id_that_doesnt_exit}")
       expect(last_response.status).to eq(404)
       expect(json_body[:error]).to eq('No such config 10000') 
     end
 
-    it 'retrieves existing run metadata' do
-      a_config = {:commit  => true }
-      json_post("/api/workflows/labors/runtime_configs/update/#{config_id}",
-        config: a_config,
-        run_interval: 120
-      )
-      expect(last_response.status).to eq(200)
-      
-      # Retrieve and verify
+    it 'retrieves existing runtime config metadata' do
+      auth_header(:editor)
       get("/api/workflows/labors/runtime_configs/#{config_id}")
       expect(last_response.status).to eq(200)
-      expect(json_body[:config]).to eq(a_config)
+      expect(json_body[:config]).to eq(commit: true)
     end
   end
 
@@ -502,8 +547,9 @@ context '#revisions' do
       # Stub argo client command
       workflow_output = "Workflow Name: simple-two-jobs-ktm4g\nWorkflow UID: de6df0ed-b32c-4707-814f-11c323b0687b\n"
       allow(Open3).to receive(:capture3).and_return([workflow_output, "", double(success?: true)])
+      auth_header(:editor)
       json_post("/api/workflows/labors/runtime_configs/run_once/#{config.config_id}", 
-        workflow_type: "test-workflow",
+        workflow_type: "test",
         config: { commit: true }
       )
       expect(last_response.status).to eq(200)
@@ -528,8 +574,9 @@ context '#revisions' do
       # If we don't mock anything this will fail since there is no workflow.yaml for test-workflow.yaml
       config = Polyphemus::Config.current.where(project_name: 'labors', config_id: config_id).first
       allow(Open3).to receive(:capture3).and_return(["", "Command failed", double(success?: false)])
+      auth_header(:editor)
       json_post("/api/workflows/labors/runtime_configs/run_once/#{config.config_id}", 
-        workflow_type: "test-workflow",
+        workflow_type: "test",
         config: { commit: true }
       )
 
@@ -543,72 +590,19 @@ context '#revisions' do
 
     it 'returns the status of a workflow that has completed' do
 
-      config_id = Polyphemus::Config.next_id
-
-      config_1 = Polyphemus::Config.create(
-        project_name: 'labors',
+      config, *_ = create_workflow(
         workflow_name: 'my-cat-ingestion',
-        workflow_type: 'cat-ingestion',
-        config_id: config_id,
-        version_number: 1,
-        config: {"some_key" => "some_value"},
-        secrets: {},
-        created_at: '2025-01-16T12:00:00Z',
-        updated_at: '2025-01-16T12:00:00Z'
+        run_interval: 0,
+        runtime_config:{commit: true},
+        run_start: '2025-01-16T12:00:00Z',
+        run_stop: '2025-01-16T12:20:00Z'
       )
 
-      config_2 = Polyphemus::Config.create(
-        project_name: 'labors',
-        workflow_name: 'my-cat-ingestion',
-        workflow_type: 'cat-ingestion',
-        config_id: config_id,
-        version_number: 2,
-        config: {"some_key" => "some_value_2"},
-        secrets: {},
-        created_at: '2025-01-18T12:00:00Z',
-        updated_at: '2025-01-18T12:00:00Z'
-      )
-
-      runtime_config_1 = Polyphemus::RuntimeConfig.create(
-        config_id: config_id,
-        run_interval: 1000,
-        config:{commit: true} 
-      )
-
-      # Create a run for the first version
-      Polyphemus::Run.create(
-        run_id: "hello-there-1",
-        config_id: config_id,
-        version_number: config_1.version_number,
-        name: 'my-cat-ingestion-1000',
-        orchestrator_metadata: {
-          'startedAt' => '2025-01-16T12:00:00Z',
-          'nodes' => {
-            'steps-node' => {
-              'finishedAt' => '2025-01-16T12:20:00Z',
-              'phase' => 'Succeeded',
-              'type' => 'Steps'
-            }
-          }
-        }
-      )
-
-      # Create a run for the second version
-      Polyphemus::Run.create(
-        run_id: "hello-there-2",
-        config_id: config_id,
-        version_number: config_2.version_number,
-        name: 'my-cat-ingestion-2000',
-        orchestrator_metadata: {
-          'startedAt' => '2025-01-18T12:00:00Z',
-          'nodes' => {
-            'steps-node' => {
-              'finishedAt' => '2025-01-18T12:20:00Z',
-              'phase' => 'Succeeded',
-              'type' => 'Steps'
-            }
-          }
-        }
+      create_run(
+        config, 2000,
+        status: 'Succeeded',
+        run_start: '2025-01-18T12:00:00Z',
+        run_stop: '2025-01-18T12:20:00Z'
       )
 
       auth_header(:editor)
@@ -618,7 +612,7 @@ context '#revisions' do
       # Make sure the second version of the config is used (we use the latest run)
       expect(json_body.count).to eq(1)
       expect(json_body[0][:workflow_name]).to eq("my-cat-ingestion")
-      expect(json_body[0][:workflow_type]).to eq("cat-ingestion")
+      expect(json_body[0][:workflow_type]).to eq("test")
       expect(json_body[0][:pipeline_state]).to eq("succeeded")
       # This should be the most recent run from version 2
       expect(json_body[0][:pipeline_finished_at]).to eq("2025-01-18T12:20:00Z")
@@ -666,24 +660,35 @@ context '#revisions' do
       expect(json_body[0][:pipeline_finished_at]).to be_nil
     end
 
-    it 'returns a nil status when the workflow hasnt been run yet' do
-      config_2 = Polyphemus::Config.create(
-        project_name: 'labors',
-        workflow_name: 'my-cat-ingestion-2',
-        workflow_type: 'cat-ingestion',
-        config_id: Polyphemus::Config.next_id,
-        version_number: 1,
-        config: {},
-        secrets: {},
+    it 'returns a nil status when the workflow hasnt been run yet and is not scheduled' do
+      create_workflow(
+        workflow_name: 'parked-workflow',
+        run_interval: nil
       )
 
       auth_header(:editor)
       get("/api/workflows/labors/status")
       expect(last_response.status).to eq(200)
       expect(json_body.count).to eq(1)
-      expect(json_body[0][:workflow_name]).to eq("my-cat-ingestion-2")
-      expect(json_body[0][:workflow_type]).to eq("cat-ingestion")
+      expect(json_body[0][:workflow_name]).to eq("parked-workflow")
+      expect(json_body[0][:workflow_type]).to eq("test")
       expect(json_body[0][:pipeline_state]).to be_nil
+      expect(json_body[0][:pipeline_finished_at]).to be_nil
+    end
+
+    it 'returns a pending status when the workflow hasnt been run yet and is scheduled' do
+      create_workflow(
+        workflow_name: 'pending-workflow',
+        run_interval: 1000
+      )
+
+      auth_header(:editor)
+      get("/api/workflows/labors/status")
+      expect(last_response.status).to eq(200)
+      expect(json_body.count).to eq(1)
+      expect(json_body[0][:workflow_name]).to eq("pending-workflow")
+      expect(json_body[0][:workflow_type]).to eq("test")
+      expect(json_body[0][:pipeline_state]).to eq("pending")
       expect(json_body[0][:pipeline_finished_at]).to be_nil
     end
   end


### PR DESCRIPTION
This PR cleans up a bunch of stuff, including:
* workflow#previous is not reliant on config version number any more
* workflow#previous is robust to the key being empty in the latest state (it finds the latest non-empty value)
* workflow#previous allows collecting all previous states
* Interval scheduler ignores run_interval <= 0
* Reports pending state for scheduled jobs
* datetime UI for initial_start_scan_time
* Adds a runtime param override_root_path
* Makes metis and deposit sftp jobs search for files in either the override_root_path or the ingest_root_path
* Chunks slack notifications to some byte number limit