### PR TITLE
consolidate update_model events

### DIFF
--- a/magma/lib/magma/server/update_model.rb
+++ b/magma/lib/magma/server/update_model.rb
@@ -16,7 +16,8 @@ class UpdateModelController < Magma::Controller
         message: "made model changes: #{@params[:actions].map{|a| a[:action_name]}.uniq.join(", ")}",
         payload: {
           actions: @params[:actions]
-        }
+        },
+        consolidate: true
       )
       success(@payload.to_hash.to_json, 'application/json')
     else


### PR DESCRIPTION
Adds "consolidate" flag to the event log for magma's update_model api to reduce spamming of the log.