### PR TITLE
Vulcan Status Report

### DIFF
--- a/vulcan/lib/client/jsx/api_types.ts
+++ b/vulcan/lib/client/jsx/api_types.ts
@@ -325,6 +325,7 @@ export type LatencyReturn = {
 };
 
 export type ClusterStatusReturn = {
+  connection_success: boolean;
   expected_down: boolean;
   message: string; // of form "#{median_latency}ms"
 };

--- a/vulcan/lib/client/jsx/api_types.ts
+++ b/vulcan/lib/client/jsx/api_types.ts
@@ -323,3 +323,8 @@ export const defaultVulcanStorage: VulcanStorage = {
 export type LatencyReturn = {
   latency:  string // of form "#{median_latency}ms"
 };
+
+export type ClusterStatusReturn = {
+  expected_down: boolean;
+  message: string; // of form "#{median_latency}ms"
+};

--- a/vulcan/lib/client/jsx/components/cluster_check.tsx
+++ b/vulcan/lib/client/jsx/components/cluster_check.tsx
@@ -1,11 +1,13 @@
 import React, {useCallback, useState, useContext, useEffect} from 'react';
 
 import {VulcanContext} from '../contexts/vulcan_context';
-import Alert from '@material-ui/lab/Alert'
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
 
-export default function ClusterKnownStatusReport({projectName}: {
+export default function ClusterStatusReport({projectName}: {
   projectName: string;
 }) {
+  const [connected, setConnected] = useState(true);
   const [message, setMessage] = useState('');
   const [expectedDown, setExpectedDown] = useState(false);
 
@@ -16,6 +18,7 @@ export default function ClusterKnownStatusReport({projectName}: {
   const handleCheck = useCallback( () => {
     showErrors(getClusterStatus(projectName))
     .then( (StatusReturn) => {
+      setConnected(StatusReturn.connection_success)
       setExpectedDown(StatusReturn.expected_down)
       setMessage(StatusReturn.message)
     })
@@ -25,8 +28,15 @@ export default function ClusterKnownStatusReport({projectName}: {
     handleCheck()
   }, [])
 
-  if (message==='') return null
-  return <Alert severity={expectedDown ? 'warning' : 'info'}>
+  if (message==='' && connected) return null
+
+  let connectionMessage = !connected ? (expectedDown ? 'Expected' : 'Unexpected') + ' Connection Failure. Workspaces are inaccessible.' :
+    undefined;
+
+  return <Alert severity={!connected && expectedDown ? 'warning' : connected ? 'info' : 'error'} style={{maxHeight: '44px', overflowY: 'auto'}}>
+    {connectionMessage && <AlertTitle>
+      {connectionMessage}
+    </AlertTitle>}
     {message}
   </Alert>
 }

--- a/vulcan/lib/client/jsx/components/cluster_check.tsx
+++ b/vulcan/lib/client/jsx/components/cluster_check.tsx
@@ -1,0 +1,32 @@
+import React, {useCallback, useState, useContext, useEffect} from 'react';
+
+import {VulcanContext} from '../contexts/vulcan_context';
+import Alert from '@material-ui/lab/Alert'
+
+export default function ClusterKnownStatusReport({projectName}: {
+  projectName: string;
+}) {
+  const [message, setMessage] = useState('');
+  const [expectedDown, setExpectedDown] = useState(false);
+
+  let {showErrors,
+    getClusterStatus
+  } = useContext(VulcanContext);
+
+  const handleCheck = useCallback( () => {
+    showErrors(getClusterStatus(projectName))
+    .then( (StatusReturn) => {
+      setExpectedDown(StatusReturn.expected_down)
+      setMessage(StatusReturn.message)
+    })
+  }, [projectName, getClusterStatus]);
+
+  useEffect(() => {
+    handleCheck()
+  }, [])
+
+  if (message==='') return null
+  return <Alert severity={expectedDown ? 'warning' : 'info'}>
+    {message}
+  </Alert>
+}

--- a/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
+++ b/vulcan/lib/client/jsx/components/latency_check/latency_check.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState, useContext} from 'react';
+import React, {useCallback, useState, useContext, useEffect} from 'react';
 
 import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
@@ -13,18 +13,18 @@ export default function LatencyCheckButton({projectName}: {
   const [latency, setLatency] = useState<number | null>(null);
 
   let {showErrors,
-    getConnectionLatency
+    getClusterLatency
   } = useContext(VulcanContext);
 
   const handleCheck = useCallback( () => {
     setChecking(true);
-    showErrors(getConnectionLatency(projectName), () => {setChecking(false)})
+    showErrors(getClusterLatency(projectName), () => {setChecking(false)})
     .then( (latencyReturn) => {
       setChecking(false);
       const latencyString = latencyReturn.latency;
       setLatency(parseFloat(latencyString))
     })
-  }, [projectName, getConnectionLatency]);
+  }, [projectName, getClusterLatency]);
 
   const valShow = 'Latency: ' + (latency!=null ? latency + 'ms' : '???ms');
   const actionIcon = checking ? <LoadingIcon/> : <TimerIcon/>;

--- a/vulcan/lib/client/jsx/components/vulcan_nav.jsx
+++ b/vulcan/lib/client/jsx/components/vulcan_nav.jsx
@@ -8,6 +8,8 @@ import Nav from 'etna-js/components/Nav';
 import Link from 'etna-js/components/link';
 import {selectUser} from 'etna-js/selectors/user-selector';
 import LatencyCheckButton from './latency_check/latency_check';
+import ClusterKnownStatusReport from './cluster_check'
+import Grid from '@material-ui/core/Grid';
 
 const {sin, cos, PI, random, max, min, pow, abs, sqrt} = Math;
 
@@ -145,17 +147,24 @@ const getTabs = (workspace) => ({
 });
 
 const ModeBar = ({mode, workspace}) => (
-  <div id='nav'>
-    {Object.entries(getTabs(workspace)).map(([tab_name, route]) => (
-      <div
-        key={tab_name}
-        className={`nav_tab ${mode == tab_name ? 'selected' : ''}`}
-      >
-        <Link link={route}>{tab_name}</Link>
-      </div>
-    ))}
-    <LatencyCheckButton/>
-  </div>
+  <Grid id='nav' container alignItems='center' spacing={2}>
+    <Grid item>
+      {Object.entries(getTabs(workspace)).map(([tab_name, route]) => (
+        <div
+          key={tab_name}
+          className={`nav_tab ${mode == tab_name ? 'selected' : ''}`}
+        >
+          <Link link={route}>{tab_name}</Link>
+        </div>
+      ))}
+    </Grid>
+    <Grid item>
+      <ClusterKnownStatusReport/>
+    </Grid>
+    <Grid item>
+      <LatencyCheckButton/>
+    </Grid>
+  </Grid>
 );
 
 const VulcanNav = ({mode, user}) => {

--- a/vulcan/lib/client/jsx/components/vulcan_nav.jsx
+++ b/vulcan/lib/client/jsx/components/vulcan_nav.jsx
@@ -8,7 +8,7 @@ import Nav from 'etna-js/components/Nav';
 import Link from 'etna-js/components/link';
 import {selectUser} from 'etna-js/selectors/user-selector';
 import LatencyCheckButton from './latency_check/latency_check';
-import ClusterKnownStatusReport from './cluster_check'
+import ClusterStatusReport from './cluster_check'
 import Grid from '@material-ui/core/Grid';
 
 const {sin, cos, PI, random, max, min, pow, abs, sqrt} = Math;
@@ -147,8 +147,8 @@ const getTabs = (workspace) => ({
 });
 
 const ModeBar = ({mode, workspace}) => (
-  <Grid id='nav' container alignItems='center' spacing={2}>
-    <Grid item>
+  <Grid id='nav' container alignItems='center' spacing={2} style={{paddingLeft: '5px', paddingRight: '5px'}}>
+    <Grid item xs={1}>
       {Object.entries(getTabs(workspace)).map(([tab_name, route]) => (
         <div
           key={tab_name}
@@ -158,11 +158,11 @@ const ModeBar = ({mode, workspace}) => (
         </div>
       ))}
     </Grid>
-    <Grid item>
-      <ClusterKnownStatusReport/>
-    </Grid>
-    <Grid item>
+    <Grid item xs={2}>
       <LatencyCheckButton/>
+    </Grid>
+    <Grid item xs={9}>
+      <ClusterStatusReport/>
     </Grid>
   </Grid>
 );

--- a/vulcan/lib/client/jsx/contexts/api.ts
+++ b/vulcan/lib/client/jsx/contexts/api.ts
@@ -24,7 +24,8 @@ import {
   CreateWorkspaceResponse,
   isRunningReturn,
   WorkspacesResponseRaw,
-  LatencyReturn
+  LatencyReturn,
+  ClusterStatusReturn
 } from '../api_types';
 import { paramValuesToRaw, workspacesFromResponse } from '../selectors/workflow_selectors';
 import { isSome } from '../selectors/maybe';
@@ -103,7 +104,10 @@ export const defaultApiHelpers = {
   pullRunStatus(projectName: string, workspaceId: number, runId: number): Promise<RunStatus> {
     return new Promise(() => null);
   },
-  getConnectionLatency(projectName: string): Promise<LatencyReturn> {
+  getClusterLatency(projectName: string): Promise<LatencyReturn> {
+    return new Promise(() => null);
+  },
+  getClusterStatus(projectName: string): Promise<ClusterStatusReturn> {
     return new Promise(() => null);
   }
 };
@@ -163,7 +167,7 @@ export function useApi(
   const showError = useCallback((e: any, dismissOld: boolean = false) => {
     if (dismissOld) invoke(dismissMessages());
     console.error(e);
-    invoke(showMessages(e));
+    invoke(showMessages([e]));
   }, [invoke]);
   const showErrors = useCallback(
     <T>(work: Promise<T>, additional: (e: any) => void = (e) => {}): Promise<T> => {
@@ -351,8 +355,12 @@ export function useApi(
       return vulcanGet(vulcanPath(`/api/v2/${projectName}/workspace/${workspaceId}/run/${runId}`))
   }, [vulcanGet, vulcanPath]);
 
-  const getConnectionLatency = useCallback((projectName: string): Promise<LatencyReturn> => {
+  const getClusterLatency = useCallback((projectName: string): Promise<LatencyReturn> => {
     return vulcanGet(vulcanPath(`/api/v2/${projectName}/cluster-latency`))
+  }, [vulcanGet, vulcanPath]);
+
+  const getClusterStatus = useCallback((projectName: string): Promise<ClusterStatusReturn> => {
+    return vulcanGet(vulcanPath(`/api/v2/${projectName}/cluster-status`))
   }, [vulcanGet, vulcanPath]);
 
   return {
@@ -375,6 +383,7 @@ export function useApi(
     getIsRunning,
     pullRunStatus,
     getImage,
-    getConnectionLatency
+    getClusterLatency,
+    getClusterStatus,
   };
 }

--- a/vulcan/lib/remote_manager.rb
+++ b/vulcan/lib/remote_manager.rb
@@ -220,6 +220,16 @@ class Vulcan
       end
     end
 
+    def check_connection()
+      command = build_command.add('echo', 'connection_check')
+      begin
+        invoke_ssh_command(command.to_s)
+        return true
+      rescue => e
+        return false
+      end
+    end
+
     def measure_latency(runs: 15)
       # Measure SSH latency by running a simple command multiple times and taking the median
       latencies = []

--- a/vulcan/lib/server.rb
+++ b/vulcan/lib/server.rb
@@ -41,6 +41,7 @@ class Vulcan
   
     # Cluster latency endpoint
     get 'api/v2/:project_name/cluster-latency', action: 'vulcan_v2#cluster_latency', auth: { user: { can_view?: :project_name }}
+    get 'api/v2/:project_name/cluster-status', action: 'vulcan_v2#cluster_status', auth: { user: { can_view?: :project_name }}
   
     # root path
     get '/', as: :root do erb_view(:client) end

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -357,6 +357,13 @@ class VulcanV2Controller < Vulcan::Controller
     retrieve_file(@params[:file_name], "application/octet-stream", disposition: "attachment; filename=#{@params[:file_name]}")
   end
 
+  def cluster_status
+    success_json({
+      expected_down: Vulcan.instance.config(:ssh)[:downage_expected],
+      message: Vulcan.instance.config(:ssh)[:downage_message],
+    })
+  end
+
   def cluster_latency
     begin
       # Measure SSH latency using the remote_manager's measure_latency method

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -359,6 +359,7 @@ class VulcanV2Controller < Vulcan::Controller
 
   def cluster_status
     success_json({
+      connection_success: @remote_manager.check_connection,
       expected_down: Vulcan.instance.config(:ssh)[:downage_expected],
       message: Vulcan.instance.config(:ssh)[:downage_message],
     })


### PR DESCRIPTION
Adds a Connection Status Check on visit, with display in the Nav Bar.

This API includes 3 elements:
1. a real check of if there is an active c4 conenction
2. sourced from the app config, a call of whether downage might be 'expected' or not at this time
3. sourced from the app config, a message for describing current or future maintenance windows

The UI in the NavBar then uses the MUI Alert component where icon&color can be easily adjusted based on the current situation.  Scroll is used to keep this element constrained within our standard NavBAr height.

## Some examples:
Known Maintenance Coming:
![image](https://github.com/user-attachments/assets/51beb794-0855-4818-be12-4242e9b4d95a)
Connection Failure that's expected:
![expected-failure](https://github.com/user-attachments/assets/f5850e18-fed4-415f-b82a-bf58610fff54)
Failure that's NOT expected:
![unexpected-failure](https://github.com/user-attachments/assets/a8da510f-bdb9-4581-8bf6-fbf49915912e)