### PR TITLE
Hide disabled workflows in polyphemus status

### DIFF
--- a/polyphemus/lib/polyphemus/controllers/workflow_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/workflow_controller.rb
@@ -285,6 +285,10 @@ class WorkflowController < Polyphemus::Controller
     # Get all unique workflows created by the user (unique workflow_names)
     configs = Polyphemus::Config.current.where(project_name: @params[:project_name]).select(:config_id, :workflow_type, :workflow_name).distinct(:workflow_name).all
 
+    configs = configs.reject do |config|
+      config.runtime_config.disabled
+    end
+
     statuses = configs.map do |config|
       # Get the latest run for this config
       # All workflows that have been launched should have a run object

--- a/polyphemus/spec/workflow_controller_spec.rb
+++ b/polyphemus/spec/workflow_controller_spec.rb
@@ -698,5 +698,23 @@ describe WorkflowController do
       expect(json_body[0][:pipeline_state]).to eq("pending")
       expect(json_body[0][:pipeline_finished_at]).to be_nil
     end
+
+    it 'ignores disabled workflows' do
+      config, runtime, _ = create_workflow(
+        workflow_name: 'my-cat-ingestion',
+        run_interval: 0,
+        runtime_config:{commit: true},
+        run_start: '2025-01-16T12:00:00Z',
+        run_stop: '2025-01-16T12:20:00Z',
+        disabled: true
+      )
+
+      auth_header(:editor)
+      get("/api/workflows/labors/status")
+      expect(last_response.status).to eq(200)
+
+      expect(json_body.count).to eq(0)
+    end
+
   end
 end


### PR DESCRIPTION
This PR fixes an issue where disabled workflows show up in the project loader/status view, probably caused by the workflow_type and project_name fields improperly being in the Polyphemus::Config model, rather than in Polyphemus::RuntimeConfig. The latter is not fixed here, this PR is merely a stopgap.