### PR TITLE
Inject project_name to janus ui

### DIFF
--- a/etna/packages/etna-js/components/Nav.jsx
+++ b/etna/packages/etna-js/components/Nav.jsx
@@ -56,11 +56,11 @@ const Logo = ({ LogoImage, app }) =>
     </a>
   </div>;
 
-const Link = ({ app }) => {
+const Link = ({ app, project_name }) => {
   const name = app.name
   const host_key = `${name}_host`;
 
-  const link = CONFIG[host_key] ? new URL(...[CONFIG.project_name, CONFIG[host_key]].filter(_ => _)) : undefined;
+  const link = CONFIG[host_key] ? new URL(...[project_name || CONFIG.project_name, CONFIG[host_key]].filter(_ => _)) : undefined;
 
   return <a href={link} className='etna-link' title={titelize(name)}>
     <img src={`/images/${name}.svg`} />
@@ -68,7 +68,7 @@ const Link = ({ app }) => {
   </a>;
 }
 
-const AppsMenu = ({ currentApp }) => {
+const AppsMenu = ({ currentApp, project_name }) => {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
 
@@ -113,7 +113,7 @@ const AppsMenu = ({ currentApp }) => {
                     APPS.map(app => {
                       return (
                         <Grid item xs={6} key={app.name} className='apps-menu-item'>
-                          <Link app={app} />
+                          <Link app={app} project_name={project_name}/>
                         </Grid>
                       )
                     })
@@ -151,14 +151,14 @@ function titelize(word) {
 
 // TODO
 // make responsive?
-const Nav = ({ logo, app, children, user }) => {
+const Nav = ({ logo, app, children, user, project_name }) => {
   return (
     <AppBar position="relative" className="etna-nav" variant="outlined">
       <Toolbar disableGutters className="etna-nav-toolbar">
         <Logo LogoImage={logo} app={app} />
         {findValidChildren(children)}
         <Login user={user} />
-        <AppsMenu currentApp={app} />
+        <AppsMenu currentApp={app} project_name={project_name}/>
       </Toolbar>
     </AppBar>
   );

--- a/janus/lib/client/jsx/janus-nav.jsx
+++ b/janus/lib/client/jsx/janus-nav.jsx
@@ -12,9 +12,9 @@ const NavBar = ({user}) => <div id='nav'>
   { isSuperEditor(user) && <div className='nav_item'><a href='/users'>Users</a></div> }
 </div>;
 
-const JanusNav = () => {
+const JanusNav = ({project_name}) => {
   let user = useReduxState( state => selectUser(state) );
-  return <Nav logo={Logo} user={user} app='janus'>
+  return <Nav logo={Logo} user={user} project_name={project_name} app='janus'>
     <NavBar user={user}/>
   </Nav>;
 };

--- a/janus/lib/client/jsx/janus-ui.jsx
+++ b/janus/lib/client/jsx/janus-ui.jsx
@@ -62,7 +62,7 @@ const JanusUI = () => {
     <ThemeProvider theme={theme}>
       <div id='janus-group'>
         <Notifications />
-        <JanusNav/>
+        <JanusNav project_name={params.project_name}/>
         <Messages />
         <Component {...params}/>
       </div>


### PR DESCRIPTION
Just a small fix for the long-standing nit that you cannot navigate to */:project_name from Janus, due to the fact that its routes do not inject :project_name into the JS UI's server-side generated config_json. This instead allows project_name to be injected into the AppMenu component on the client-side, avoiding the need to inject URL params for the client-side view, which has its own router.