### PR TITLE
up query maxColumns to 100

### DIFF
--- a/timur/lib/client/jsx/components/query/query_table.tsx
+++ b/timur/lib/client/jsx/components/query/query_table.tsx
@@ -59,6 +59,7 @@ const QueryTable = ({
 }) => {
   const classes = useStyles();
 
+  const stickyStyle = index => index == 0 ? { position: 'sticky', left: 0, zIndex: 100 } : {};
   return (
     <React.Fragment>
       <Grid className={classes.table_controls} container>
@@ -94,7 +95,7 @@ const QueryTable = ({
               {columns
                 ?.slice(0, maxColumns)
                 .map(({label}: {label: string}, index: number) => (
-                  <TableCell key={index}>{label}</TableCell>
+                  <TableCell key={index} style={{ ...stickyStyle(index), background: '#fafafa' }}>{label}</TableCell>
                 ))}
             </TableRow>
           </TableHead>
@@ -103,7 +104,7 @@ const QueryTable = ({
               return (
                 <TableRow hover tabIndex={-1} key={row[0]}>
                   {row.slice(0, maxColumns).map((datum: any, index: number) => (
-                    <TableCell key={index} scope='row'>
+                    <TableCell key={index} scope='row' style={{ ...stickyStyle(index), background: 'white'}}>
                       <QueryTableAttributeViewer
                         tableColumn={columns[index]}
                         expandMatrices={expandMatrices}

--- a/timur/lib/client/jsx/contexts/query/query_results_context.tsx
+++ b/timur/lib/client/jsx/contexts/query/query_results_context.tsx
@@ -17,7 +17,7 @@ export const defaultQueryResultsParams = {
   numRecords: 0,
   queryString: '',
   savedQueries: [] as SavedQuery[],
-  maxColumns: 10
+  maxColumns: 100
 };
 
 const defaultQueryResultsState = {


### PR DESCRIPTION
This PR changes the number of maxColumns in query to be 100 instead of 10. This is larger than most (all?) models out in the wild, but the rendering is still nice and spiffy.

Also stickied the first (identifier) column for good measure (which works well except for tables, which show a meaningless numerical id).

No change to search, which might involve upgrading react-table to fix, figuring it is deprecated.