### PR TITLE
Vulcan - latency-check button in nav bar

### DIFF
--- a/vulcan/lib/client/jsx/api_types.ts
+++ b/vulcan/lib/client/jsx/api_types.ts
@@ -320,45 +320,6 @@ export const defaultVulcanStorage: VulcanStorage = {
   status: {...defaultWorkspaceStatus},
 };
 
-// export const defaultSessionStatusResponse = {
-//   session: defaultVulcanSession,
-//   status: [[]] as [StepStatus[]],
-//   files: [] as string[],
-// };
-
-// export type SessionStatusResponse = typeof defaultSessionStatusResponse;
-
-// // Update me!
-// export interface VulcanFigure {
-//   id: number | null;
-//   figure_id?: number | null;
-//   inputs: {[k: string]: any};
-//   title?: string;
-//   author?: string;
-//   thumbnails?: string[];
-//   comment?: string;
-//   tags?: string[];
-//   workflow_snapshot?: Workflow;
-// }
-
-// export type VulcanFigureSession = VulcanSession & VulcanFigure;
-
-// export interface VulcanRevision {
-//   inputs: {[k: string]: any};
-//   title?: string;
-//   tags?: string[];
-//   id: number;
-//   workflow_snapshot?: Workflow;
-//   dependencies: {[key: string]: string};
-// }
-
-// export const defaultFigure = {
-//   id: null,
-//   figure_id: null,
-//   inputs: {},
-//   workflow_snapshot: defaultWorkflow
-// };
-
-// export interface FiguresResponse {
-//   figures: VulcanFigureSession[];
-// }
+export type LatencyReturn = {
+  latency:  string // of form "#{median_latency}ms"
+};

--- a/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
+++ b/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
@@ -1,0 +1,48 @@
+import React, {useCallback, useState, useContext} from 'react';
+
+import Tooltip from '@material-ui/core/Tooltip';
+import Button from '@material-ui/core/Button';
+import {VulcanContext} from '../../contexts/vulcan_context';
+import LoadingIcon from '../dashboard/loading_icon';
+import TimerIcon from '@material-ui/icons/Timer';
+
+export default function LatencyCheckButton({projectName}: {
+  projectName: string;
+}) {
+  const [checking, setChecking] = useState(false);
+  const [latency, setLatency] = useState<number | null>(null);
+
+  let {showErrors,
+    showError,
+    getConnectionLatency
+  } = useContext(VulcanContext);
+
+  const handleCheck = useCallback( () => {
+    // Check if workflow name is available
+    setChecking(true);
+    showErrors(getConnectionLatency(projectName), () => {setChecking(false)})
+    .then( (latencyReturn) => {
+      setChecking(false);
+      const latencyString = latencyReturn.latency;
+      setLatency(parseFloat(latencyString.replace('ns', '')))
+    })
+  }, [projectName, getConnectionLatency]);
+
+  console.log({latency})
+
+  const valShow = 'Latency: ' + (latency!=null ? latency + 'ms' : '???ms');
+  const actionIcon = checking ? <LoadingIcon/> : <TimerIcon/>;
+  const tooltipText = (checking ? 'Measuring' : latency!=null ? 'Re-measure' : 'Measure') + ' latency in calculation server connection';
+
+  return <Tooltip title={tooltipText}>
+    <Button
+      onClick={handleCheck}
+      color='primary'
+      variant='contained'
+    >
+      {valShow}
+      {actionIcon}
+    </Button>
+  </Tooltip>
+}
+

--- a/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
+++ b/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
@@ -13,22 +13,18 @@ export default function LatencyCheckButton({projectName}: {
   const [latency, setLatency] = useState<number | null>(null);
 
   let {showErrors,
-    showError,
     getConnectionLatency
   } = useContext(VulcanContext);
 
   const handleCheck = useCallback( () => {
-    // Check if workflow name is available
     setChecking(true);
     showErrors(getConnectionLatency(projectName), () => {setChecking(false)})
     .then( (latencyReturn) => {
       setChecking(false);
       const latencyString = latencyReturn.latency;
-      setLatency(parseFloat(latencyString.replace('ns', '')))
+      setLatency(parseFloat(latencyString))
     })
   }, [projectName, getConnectionLatency]);
-
-  console.log({latency})
 
   const valShow = 'Latency: ' + (latency!=null ? latency + 'ms' : '???ms');
   const actionIcon = checking ? <LoadingIcon/> : <TimerIcon/>;

--- a/vulcan/lib/client/jsx/components/vulcan_nav.jsx
+++ b/vulcan/lib/client/jsx/components/vulcan_nav.jsx
@@ -7,6 +7,7 @@ import {hasRunningSteps} from '../selectors/workflow_selectors';
 import Nav from 'etna-js/components/Nav';
 import Link from 'etna-js/components/link';
 import {selectUser} from 'etna-js/selectors/user-selector';
+import LatencyCheckButton from './latency_check/latency_check';
 
 const {sin, cos, PI, random, max, min, pow, abs, sqrt} = Math;
 
@@ -153,6 +154,7 @@ const ModeBar = ({mode, workspace}) => (
         <Link link={route}>{tab_name}</Link>
       </div>
     ))}
+    <LatencyCheckButton/>
   </div>
 );
 

--- a/vulcan/lib/client/jsx/contexts/api.ts
+++ b/vulcan/lib/client/jsx/contexts/api.ts
@@ -23,7 +23,8 @@ import {
   WorkflowCreateResponse,
   CreateWorkspaceResponse,
   isRunningReturn,
-  WorkspacesResponseRaw
+  WorkspacesResponseRaw,
+  LatencyReturn
 } from '../api_types';
 import { paramValuesToRaw, workspacesFromResponse } from '../selectors/workflow_selectors';
 import { isSome } from '../selectors/maybe';
@@ -100,6 +101,9 @@ export const defaultApiHelpers = {
     return new Promise(() => null);
   },
   pullRunStatus(projectName: string, workspaceId: number, runId: number): Promise<RunStatus> {
+    return new Promise(() => null);
+  },
+  getConnectionLatency(projectName: string): Promise<LatencyReturn> {
     return new Promise(() => null);
   }
 };
@@ -347,6 +351,10 @@ export function useApi(
       return vulcanGet(vulcanPath(`/api/v2/${projectName}/workspace/${workspaceId}/run/${runId}`))
   }, [vulcanGet, vulcanPath]);
 
+  const getConnectionLatency = useCallback((projectName: string): Promise<LatencyReturn> => {
+    return vulcanGet(vulcanPath(`/api/v2/${projectName}/cluster-latency`))
+  }, [vulcanGet, vulcanPath]);
+
   return {
     vulcanPath,
     showError,
@@ -366,6 +374,7 @@ export function useApi(
     requestRun,
     getIsRunning,
     pullRunStatus,
-    getImage
+    getImage,
+    getConnectionLatency
   };
 }


### PR DESCRIPTION
Adds a button for making use of the newly created latency-check endpoint.
![image](https://github.com/user-attachments/assets/397532f6-d356-43f2-b8c4-1baf846b18e6)

An **initial** implementation to get us started.  Eventually, we should improve and use colors as quality indicators based on results that we can start gathering after this is implemented.