### PR TITLE
More Vulcan Bug-fixes

### DIFF
--- a/vulcan/lib/client/jsx/components/dashboard/dashboard.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/dashboard.tsx
@@ -65,9 +65,8 @@ export default function Dashboard({project_name}: {project_name: string}) {
   const {canEdit} = useUserHooks();
   const visibleWorkspaces = useMemo(() => {
     const projectWorkflowIds = workflows.filter(w => w.project_name == project_name).map(w => w.id)
-    return workspaces.filter((w) => projectWorkflowIds.includes(w.workflow_id)
-      && canEdit(w) || (w.tags || []).includes('published')
-    )
+    const projectWorkspaces = workspaces.filter((w) => projectWorkflowIds.includes(w.workflow_id))
+    return projectWorkspaces.filter((w) => canEdit(w) || (w.tags || []).includes('published'))
   }, [workflows, workspaces, project_name]);
 
   return (

--- a/vulcan/lib/client/jsx/components/dashboard/workflow_control/workspace_creation.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/workflow_control/workspace_creation.tsx
@@ -236,7 +236,7 @@ export default function WorkspaceCreateButtonModal({
       setCreateTag('Create Workspace');
     }
   }, [valUse, versionText, createTag])
-  const disableCreate = createTag!='Create Workspace';
+  const disableCreate = createTag!='Create Workspace' || creating;
 
   return (
     <>


### PR DESCRIPTION
Hits one VERY important bugfix, and one semi-important bugfix:
- Only showing within-project workspaces in the project dashboard
- disable the `Create Workspace` button while that action is being attempted