### PR TITLE
Support 0,1 in magma booleans

### DIFF
--- a/magma/lib/magma/attributes/boolean_attribute.rb
+++ b/magma/lib/magma/attributes/boolean_attribute.rb
@@ -3,5 +3,17 @@ class Magma
     def database_type
       TrueClass
     end
+
+    def revision_to_loader(record_name, new_value)
+      v = case new_value
+          when 0, "0"
+            false
+          when 1, "1"
+            true
+          else
+            new_value
+          end
+      [ name, v ]
+    end
   end
 end

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -123,7 +123,7 @@ def load_labors_project
 end
 
 Magma.instance.setup_db
-load_labors_project
+#load_labors_project
 
 OUTER_APP = Rack::Builder.new do
   use Etna::ParseBody

--- a/magma/spec/spec_helper.rb
+++ b/magma/spec/spec_helper.rb
@@ -123,7 +123,7 @@ def load_labors_project
 end
 
 Magma.instance.setup_db
-#load_labors_project
+load_labors_project
 
 OUTER_APP = Rack::Builder.new do
   use Etna::ParseBody

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -120,6 +120,36 @@ describe UpdateController do
     #expect(json_document(:prize,skin.id.to_s)).to eq(worth: 8)
   end
 
+  context 'boolean' do
+    it 'updates a boolean attribute' do
+      lion = create(:labor, name: 'Nemean Lion', completed: false)
+      update(labor: { 'Nemean Lion' => { completed: true } })
+
+      lion.refresh
+      expect(last_response.status).to eq(200)
+      expect(lion.completed).to eq(true)
+    end
+
+    it 'updates a boolean attribute from string tokens' do
+      lion = create(:labor, name: 'Nemean Lion', completed: false)
+      [ true, "true", "t", "yes", "y", "T", "TRUE", "YES", "Y", "1", 1 ].each do |true_val|
+        update(labor: { 'Nemean Lion' => { completed: true_val } })
+
+        lion.refresh
+        expect(last_response.status).to eq(200)
+        expect(lion.completed).to eq(true)
+      end
+
+      [ false, "false", "f", "no", "n", "F", "FALSE", "NO", "N", "0", 0 ].each do |false_val|
+        update(labor: { 'Nemean Lion' => { completed: false_val } })
+
+        lion.refresh
+        expect(last_response.status).to eq(200)
+        expect(lion.completed).to eq(false)
+      end
+    end
+  end
+
   it 'updates a date-time attribute' do
     lion = create(:labor, name: 'Nemean Lion', year: '0002-01-01')
     update(


### PR DESCRIPTION
Magma boolean attributes can read a variety of tokens as "true" or "false", now including 0, 1, "0" and "1".