### PR TITLE
(WIP) vesta - refresh cache fetch for projects and stats after 5 minutes

### DIFF
--- a/vesta/vesta_ui/src/lib/clients/vesta-api/client.ts
+++ b/vesta/vesta_ui/src/lib/clients/vesta-api/client.ts
@@ -14,8 +14,8 @@ export class VestaApiClient {
             globalStatsRes,
             projectStatsRes,
         ] = await Promise.all([
-            fetch(this.#createUrl('stats')),
-            fetch(this.#createUrl('stats/projects')),
+            fetch(this.#createUrl('stats'), { next: { revalidate: 300 } }),
+            fetch(this.#createUrl('stats/projects'), { next: { revalidate: 300 } }),
         ])
 
         let globalStats: ApiStatsInstance[]


### PR DESCRIPTION
Not tested yet so not ready!

Follows a [nextjs fetch extension](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate) to reduce lag in the update of project info and stats updates.

Better would be if we can trigger a cache refresh on-demand via either a command built into the stats/projects pull cron jobs or run via console within the vesta pods!

ToDo:
- [ ] alternative available?
- [ ] test
- [ ] adjust timing?  5mins now, but we could lower it