### PR TITLE
fix gnomon decomposition

### DIFF
--- a/magma/lib/magma/gnomon/rule_definition.rb
+++ b/magma/lib/magma/gnomon/rule_definition.rb
@@ -67,7 +67,7 @@ class Magma
         magma_model = Magma.instance.get_project(project_name)&.models[ @name.to_sym ]
 
         magma_record = magma_model&.where(
-          magma_model.identity.name => composed_identifier
+          magma_model.identity.column_name.to_sym => composed_identifier
         )&.first
 
         [


### PR DESCRIPTION
Makes gnomon rule definition decomposer return record_created_at based on identity.column_name, not name