### PR TITLE
Fix redcap autolink

### DIFF
--- a/magma/lib/magma/attributes/identifier_attribute.rb
+++ b/magma/lib/magma/attributes/identifier_attribute.rb
@@ -37,7 +37,7 @@ class Magma
 
             rule = grammar.parser.rules[@model.model_name.to_s]
             raise "No such rule #{@model.model_name} for #{@model.project_name}" unless rule
-            raise "The identifier '#{value}' does not conform to a grammar in Gnomon." unless rule.valid?(value)
+            raise "The identifier '#{value}' does not conform to the rule for #{@model.model_name} in Gnomon." unless rule.valid?(value)
           end
         rescue Exception => e
           yield "#{e.message}"

--- a/magma/spec/update_spec.rb
+++ b/magma/spec/update_spec.rb
@@ -1555,7 +1555,7 @@ describe UpdateController do
           }
         )
         expect(last_response.status).to eq(422)
-        expect(json_body[:errors]).to eq(["The identifier '#{identifier}' does not conform to a grammar in Gnomon."])
+        expect(json_body[:errors]).to eq(["The identifier '#{identifier}' does not conform to the rule for victim in Gnomon."])
 
       end
 

--- a/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
+++ b/polyphemus/lib/etls/redcap/redcap_etl_script_runner.rb
@@ -158,6 +158,7 @@ class Polyphemus
           update_request = Etna::Clients::Magma::UpdateRequest.new(
             project_name: @project_name,
             revisions: records,
+            autolink: true,
             dry_run: !commit)
           select_documents(magma_client.update_json(update_request))
         end


### PR DESCRIPTION
Redcap loader did not post to Magma with autolink: true, contrary to expectation. This passes autolink: true, which in cases where gnomon_mode=="pattern" are used will cause linking. In other cases this will be ignored. There are potentially problems of a "stirring up dust" sort, where autolink: true might cause some purposefully detached data to be reattached, left unaddressed.