### PR TITLE
Fix query bugs

### DIFF
--- a/etna/packages/etna-js/components/messages.jsx
+++ b/etna/packages/etna-js/components/messages.jsx
@@ -2,6 +2,10 @@
 import React, {useEffect, useState} from 'react';
 import {connect} from 'react-redux';
 
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import CloseIcon from '@material-ui/icons/Close';
+
 import {dismissMessages} from 'etna-js/actions/message_actions';
 import markdown from '../utils/markdown';
 import {useNotifications} from "etna-js/components/Notifications";
@@ -63,13 +67,8 @@ class Messages extends React.Component {
 
     return <MessagesToNotificationsBridge messages={messages}>
       <div id="messages">
-        <div id="quote">
-          <svg width="31" height="40">
-            <path d="M 2,40 20,25 18,40"/>
-          </svg>
-        </div>
         <div id="dismiss" onClick={this.dismissMessages.bind(this)}>
-          <span className="fas fa-check"> </span>
+          <IconButton color='secondary' size='small' onClick={this.dismissMessages.bind(this)}><CloseIcon/></IconButton>
         </div>
         <div id="message_viewer">
           {nav}

--- a/etna/packages/etna-js/models/magma-model.tsx
+++ b/etna/packages/etna-js/models/magma-model.tsx
@@ -113,6 +113,9 @@ export class Model {
   }
 
   collects(modelName: string): boolean {
+    // ignore self-references
+    if (this.name == modelName) return false;
+
     return this.hasAttribute(
       (a: Attribute) => a.isCollectionLink() && a.link_model_name == modelName
     );

--- a/magma/lib/magma/query/question.rb
+++ b/magma/lib/magma/query/question.rb
@@ -343,7 +343,13 @@ class Magma
       bounds = to_table(page_bounds_query).map do |row|
         order_by_aliases.map { |c| row[c] }
       end
-      raise QuestionError, "Page #{@options[:page]} not found" if bounds.empty?
+      if bounds.empty?
+        if @options[:page] == 1
+          raise QuestionError, "No results found"
+        else
+          raise QuestionError, "Page #{@options[:page]} not found"
+        end
+      end
 
       apply_bounds(query, bounds[0], bounds[1])
     end

--- a/magma/spec/retrieve_spec.rb
+++ b/magma/spec/retrieve_spec.rb
@@ -1378,7 +1378,7 @@ describe RetrieveController do
       )
 
       expect(last_response.status).to eq(422)
-      expect(json_body[:errors]).to eq(["Page 1 not found"])
+      expect(json_body[:errors]).to eq(["No results found"])
     end
   end
 

--- a/timur/lib/client/jsx/components/query/query_builder.tsx
+++ b/timur/lib/client/jsx/components/query/query_builder.tsx
@@ -45,8 +45,10 @@ const useStyles = makeStyles((theme) => ({
   results: {
     boxShadow: '1px 1px 5px -2px #ccc inset',
     overflowX: 'auto',
+    overflowY: 'auto',
     flex: '1 1 calc(100% - max(700px, 40%))',
-    flexWrap: 'nowrap'
+    flexWrap: 'nowrap',
+    height: '100%'
   }
 }));
 

--- a/timur/lib/client/jsx/components/query/query_control_buttons.tsx
+++ b/timur/lib/client/jsx/components/query/query_control_buttons.tsx
@@ -67,6 +67,7 @@ const QueryControlButtons = () => {
       maxColumns
     },
     setQueryString,
+    setPage,
     setDataAndNumRecords,
     setResultsState
   } = useContext(QueryResultsContext);
@@ -206,7 +207,9 @@ const QueryControlButtons = () => {
   ]);
 
   const handleRunQuery = useCallback(() => {
-    runQuery();
+    runQuery(0);
+    setPage(0);
+    setLastPage(0);
     setLastColumns(columns);
     setLastFilters(recordFilters);
     setLastOrFilterIndices(orRecordFilterIndices);

--- a/timur/lib/client/jsx/components/query/query_controls.tsx
+++ b/timur/lib/client/jsx/components/query/query_controls.tsx
@@ -18,8 +18,8 @@ const QueryControls = () => {
   return (
     <>
       <QueryRowPane />
-      <QueryColumnPane />
       <QueryWherePane />
+      <QueryColumnPane />
     </>
   );
 };

--- a/timur/lib/client/jsx/components/query/query_results.tsx
+++ b/timur/lib/client/jsx/components/query/query_results.tsx
@@ -13,13 +13,9 @@ const useStyles = makeStyles((theme) => ({
   checkbox: {
     marginRight: '30px'
   },
-  result: {
-    width: '100%',
-    padding: 10,
-    margin: 10,
-    border: '1px solid #0f0',
-    borderRadius: 2,
-    backgroundColor: 'rgba(0,255,0,0.1)'
+  results: {
+    height: '100%',
+    overflowY: 'hidden'
   }
 }));
 
@@ -74,21 +70,19 @@ const QueryResults = () => {
   if (!rootModel) return null;
 
   return (
-    <>
-      <Grid xs={12} item container direction='column'>
-        <QueryTable
-          maxColumns={maxColumns}
-          columns={formattedColumns}
-          rows={rows}
-          pageSize={pageSize}
-          numRecords={numRecords}
-          page={page}
-          expandMatrices={expandMatrices}
-          handlePageChange={handlePageChange}
-          handlePageSizeChange={handlePageSizeChange}
-        />
-      </Grid>
-    </>
+    <Grid xs={12} item container direction='column' className={classes.results}>
+      <QueryTable
+        maxColumns={maxColumns}
+        columns={formattedColumns}
+        rows={rows}
+        pageSize={pageSize}
+        numRecords={numRecords}
+        page={page}
+        expandMatrices={expandMatrices}
+        handlePageChange={handlePageChange}
+        handlePageSizeChange={handlePageSizeChange}
+      />
+    </Grid>
   );
 };
 

--- a/timur/lib/client/jsx/components/query/query_table.tsx
+++ b/timur/lib/client/jsx/components/query/query_table.tsx
@@ -19,6 +19,10 @@ const useStyles = makeStyles({
   table: {
     minWidth: 650
   },
+  table_container: {
+    flex: '1 0',
+    overflowY: 'scroll'
+  },
   table_controls: {
     padding: '0px 15px'
   },
@@ -83,8 +87,8 @@ const QueryTable = ({
           />
         </Grid>
       </Grid>
-      <TableContainer>
-        <Table className={classes.table} size='small' aria-label='result table'>
+      <TableContainer className={classes.table_container}>
+        <Table stickyHeader className={classes.table} size='small' aria-label='result table'>
           <TableHead>
             <TableRow>
               {columns

--- a/timur/lib/client/jsx/components/query/query_where_pane.tsx
+++ b/timur/lib/client/jsx/components/query/query_where_pane.tsx
@@ -120,7 +120,7 @@ const QueryWherePane = () => {
   );
 
   const modelNames = useMemo(
-    () => [...graph.connectedModels(rootModel)].sort(),
+    () => [...graph.connectedModelsAnd(rootModel)].sort(),
     [graph, rootModel]
   );
 

--- a/timur/lib/client/jsx/components/query/save_query_modal.tsx
+++ b/timur/lib/client/jsx/components/query/save_query_modal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
 import {QueryResultsContext} from '../../contexts/query/query_results_context';
+import {SavedQuery} from '../../contexts/query/query_types';
 import Grid from '@material-ui/core/Grid';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -30,7 +31,7 @@ const QuerySaveModal = ({
   onClose: () => void;
 }) => {
   const classes = useStyles();
-  const { } = useContext(QueryResultsContext);
+  const { state: { savedQueries }, setSavedQueries } = useContext(QueryResultsContext);
 
   const [ comment, setComment ] = useState('');
 
@@ -55,6 +56,8 @@ const QuerySaveModal = ({
       json_post(`/api/query_history/${CONFIG.project_name}/create`, {
         comment,
         query
+      }).then( ({query}:{query: SavedQuery}) => {
+        setSavedQueries(savedQueries.concat(query));
       });
 
       handleClose();

--- a/timur/lib/client/jsx/contexts/query/query_types.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_types.tsx
@@ -106,3 +106,11 @@ export interface CreateFigurePayload {
   workflow_name: string;
   inputs: {[key: string]: any};
 }
+
+export interface SavedQuery {
+  id: number;
+  created_at: string;
+  comment: string;
+  query: string;
+  unpackedQuery?: string;
+}

--- a/timur/lib/client/jsx/utils/query_graph.ts
+++ b/timur/lib/client/jsx/utils/query_graph.ts
@@ -46,16 +46,19 @@ export class QueryGraph {
   }
 
   sliceable(modelName: string, selectedModel: string): boolean {
+    if (!this.models.has(modelName)) return false;
+
     return this.allPaths(modelName).some((path: string[]) => {
       for (let i = 0; i < path.length - 1; i++) {
         let current = path[i];
         let next = path[i + 1];
+
         if ((current === modelName && !next) ||
           next === modelName) continue;
 
         if (
           i === 0 &&
-          this.models.model(modelName)?.collects(current) &&
+          this.models.model(modelName).collects(current) &&
           selectedModel == current
         ) {
           return true;

--- a/timur/lib/client/jsx/utils/query_graph.ts
+++ b/timur/lib/client/jsx/utils/query_graph.ts
@@ -58,7 +58,7 @@ export class QueryGraph {
 
         if (
           i === 0 &&
-          this.models.model(modelName).collects(current) &&
+          this.models.model(modelName)!.collects(current) &&
           selectedModel == current
         ) {
           return true;

--- a/timur/lib/server/controllers/query_history_controller.rb
+++ b/timur/lib/server/controllers/query_history_controller.rb
@@ -2,14 +2,14 @@ class QueryHistoryController < Timur::Controller
   def create
     require_params(:query, :comment)
 
-    QueryHistory.create(
+    query = QueryHistory.create(
       project_name: @params[:project_name],
       user: @user.email,
       query: @params[:query],
       comment: @params[:comment]
     )
 
-    success_json(success: true)
+    success_json(query: query.to_hash)
   end
 
   def list

--- a/timur/spec/query_history_spec.rb
+++ b/timur/spec/query_history_spec.rb
@@ -30,9 +30,8 @@ describe QueryHistoryController do
 
       expect(last_response.status).to eq(200)
 
-      expect(json_body[:success]).to eq(true)
       expect(QueryHistory.count).to eq(1)
-      expect(QueryHistory.first.to_hash).to eq(
+      expect(json_body[:query]).to eq(
         comment: "test query",
         created_at: Time.now.iso8601,
         id: 1,

--- a/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_builder.test.tsx.snap
@@ -531,6 +531,51 @@ exports[`QueryBuilder renders 1`] = `
                     viewBox="0 0 24 24"
                   >
                     <path
+                      d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <p
+                class="MuiTypography-root makeStyles-title MuiTypography-body1"
+              >
+                Where:
+              </p>
+              <span
+                class="MuiTypography-root makeStyles-folded MuiTypography-body1"
+              >
+                1 condition
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root makeStyles-queryClause MuiGrid-container MuiGrid-align-items-xs-flex-start"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root makeStyles-chevron MuiIconButton-sizeSmall"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
                       d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
                     />
                   </svg>
@@ -1404,57 +1449,12 @@ exports[`QueryBuilder renders 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="MuiGrid-root makeStyles-queryClause MuiGrid-container MuiGrid-align-items-xs-flex-start"
-        >
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
-            >
-              <button
-                class="MuiButtonBase-root MuiIconButton-root makeStyles-chevron MuiIconButton-sizeSmall"
-                tabindex="0"
-                type="button"
-              >
-                <span
-                  class="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="MuiTouchRipple-root"
-                />
-              </button>
-              <p
-                class="MuiTypography-root makeStyles-title MuiTypography-body1"
-              >
-                Where:
-              </p>
-              <span
-                class="MuiTypography-root makeStyles-folded MuiTypography-body1"
-              >
-                1 condition
-              </span>
-            </div>
-          </div>
-        </div>
       </div>
       <div
         class="MuiGrid-root makeStyles-results MuiGrid-container MuiGrid-direction-xs-column"
       >
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
+          class="MuiGrid-root makeStyles-results MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
         >
           <div
             class="MuiGrid-root makeStyles-table_controls MuiGrid-container"
@@ -1571,11 +1571,11 @@ exports[`QueryBuilder renders 1`] = `
             </div>
           </div>
           <div
-            class="MuiTableContainer-root"
+            class="MuiTableContainer-root makeStyles-table_container"
           >
             <table
               aria-label="result table"
-              class="MuiTable-root makeStyles-table"
+              class="MuiTable-root makeStyles-table MuiTable-stickyHeader"
             >
               <thead
                 class="MuiTableHead-root"
@@ -1584,25 +1584,25 @@ exports[`QueryBuilder renders 1`] = `
                   class="MuiTableRow-root MuiTableRow-head"
                 >
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
                     scope="col"
                   >
                     monster.name
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
                     scope="col"
                   >
                     prize.name
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
                     scope="col"
                   >
                     prize.name
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
                     scope="col"
                   >
                     victim.country

--- a/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
+++ b/timur/test/javascript/components/query/__snapshots__/query_results.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`QueryResults expands and nests matrix columns 1`] = `
 <DocumentFragment>
   <div
-    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
+    class="MuiGrid-root makeStyles-results MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
   >
     <div
       class="MuiGrid-root makeStyles-table_controls MuiGrid-container"
@@ -120,11 +120,11 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
       </div>
     </div>
     <div
-      class="MuiTableContainer-root"
+      class="MuiTableContainer-root makeStyles-table_container"
     >
       <table
         aria-label="result table"
-        class="MuiTable-root makeStyles-table"
+        class="MuiTable-root makeStyles-table MuiTable-stickyHeader"
       >
         <thead
           class="MuiTableHead-root"
@@ -133,25 +133,25 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
             class="MuiTableRow-root MuiTableRow-head"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               monster.name
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               prize.name
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               labor.contributions.Athens
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               labor.contributions.Sparta
@@ -170,7 +170,7 @@ exports[`QueryResults expands and nests matrix columns 1`] = `
 exports[`QueryResults renders 1`] = `
 <DocumentFragment>
   <div
-    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
+    class="MuiGrid-root makeStyles-results MuiGrid-container MuiGrid-item MuiGrid-direction-xs-column MuiGrid-grid-xs-12"
   >
     <div
       class="MuiGrid-root makeStyles-table_controls MuiGrid-container"
@@ -287,11 +287,11 @@ exports[`QueryResults renders 1`] = `
       </div>
     </div>
     <div
-      class="MuiTableContainer-root"
+      class="MuiTableContainer-root makeStyles-table_container"
     >
       <table
         aria-label="result table"
-        class="MuiTable-root makeStyles-table"
+        class="MuiTable-root makeStyles-table MuiTable-stickyHeader"
       >
         <thead
           class="MuiTableHead-root"
@@ -300,13 +300,13 @@ exports[`QueryResults renders 1`] = `
             class="MuiTableRow-root MuiTableRow-head"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               monster.name
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall MuiTableCell-stickyHeader"
               scope="col"
             >
               prize.name


### PR DESCRIPTION
Fixes a number of issues with the query page:
- page numbers reset to 0 on a new query
- fixes some query graph issues resulting in incorrectly un-selectable models
- memoizes some query graph searches, hopefully making column display faster
- updates query history list when you save
- fixes scrolling issues in results
- reorders 'where' pane above 'columns' pane