### PR TITLE
Fix metis form for missing models

### DIFF
--- a/polyphemus/lib/client/jsx/workflow/metis-form-components.tsx
+++ b/polyphemus/lib/client/jsx/workflow/metis-form-components.tsx
@@ -224,17 +224,25 @@ export const ValuesToIgnore = ({value, update, modelName, classes}:ScriptItem) =
 export const ColumnMap = ({value, update, modelName, classes}:ScriptItem) => {
 
   const {models} = useContext(MagmaContext);
-  const idAttribute: string = models ? models[modelName]?.template?.identifier : '__error__'
-  const parentAttribute: string = models ? models[modelName]?.template?.parent : '__error__'
+  const model = models ? models[modelName] : null;
+
+  if (!model) return <div>No such model {modelName}</div>;
+
+  const idAttribute: string = models?.[modelName]?.template?.identifier || '__error__'
+  const parentAttribute: string = models?.[modelName]?.template?.parent || '__error__'
   // Determine if table.
   const isTable: boolean = parentAttribute!='project' && models[parentAttribute]?.template?.attributes[modelName].attribute_type=='table'
   const autoAttribute: string = isTable ? parentAttribute : idAttribute
 
-  if (value==undefined) {
-    update({[autoAttribute]: autoAttribute})
-  } else if (!Object.keys(value).includes(autoAttribute)) {
-    update({[autoAttribute]: autoAttribute, ...value})
-  }
+  useEffect( () => {
+    if (autoAttribute && !(autoAttribute in value)) {
+      update({
+        [autoAttribute]: autoAttribute,
+        ...value
+      });
+    }
+  }, []);
+
   const attributesChosen = Object.keys(value).filter((val)=>val!=autoAttribute)
   const attributesToFilter = [autoAttribute]
 

--- a/polyphemus/lib/client/jsx/workflow/metis-form.tsx
+++ b/polyphemus/lib/client/jsx/workflow/metis-form.tsx
@@ -20,6 +20,7 @@ import CopyIcon from '@material-ui/icons/FileCopy';
 import Pagination from '@material-ui/lab/Pagination';
 import Switch from '@material-ui/core/Switch';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import {MagmaContext} from 'etna-js/contexts/magma-context';
 
 import {SchemaContext, SchemaProvider} from './schema-context';
 import {PickBucket} from 'etna-js/components/metis_exploration';
@@ -258,54 +259,62 @@ const MetisModel = ({
     [config, update, scripts]
   );
 
+  const {models} = useContext(MagmaContext);
+
   return (
     <Grid className={classes.model} container>
       <ModelRow name='remove'>
         <Button onClick={() => update(undefined)}>Remove model</Button>
       </ModelRow>
-      <ModelRow name='scripts'>
-        <Button
-          onClick={() =>
-            update({...config, scripts: [{}, ...scripts]})
-          }
-        >
-          <AddIcon fontSize='small' /> Add Script
-        </Button>
-        {(pages > 1 || pageSize != 5) && (
-          <>
-            <Typography className={classes.page_size}>Page size</Typography>
-            <Select
-              value={pageSize}
-              onChange={(e) => setPageSize(e.target.value as number)}
-            >
-              {[5, 10, 100].map((n) => (
-                <MenuItem key={n} value={n}>
-                  {n}
-                </MenuItem>
-              ))}
-            </Select>
-            <Pagination
-              count={pages}
-              page={page}
-              onChange={(e, v) => setPage(v)}
-            />
-          </>
-        )}
-        {page_scripts.map((script: Script | undefined, i: number) => (
-          <MetisScript
-            key={i}
-            script={script}
-            num={i + (page - 1) * pageSize + 1}
-            modelName={modelName}
-            projectName={projectName}
-            bucketName={bucketName}
-            update={(newScript: Script | undefined) =>
-              handleUpdateScript(i, newScript)
+      {
+        !(modelName in models) ?
+        <ModelRow>
+          <Typography color='error'>{modelName}</Typography>&nbsp;is not defined for this project.
+        </ModelRow> :
+        <ModelRow name='scripts'>
+          <Button
+            onClick={() =>
+              update({...config, scripts: [{}, ...scripts]})
             }
-            copy={() => handleCopyScript(i + (page - 1) * pageSize, script)}
-          />
-        ))}
-      </ModelRow>
+          >
+            <AddIcon fontSize='small' /> Add Script
+          </Button>
+          {(pages > 1 || pageSize != 5) && (
+            <>
+              <Typography className={classes.page_size}>Page size</Typography>
+              <Select
+                value={pageSize}
+                onChange={(e) => setPageSize(e.target.value as number)}
+              >
+                {[5, 10, 100].map((n) => (
+                  <MenuItem key={n} value={n}>
+                    {n}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Pagination
+                count={pages}
+                page={page}
+                onChange={(e, v) => setPage(v)}
+              />
+            </>
+          )}
+          {page_scripts.map((script: Script | undefined, i: number) => (
+            <MetisScript
+              key={i}
+              script={script}
+              num={i + (page - 1) * pageSize + 1}
+              modelName={modelName}
+              projectName={projectName}
+              bucketName={bucketName}
+              update={(newScript: Script | undefined) =>
+                handleUpdateScript(i, newScript)
+              }
+              copy={() => handleCopyScript(i + (page - 1) * pageSize, script)}
+            />
+          ))}
+        </ModelRow>
+      }
     </Grid>
   );
 };


### PR DESCRIPTION
If there is no model defined but the metis form config expects one (usually only possible with a pasted JSON config), the metis form crashes due to issues with the ColumnMap. This PR repairs the issues by not rendering if the model is missing.