### PR TITLE
add gnomon update event log

### DIFF
--- a/magma/lib/magma/server/gnomon.rb
+++ b/magma/lib/magma/server/gnomon.rb
@@ -29,6 +29,14 @@ class GnomonController < Magma::Controller
       identifier: @params[:identifiers]
     ).delete
 
+    event_log(
+      event: 'delete_name',
+      message: "removed identifiers",
+      payload: {
+        identifiers: @params[:identifiers]
+      }
+    )
+
     success_json(success: "Deleted #{@params[:identifiers].count} identifiers")
   end
 

--- a/magma/lib/magma/server/gnomon.rb
+++ b/magma/lib/magma/server/gnomon.rb
@@ -49,6 +49,11 @@ class GnomonController < Magma::Controller
       version_number: version_number
     )
 
+    event_log(
+      event: 'update_rules',
+      message: "created version #{version_number} of rules"
+    )
+
     return success_json(grammar.to_hash)
   end
 
@@ -323,5 +328,13 @@ class GnomonController < Magma::Controller
 
   def rule_name
     @params[:rule_name]
+  end
+
+  def event_log(params)
+    super(
+      params.merge(
+        application: 'gnomon'
+      )
+    )
   end
 end

--- a/polyphemus/lib/polyphemus/controllers/log_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/log_controller.rb
@@ -8,7 +8,7 @@ class LogController < Polyphemus::Controller
 
     if @params[:consolidate]
       entry = Polyphemus::Log.where(
-        application: @hmac.id.to_s,
+        application: @params[:application] || @hmac.id.to_s,
         project_name: @params[:project_name],
         user: @params[:user],
         event: @params[:event],
@@ -29,7 +29,7 @@ class LogController < Polyphemus::Controller
     end
 
     entry = Polyphemus::Log.create(
-      application: @hmac.id,
+      application: @params[:application] || @hmac.id.to_s,
       project_name: @params[:project_name],
       user: @params[:user],
       event: @params[:event],

--- a/polyphemus/spec/log_controller_spec.rb
+++ b/polyphemus/spec/log_controller_spec.rb
@@ -31,6 +31,7 @@ describe LogController do
       expect(last_response.status).to eq(200)
       expect(Polyphemus::Log.count).to eq(1)
       expect(Polyphemus::Log.first.message).to eq(msg)
+      expect(Polyphemus::Log.first.application).to eq('polyphemus')
     end
 
     it 'consolidates logs with matching entries from the past day' do
@@ -50,6 +51,25 @@ describe LogController do
       expect(last_response.status).to eq(200)
       expect(Polyphemus::Log.count).to eq(1)
       expect(Polyphemus::Log.first.payload['victims']).to eq(['Leon', 'Outis', 'Aisopos'])
+    end
+
+    it 'allows the application to be overridden' do
+      msg = 'The Nemean Lion was slain by Eurystheus'
+      hmac_header
+      json_post(
+        '/api/log/labors/write',
+        user: 'eurystheus@twelve-labors.org',
+        application: 'eurystheus',
+        event: 'update',
+        message: msg,
+        payload: {
+          victims: 122
+        }
+      )
+      expect(last_response.status).to eq(200)
+      expect(Polyphemus::Log.count).to eq(1)
+      expect(Polyphemus::Log.first.message).to eq(msg)
+      expect(Polyphemus::Log.first.application).to eq('eurystheus')
     end
   end
 


### PR DESCRIPTION
Adds update_rules event to gnomon, also makes gnomon events come from application 'gnomon' instead of 'magma' (even though they are being sent by magma).