### PR TITLE
Project Dashboard

### DIFF
--- a/decisions/adr-0006-project-dashboard.md
+++ b/decisions/adr-0006-project-dashboard.md
@@ -1,0 +1,81 @@
+# ADR-0006: Project Dashboard
+
+## Status
+
+Proposed
+
+## Context
+
+Currently the experience of using the data library applications is diffuse;
+there are several applications covering various scopes of work, but the user
+is left to navigate each of these applications without assistance. The new
+user, especially, may feel adrift when beginning with a blank project, and may
+not know how to navigate to the necessary functions in each application.
+
+By contrast there is a clear workflow that has emerged on how, generally, data
+should move in the library.
+
+1. Create the project - usually initiated by a library administrator, adding an
+   admin user to the project.
+2. Add users to the project
+3. Create models in Magma
+4. Create a naming grammar in Gnomon
+5. Create buckets for holding data in Metis
+6. Ingest data to Metis via metis_client
+7. Create data loaders in Polyphemus
+8. Run data loaders to link records into Magma
+9. Query, search, etc. data
+10. Analyze data using Vulcan workflows
+
+## Decision
+
+We will create a project dashboard, which will appear for the moment in the
+Timur data browsing app, and will be the primary landing point directed to by
+Vesta landing page app.
+
+The dashboard will summarize project state across each of the library
+applications, and will also direct the user on how to complete outstanding
+tasks to facilitate the above progression.
+
+The app components will each present data and actions appropriate to the user's
+role in the project. For viewers, the component will summarize the project
+data. For editors, it will link to tools or documentation to add or edit data.
+For admins, it will link to tools or documentation to configure the project.
+
+HEADER
+
+PROJECT          Project
+TEXT             Dashboard
+
+                 Map
+
+Janus
+  viewer: Show count of users in project broken down by role (m admins, n editors, o viewers), link to janus
+  admin: Show "Add new users" link to Janus project page if user count is 0
+
+Timur:
+  viewer: Show count of defined models. Show count of total project records if models exist, link to search
+  admin: Show "Add new models" link to map page if model count is 0, show link to modeling docs
+
+Gnomon:
+  viewer: Show count of rules / models with identifiers. Show count of created identifiers.
+  editor: Show "Create grammar" link to Gnomon project page, show link to naming docs if grammar is absent. Show "Add identifiers" link to gnomon if gnomon mode allows.
+
+Metis:
+  viewer: Show count of buckets. Show total count of files. Show total byte count. -> download links
+  editor: Show "Upload data" link to metis_client docs if file count is less than 10.
+  admin: Show "Create data buckets" link to metis if bucket count is 0
+
+Polyphemus:
+  viewer: Show count of data loaders. Show last runtime for any loader.
+  editor: Show "Create data loader" link to polyphemus if data loader count is 0.
+
+Vulcan:
+  viewer: Show count of workspaces created. Show count of project workflows.
+  editor: Show "Create workspace" link to vulcan if workspace count is 0.
+
+## Consequences
+
+Users will have a more streamlined experience into the library, with a single
+reference point they can consult to maintain and improve the state of the
+project.

--- a/docker/vulcan_c4_env/Dockerfile
+++ b/docker/vulcan_c4_env/Dockerfile
@@ -35,6 +35,8 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 # Create conda environmnent
 RUN . /$HOME/miniconda/etc/profile.d/conda.sh && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
     conda create -n conda-vulcan -c conda-forge -c bioconda snakemake=8.10.4 snakemake-executor-plugin-slurm=0.4.2 -y
 
 # TODO inject conda func into bashrc

--- a/etna/packages/etna-js/api/magma_api.js
+++ b/etna/packages/etna-js/api/magma_api.js
@@ -95,6 +95,6 @@ export const postRevisions = (revision_data, fetch=window.fetch) => {
   return magmaPost('update', fetch, revision_data);
 };
 
-export const getAnswer = (question, fetch) => {
+export const getAnswer = (question, fetch=window.fetch) => {
   return magmaPost('query', fetch, question);
 };

--- a/etna/packages/etna-js/contexts/route-context.tsx
+++ b/etna/packages/etna-js/contexts/route-context.tsx
@@ -7,6 +7,7 @@ export const RouteProvider = ({children, state}:{
   children: React.ReactNode;
 }) => {
   return (<RouteContext.Provider value={{
+    state
   }}>
     {children}
   </RouteContext.Provider>);

--- a/etna/packages/etna-js/contexts/route-context.tsx
+++ b/etna/packages/etna-js/contexts/route-context.tsx
@@ -1,0 +1,13 @@
+import React, { useContext, useState } from 'react';
+
+export const RouteContext = React.createContext({});
+
+export const RouteProvider = ({children, state}:{
+  state: any;
+  children: React.ReactNode;
+}) => {
+  return (<RouteContext.Provider value={{
+  }}>
+    {children}
+  </RouteContext.Provider>);
+}

--- a/etna/packages/etna-js/dispatchers/router.jsx
+++ b/etna/packages/etna-js/dispatchers/router.jsx
@@ -1,4 +1,3 @@
-
 const NAMED_PARAM=/:([\w]+)/g;
 const GLOB_PARAM=/\*([\w]+)$/g;
 const ROUTE_PART=/(:[\w]+|\*[\w]+$)/g;

--- a/metis/lib/server.rb
+++ b/metis/lib/server.rb
@@ -20,6 +20,9 @@ class Metis
     get '/api/stats/files', action: 'stats#file_count_by_project', auth: { user: { is_supereditor?: true } }
     get '/api/stats/bytes', action: 'stats#byte_count_by_project', auth: { user: { is_supereditor?: true } }
 
+    get '/api/stats/files/:project_name', action: 'stats#file_count', auth: { user: { can_view?: :project_name } }
+    get '/api/stats/bytes/:project_name', action: 'stats#byte_count', auth: { user: { can_view?: :project_name } }
+
     get '/:project_name', action: 'client#index', auth: { user: { can_view?: :project_name } }
     get '/:project_name/browse/:bucket_name', action: 'client#index', auth: { user: { can_view?: :project_name } }
     get '/:project_name/browse/:bucket_name/*folder_name', action: 'client#index', auth: { user: { can_view?: :project_name } }

--- a/metis/lib/server/controllers/stats_controller.rb
+++ b/metis/lib/server/controllers/stats_controller.rb
@@ -13,6 +13,15 @@ class StatsController < Metis::Controller
     success_json(count_detached!(file_count_by_project))
   end
 
+  def file_count
+    success_json(
+      @params[:project_name] =>
+      Metis::File
+      .where(project_name: @params[:project_name])
+      .distinct(:data_block_id).count
+    )
+  end
+
   def byte_count_by_project
     projects_to_include = @params[:projects]
 
@@ -29,6 +38,15 @@ class StatsController < Metis::Controller
     success_json(count_detached!(byte_count_by_project))
   end
 
+  def byte_count
+    success_json(
+      @params[:project_name] => Metis::DataBlock.where(
+        id: Metis::File.where(
+          project_name: @params[:project_name]
+        ).distinct(:data_block_id).select(:data_block_id)
+      ).select_map(:size).sum
+    )
+  end
   private
 
   def count_detached!(count_by_project)

--- a/metis/spec/spec_helper.rb
+++ b/metis/spec/spec_helper.rb
@@ -389,6 +389,22 @@ SHINY_HELMET=<<EOT
   xXx
  xO|Ox
 EOT
+LABORS_LIST=<<EOT
+The Twelve Labors of Hercules
+- The Nemean Lion
+- The Lernaean Hydra
+- The Ceryneian Hind
+- The Erymanthian Boar
+- The Augean Stables
+- The Stymphalian Birds
+- The Cretan Bull
+- The Mares of Diomedes
+- The Belt of Hippolyta
+- The Cattle of Geryon
+- The Golden Apples of the Hesperides
+- Cerberus
+EOT
+
 
 
 AUTH_USERS = {

--- a/metis/spec/stats_spec.rb
+++ b/metis/spec/stats_spec.rb
@@ -43,6 +43,30 @@ describe StatsController do
     end
   end
 
+  context "#file_count" do
+    before(:each) do
+      create_file('athena', 'wisdom.txt', WISDOM)
+      create_file('athena', 'helmet.jpg', HELMET)
+      create_file('athena', 'helmet-shiny.jpg', SHINY_HELMET)
+    end
+
+    it "returns file count for the project" do
+      token_header(:viewer)
+      get('/api/stats/files/athena')
+
+      expect(last_response.status).to eq(200)
+
+      expect(json_body).to eq(athena: 3)
+    end
+
+    it "only allows project viewers" do
+      token_header(:non_user)
+      get('/api/stats/files/athena')
+
+      expect(last_response.status).to eq(403)
+    end
+  end
+
   context "#byte_count_by_project" do
     before(:each) do
       create_file('athena', 'wisdom.txt', WISDOM)
@@ -81,4 +105,30 @@ describe StatsController do
     end
   end
 
+  context "#byte_count" do
+    before(:each) do
+      create_file('athena', 'wisdom.txt', WISDOM)
+      create_file('athena', 'helmet.jpg', HELMET)
+      create_file('athena', 'helmet-shiny.jpg', SHINY_HELMET)
+      create_file('labors', 'labors-list.txt', LABORS_LIST)
+    end
+
+    it "returns file count for all projects if none specified" do
+      token_header(:viewer)
+      get('/api/stats/bytes/athena')
+
+      expect(last_response.status).to eq(200)
+
+      expect(json_body).to eq({
+        athena: (WISDOM + HELMET + SHINY_HELMET).bytesize,
+      })
+    end
+
+    it "only allows project viewers" do
+      token_header(:non_user)
+      get('/api/stats/bytes/athena')
+
+      expect(last_response.status).to eq(403)
+    end
+  end
 end

--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -9,17 +9,14 @@
  * shown).
  */
 
-// Framework libraries.
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import 'regenerator-runtime/runtime';
 import useAsyncWork from 'etna-js/hooks/useAsyncWork';
 
-// Class imports.
 import Header from '../header';
 import ViewTabBar from './view_tab_bar';
 import ViewTab from './view_tab';
 
-// Module imports.
 import {setLocation} from 'etna-js/actions/location_actions';
 import {requestView} from '../../actions/view_actions';
 import {

--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -16,6 +16,7 @@ import useAsyncWork from 'etna-js/hooks/useAsyncWork';
 import Header from '../header';
 import ViewTabBar from './view_tab_bar';
 import ViewTab from './view_tab';
+import Dashboard from '../dashboard/dashboard';
 
 import {setLocation} from 'etna-js/actions/location_actions';
 import {requestView} from '../../actions/view_actions';
@@ -257,6 +258,7 @@ export default function Browser({model_name, record_name, tab_name}) {
       <ViewTab
         {...{model_name, record_name, template, record, revision, mode, tab}}
       />
+      <Dashboard project_name={CONFIG.project_name}/>
     </div>
   );
 }

--- a/timur/lib/client/jsx/components/browser/browser.jsx
+++ b/timur/lib/client/jsx/components/browser/browser.jsx
@@ -258,7 +258,7 @@ export default function Browser({model_name, record_name, tab_name}) {
       <ViewTab
         {...{model_name, record_name, template, record, revision, mode, tab}}
       />
-      <Dashboard project_name={CONFIG.project_name}/>
+      <Dashboard project_name={CONFIG.project_name} model_name={model_name} />
     </div>
   );
 }

--- a/timur/lib/client/jsx/components/dashboard/dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/dashboard.tsx
@@ -2,6 +2,7 @@ import React, {useState, useCallback, useEffect, useMemo} from 'react';
 
 import ProjectDashboard from './project_dashboard';
 import ModelMapGraphic from '../model_map/model_map_graphic';
+import {DashboardProvider} from '../../contexts/dashboard_context';
 
 import { useTheme, makeStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
@@ -64,44 +65,46 @@ const Dashboard = ({project_name, model_name}:{project_name: string, model_name?
     transitionTimingFunction: `${theme.transitions.easing.easeIn}`
   };
 
-  return <Grid
-      style={transitionStyle}
-      item
-      container
-      className={classes.slide}
-      justifyContent='flex-start'
-    >
-      <Grid container className={classes.topshadow} alignItems='flex-start' >
-        <Grid container direction='column' className={ classes.controls }>
-          <Tabs value={tab} onChange={ (e, tab) => {
-            setTab(tab); setShowDrawer(true);
-          } } orientation='vertical'
-          className={ classes.tabs }>
-            <Tab className={ classes.tab } disableRipple icon={
-              <Tooltip title="dashboard"><BuildIcon/></Tooltip>
-            } />
-            <Tab className={ classes.tab } disableRipple icon={
-              <Tooltip title="map"><MapIcon/></Tooltip>
-            } />
-          </Tabs>
+  return <DashboardProvider>
+    <Grid
+        style={transitionStyle}
+        item
+        container
+        className={classes.slide}
+        justifyContent='flex-start'
+      >
+        <Grid container className={classes.topshadow} alignItems='flex-start' >
+          <Grid container direction='column' className={ classes.controls }>
+            <Tabs value={tab} onChange={ (e, tab) => {
+              setTab(tab); setShowDrawer(true);
+            } } orientation='vertical'
+            className={ classes.tabs }>
+              <Tab className={ classes.tab } disableRipple icon={
+                <Tooltip title="dashboard"><BuildIcon/></Tooltip>
+              } />
+              <Tab className={ classes.tab } disableRipple icon={
+                <Tooltip title="map"><MapIcon/></Tooltip>
+              } />
+            </Tabs>
+            {
+              showDrawer && <IconButton onClick={ () => setShowDrawer(false) }><CloseIcon/></IconButton>
+            }
+          </Grid>
+          <Grid className={classes.tab_panel}>
           {
-            showDrawer && <IconButton onClick={ () => setShowDrawer(false) }><CloseIcon/></IconButton>
+            tab == 0 && <ProjectDashboard project_name={project_name}/>
           }
-        </Grid>
-        <Grid className={classes.tab_panel}>
-        {
-          tab == 0 && <ProjectDashboard project_name={project_name}/>
-        }
-        {
-          tab == 1 && <ModelMapGraphic
-              width={600}
-              height={600}
-              selected_models={[]}
-            />
-        }
+          {
+            tab == 1 && <ModelMapGraphic
+                width={600}
+                height={600}
+                selected_models={[]}
+              />
+          }
         </Grid>
       </Grid>
     </Grid>
+  </DashboardProvider>
 }
 
 export default Dashboard;

--- a/timur/lib/client/jsx/components/dashboard/dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/dashboard.tsx
@@ -1,0 +1,27 @@
+import React, {useState, useCallback, useEffect, useMemo} from 'react';
+
+import ProjectDashboard from './project_dashboard';
+import ModelMapGraphic from '../model_map/model_map_graphic';
+
+import {makeStyles} from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+
+const useStyles = makeStyles((theme) => ({
+}));
+
+const Dashboard = ({project_name}) => {
+  return <Grid container style={{ height: 'calc(100vh - 150px)', width: '100vw', flexWrap: 'nowrap' }}>
+    <Grid item container style={{ overflow: 'auto', width: 'calc(100vw - 600px)' }}>
+      <ProjectDashboard project_name={project_name}/>
+    </Grid>
+    <Grid item container style={{ overflow: 'auto', width: '600px' }}>
+      <ModelMapGraphic
+        width={600}
+        height={600}
+        selected_models={[]}
+      />
+    </Grid>
+  </Grid>
+}
+
+export default Dashboard;

--- a/timur/lib/client/jsx/components/dashboard/dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/dashboard.tsx
@@ -50,8 +50,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Dashboard = ({project_name}:{project_name: string}) => {
-  const [ showDrawer, setShowDrawer ] = useState(true);
+const Dashboard = ({project_name, model_name}:{project_name: string, model_name?: string}) => {
+  const [ showDrawer, setShowDrawer ] = useState(model_name == 'project');
   const [ tab, setTab ] = useState(0);
 
   const classes = useStyles();

--- a/timur/lib/client/jsx/components/dashboard/dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/dashboard.tsx
@@ -3,25 +3,105 @@ import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import ProjectDashboard from './project_dashboard';
 import ModelMapGraphic from '../model_map/model_map_graphic';
 
-import {makeStyles} from '@material-ui/core/styles';
+import { useTheme, makeStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import BuildIcon from '@material-ui/icons/Build';
+import MapIcon from '@material-ui/icons/Map';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import CloseIcon from '@material-ui/icons/Close';
 import Grid from '@material-ui/core/Grid';
+import Drawer from '@material-ui/core/Drawer';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const useStyles = makeStyles((theme) => ({
+  tab: {
+    minWidth: '60px'
+  },
+  controls: {
+    width: '60px',
+    boxShadow: '0 0 5px #888',
+    clipPath: 'inset(0 0 -10px -10px)',
+    zIndex: 1,
+    background: '#fbf9f6'
+  },
+  tabs: {
+    background: 'goldenrod'
+  },
+  tab_panel: {
+    background: 'white',
+    boxShadow: '0 0 5px #888',
+    clipPath: 'inset(0 -10px -10px -10px)',
+  },
+  topshadow: {
+    boxShadow: '10px 0 5px #888',
+    clipPath: 'inset(-10px 0 0 0)',
+    paddingLeft: '10px'
+  },
+  slide: {
+    overflow: 'visible',
+    height: '650px',
+    width: '672px',
+    position: 'fixed',
+    top: '70px',
+    right: '-1px',
+    clipPath: 'inset(-10px 0 0 -10px)'
+  },
 }));
 
-const Dashboard = ({project_name}) => {
-  return <Grid container style={{ height: 'calc(100vh - 150px)', width: '100vw', flexWrap: 'nowrap' }}>
-    <Grid item container style={{ overflow: 'auto', width: 'calc(100vw - 600px)' }}>
-      <ProjectDashboard project_name={project_name}/>
+const Dashboard = ({project_name}:{project_name: string}) => {
+  const [ showDrawer, setShowDrawer ] = useState(true);
+  const [ tab, setTab ] = useState(0);
+
+  const classes = useStyles();
+  const theme = useTheme();
+
+  const transitionStyle = {
+    transform: showDrawer ? 'none' : 'translate(604px)',
+    transitionProperty: 'transform',
+    transitionDuration: `${theme.transitions.duration.standard}ms`,
+    transitionTimingFunction: `${theme.transitions.easing.easeIn}`
+  };
+
+  return <Grid
+      style={transitionStyle}
+      item
+      container
+      className={classes.slide}
+      justifyContent='flex-start'
+    >
+      <Grid container className={classes.topshadow} alignItems='flex-start' >
+        <Grid container direction='column' className={ classes.controls }>
+          <Tabs value={tab} onChange={ (e, tab) => {
+            setTab(tab); setShowDrawer(true);
+          } } orientation='vertical'
+          className={ classes.tabs }>
+            <Tab className={ classes.tab } disableRipple icon={
+              <Tooltip title="dashboard"><BuildIcon/></Tooltip>
+            } />
+            <Tab className={ classes.tab } disableRipple icon={
+              <Tooltip title="map"><MapIcon/></Tooltip>
+            } />
+          </Tabs>
+          {
+            showDrawer && <IconButton onClick={ () => setShowDrawer(false) }><CloseIcon/></IconButton>
+          }
+        </Grid>
+        <Grid className={classes.tab_panel}>
+        {
+          tab == 0 && <ProjectDashboard project_name={project_name}/>
+        }
+        {
+          tab == 1 && <ModelMapGraphic
+              width={600}
+              height={600}
+              selected_models={[]}
+            />
+        }
+        </Grid>
+      </Grid>
     </Grid>
-    <Grid item container style={{ overflow: 'auto', width: '600px' }}>
-      <ModelMapGraphic
-        width={600}
-        height={600}
-        selected_models={[]}
-      />
-    </Grid>
-  </Grid>
 }
 
 export default Dashboard;

--- a/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
@@ -158,7 +158,7 @@ const AppInfo = ({sensor,action,role,actionRole=role,actionLink}:{
   const [ info, setInfo ] = useState({ level: 0, text: undefined });
 
   const user = useReduxState((state:any) => selectUser(state));
-  const userRole =  'viewer';//user.permissions[CONFIG.project_name].role;
+  const userRole =  user.permissions[CONFIG.project_name].role;
 
   const dashboardState = useContext(DashboardContext);
   useEffect( () => {

--- a/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useEffect, useMemo} from 'react';
+import React, {useState, useCallback, useContext, useEffect, useMemo} from 'react';
 
 import {makeStyles} from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -23,6 +23,7 @@ import CardMedia from '@material-ui/core/CardMedia';
 
 import {useReduxState} from 'etna-js/hooks/useReduxState';
 import {selectUser} from 'etna-js/selectors/user-selector';
+import {DashboardContext} from '../../contexts/dashboard_context';
 import {
   addUsersSensor,
   editModelsSensor,
@@ -159,9 +160,10 @@ const AppInfo = ({sensor,action,role,actionRole=role,actionLink}:{
   const user = useReduxState((state:any) => selectUser(state));
   const userRole =  'viewer';//user.permissions[CONFIG.project_name].role;
 
+  const dashboardState = useContext(DashboardContext);
   useEffect( () => {
-    sensor(setInfo);
-  }, [] );
+    sensor(setInfo, dashboardState);
+  }, [dashboardState] );
 
   const Star = STAR[info.level];
 

--- a/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
@@ -98,7 +98,7 @@ const AppDashboard = ({app,title,help,helpLink,children}:{
   const classes = useStyles();
 
   const user = useReduxState((state:any) => selectUser(state));
-  const userRole = 'viewer';//user.permissions[CONFIG.project_name].role;
+  const userRole = user.permissions[CONFIG.project_name].role;
 
   const shownChildren = React.Children.map(
     children, child => ROLES[child.props.role as keyof typeof ROLES] > ROLES[userRole] ? null : child

--- a/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
@@ -1,0 +1,107 @@
+import React, {useState, useCallback, useEffect, useMemo} from 'react';
+
+import {makeStyles} from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
+
+const size = '35px';
+const useStyles = makeStyles((theme) => ({
+  app: {
+    padding: '0px 15px',
+    borderBottom: '1px solid #eee'
+  },
+  appImage: {
+    border: '2px solid #066306',
+    borderRadius: size,
+    backgroundSize: `${size} ${size}`,
+    width: size,
+    height: size,
+  },
+  appTitle: {
+    fontSize: '0.9em',
+    textTransform: 'capitalize',
+    color: theme.palette.secondary.main
+  },
+  list: {
+    width: '100%',
+    maxWidth: '36ch',
+    backgroundColor: theme.palette.background.paper
+  },
+}));
+
+const APPLICATIONS = {
+}
+
+const AppDashboard = ({app,title,items}) => {
+  const classes = useStyles();
+  return <Grid container alignContent='center' className={classes.app}>
+    <Grid item direction='column' container alignContent='center' alignItems='center' justifyContent='flex-start' style={{ width: '60px', padding: '10px' }}>
+      <Grid item>
+      <div
+        className={classes.appImage}
+        title={app}
+        style={{
+          backgroundImage: `url(/images/${app}.svg)`,
+        }}
+      />
+      </Grid>
+      <Grid item><Typography className={classes.appTitle}>{title}</Typography></Grid>
+    </Grid>
+    <Grid container alignContent='center' direction='column' style={{ width: 'auto', paddingLeft: '25px' }}>
+      <List className={classes.list}>
+        {
+          items.map( (item,i) =>
+            <ListItem key={i}>
+              <ListItemText primary={item} />
+            </ListItem>
+          )
+        }
+      </List>
+    </Grid>
+  </Grid>
+}
+
+const JanusAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='janus' title='access' items={[ '2 administrators' ]}/>
+}
+
+const TimurAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='timur' title='modeling' items={[ '2 models with attributes', '1 empty model' ]}/>
+}
+
+const GnomonAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='gnomon' title='naming' items={[ '1 of 12 models have identifier rules' ]}/>
+}
+
+const MetisAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='metis' title='files' items={[ '572 files', '2033 GB' ]}/>
+}
+
+const PolyphemusAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='polyphemus' title='linking' items={[ '200 records created', '1 data loader', 'Last loader ran 2025-02-02' ]}/>
+}
+
+const VulcanAppDashboard = ({project_name, mode}) => {
+  return <AppDashboard app='vulcan' title='analysis' items={[ '1 analysis workspace' ]}/>
+}
+
+const Dashboard = ({project_name}) => {
+  const items = [];
+  const mode = 'administrator';
+  return <Grid container alignContent='flex-start'>
+    <JanusAppDashboard project_name={project_name} mode={mode}/>
+    <TimurAppDashboard project_name={project_name} mode={mode}/>
+    <GnomonAppDashboard project_name={project_name} mode={mode}/>
+    <MetisAppDashboard project_name={project_name} mode={mode}/>
+    <PolyphemusAppDashboard project_name={project_name} mode={mode}/>
+    <VulcanAppDashboard project_name={project_name} mode={mode}/>
+  </Grid>
+}
+
+export default Dashboard;

--- a/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
+++ b/timur/lib/client/jsx/components/dashboard/project_dashboard.tsx
@@ -2,22 +2,40 @@ import React, {useState, useCallback, useEffect, useMemo} from 'react';
 
 import {makeStyles} from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import Typography from '@material-ui/core/Typography';
 
+import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import Divider from '@material-ui/core/Divider';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import HelpIcon from '@material-ui/icons/Help';
+import StarIcon from '@material-ui/icons/Star';
+import StarBorderIcon from '@material-ui/icons/StarBorder';
+import StarHalfIcon from '@material-ui/icons/StarHalf';
+
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+
+import {json_get, json_delete} from 'etna-js/utils/fetch';
+
+const STAR = [
+  StarBorderIcon,
+  StarHalfIcon,
+  StarIcon
+];
 
 const size = '35px';
 const useStyles = makeStyles((theme) => ({
   app: {
     padding: '0px 15px',
-    borderBottom: '1px solid #eee'
+    borderTop: '1px solid #eee',
+    height: '90px',
   },
   appImage: {
-    border: '2px solid #066306',
+    border: '1px solid green',
     borderRadius: size,
     backgroundSize: `${size} ${size}`,
     width: size,
@@ -26,23 +44,45 @@ const useStyles = makeStyles((theme) => ({
   appTitle: {
     fontSize: '0.9em',
     textTransform: 'capitalize',
+    textAlign: 'center',
     color: theme.palette.secondary.main
   },
   list: {
     width: '100%',
     maxWidth: '36ch',
-    backgroundColor: theme.palette.background.paper
+    backgroundColor: theme.palette.background.paper,
+    padding: '0px'
   },
+  list_item: {
+    padding: '0px'
+  },
+  dashboard: {
+    width: '600px',
+    height: '600px'
+  }
 }));
 
 const APPLICATIONS = {
 }
 
-const AppDashboard = ({app,title,items}) => {
+type Info = {
+  level: number;
+  text: string;
+}
+
+const AppDashboard = ({app,title,action,children}:{
+  app: string;
+  title: string;
+  action: string;
+  children: any;
+}) => {
   const classes = useStyles();
+
   return <Grid container alignContent='center' className={classes.app}>
-    <Grid item direction='column' container alignContent='center' alignItems='center' justifyContent='flex-start' style={{ width: '60px', padding: '10px' }}>
-      <Grid item>
+    <Grid item direction='column' container alignContent='flex-start' alignItems='flex-start' justifyContent='space-evenly' style={{ width: '60px', padding: '0px', height: '100%', paddingBottom: '5px' }}>
+      <Grid item
+        style={{ width: '60px' }}><Typography className={classes.appTitle}>{title}</Typography></Grid>
+      <Grid item style={{ paddingLeft: '10px' }}>
       <div
         className={classes.appImage}
         title={app}
@@ -51,57 +91,133 @@ const AppDashboard = ({app,title,items}) => {
         }}
       />
       </Grid>
-      <Grid item><Typography className={classes.appTitle}>{title}</Typography></Grid>
     </Grid>
-    <Grid container alignContent='center' direction='column' style={{ width: 'auto', paddingLeft: '25px' }}>
+    <Grid item container justifyContent='space-around' direction='column' style={{ width: 'auto', paddingLeft: '15px', flex: '1 1 auto' }}>
       <List className={classes.list}>
         {
-          items.map( (item,i) =>
-            <ListItem key={i}>
-              <ListItemText primary={item} />
-            </ListItem>
-          )
+          children
         }
       </List>
     </Grid>
+    <Grid item container style={{width: '60px'}} alignContent='center' justifyContent='space-between' alignItems='center'>
+      <HelpIcon style={{ color:'dodgerblue' }}/>
+    </Grid>
   </Grid>
 }
 
-const JanusAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='janus' title='access' items={[ '2 administrators' ]}/>
+const STAR_STYLES = [
+  { color: 'red' },
+  { color: 'goldenrod' },
+  { color: 'green' }
+]
+
+const AppInfo = ({sensor}:{sensor: Function})=> {
+  const classes = useStyles();
+  const [ info, setInfo ] = useState({ level: 0, text: undefined });
+
+  useEffect( () => {
+    sensor(setInfo);
+  }, [] );
+
+  const Star = STAR[info.level];
+
+  return <ListItem className={classes.list_item}>
+    <ListItemIcon>
+      <Star style={STAR_STYLES[info.level]}/>
+    </ListItemIcon>
+    { info.text ?  <ListItemText secondary={info.text} /> : <div style={{width: '50px'}}><LinearProgress/></div> }
+  </ListItem>
 }
 
-const TimurAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='timur' title='modeling' items={[ '2 models with attributes', '1 empty model' ]}/>
+const JanusAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='janus' title='access' action='Add users'>
+    <AppInfo
+      sensor={ (setInfo: Function) => json_get(`${CONFIG.janus_host}/api/admin/${project_name}/info`).then(
+        ({project}) => {
+          const summary = project.permissions.map( ({role}:{role: string}) => role ).reduce(
+            (s: any,r: string) => {
+              s[r] = (s[r] || 0) + 1;
+              s.count = (s.count || 0) + 1;
+              return s
+            }, {}
+          );
+          const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
+          const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
+          const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
+            role => role in summary ? count(summary[role], role) : ''
+          ).filter(_=>_).join(', ')
+          setInfo({level, text})
+        }
+      ) }
+    />
+  </AppDashboard>
 }
 
-const GnomonAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='gnomon' title='naming' items={[ '1 of 12 models have identifier rules' ]}/>
+const TimurAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='timur' title='modeling' action='Model'>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 1, text: '1 out of 3 models with attributes' }
+    ) }/>
+  </AppDashboard>
 }
 
-const MetisAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='metis' title='files' items={[ '572 files', '2033 GB' ]}/>
+const GnomonAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='gnomon' title='naming' action='Edit rules'>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 0, text: '1 of 12 models have identifier rules' }
+    ) }/>
+  </AppDashboard>
 }
 
-const PolyphemusAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='polyphemus' title='linking' items={[ '200 records created', '1 data loader', 'Last loader ran 2025-02-02' ]}/>
+const MetisAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='metis' title='files' action='Add files'>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '2 buckets created' }
+    ) }/>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '572 files, 2.03 TB stored'}
+    ) }/>
+  </AppDashboard>
 }
 
-const VulcanAppDashboard = ({project_name, mode}) => {
-  return <AppDashboard app='vulcan' title='analysis' items={[ '1 analysis workspace' ]}/>
+const PolyphemusAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='polyphemus' title='linking' action='Link records'>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '200 records created' }
+    ) }/>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '1 data loader, last run 2025-02-02' }
+    ) }/>
+  </AppDashboard>
 }
 
-const Dashboard = ({project_name}) => {
-  const items = [];
+const VulcanAppDashboard = ({project_name, mode}:{project_name: string, mode: any}) => {
+  return <AppDashboard app='vulcan' title='analysis' action='Add workflows'>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '1 workflow' }
+    ) }/>
+    <AppInfo sensor={ (setInfo: Function) => setInfo(
+      { level: 2, text: '1 workspace, last run 2025-03-03' }
+    ) }/>
+  </AppDashboard>
+}
+
+const Dashboard = ({project_name}:{project_name: string}) => {
   const mode = 'administrator';
-  return <Grid container alignContent='flex-start'>
-    <JanusAppDashboard project_name={project_name} mode={mode}/>
-    <TimurAppDashboard project_name={project_name} mode={mode}/>
-    <GnomonAppDashboard project_name={project_name} mode={mode}/>
-    <MetisAppDashboard project_name={project_name} mode={mode}/>
-    <PolyphemusAppDashboard project_name={project_name} mode={mode}/>
-    <VulcanAppDashboard project_name={project_name} mode={mode}/>
-  </Grid>
+  const classes = useStyles();
+  return <Card className={ classes.dashboard }>
+    <CardContent>
+    <Typography>Dashboard</Typography>
+    </CardContent>
+    <CardMedia>
+      <JanusAppDashboard project_name={project_name} mode={mode}/>
+      <TimurAppDashboard project_name={project_name} mode={mode}/>
+      <GnomonAppDashboard project_name={project_name} mode={mode}/>
+      <MetisAppDashboard project_name={project_name} mode={mode}/>
+      <PolyphemusAppDashboard project_name={project_name} mode={mode}/>
+      <VulcanAppDashboard project_name={project_name} mode={mode}/>
+    </CardMedia>
+  </Card>
 }
 
 export default Dashboard;

--- a/timur/lib/client/jsx/components/dashboard/sensors.tsx
+++ b/timur/lib/client/jsx/components/dashboard/sensors.tsx
@@ -1,9 +1,11 @@
 import {json_get, json_delete} from 'etna-js/utils/fetch';
-import {DashboardContext} from '../../contexts/dashboard_context';
-import React, {useContext} from 'react';
+import {byteFormat} from 'etna-js/utils/format';
 
-export const addUsersSensor = (setInfo: Function) => {
-  const { projectInfo } = useContext(DashboardContext);
+const plural = (word,count) => count == 1 ? word : word + 's';
+export const addUsersSensor = (setInfo: Function, state: any) => {
+  const { projectInfo } = state;
+
+  if (!projectInfo) return;
 
   const summary = projectInfo.permissions.map( ({role}:{role: string}) => role ).reduce(
     (s: any,r: string) => {
@@ -12,48 +14,86 @@ export const addUsersSensor = (setInfo: Function) => {
       return s
     }, {}
   );
-  const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
   const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
   const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
-    role => role in summary ? count(summary[role], role) : ''
+    role => role in summary ? `${summary[role]} ${plural(role, summary[role])}` : ''
   ).filter(_=>_).join(', ');
 
   setInfo({level, text})
 }
 
-export const editModelsSensor = (setInfo: Function) => {
-  const { models } = useContext(DashboardContext);
+export const editModelsSensor = (setInfo: Function, state: any) => {
+  const { models } = state;
+
+  if (!models) return;
+  console.log({models});
 
   const modelCount = Object.values(models).length;
+  const filledCount = Object.values(models).filter(
+    model => Object.values(model.template.attributes).filter(
+      attribute => !attribute.link_model_name && attribute.attribute_type != 'identifier' && attribute.attribute_name != 'created_at' && attribute.attribute_name != 'updated_at'
+    ).length > 0
+  ).length
 
-  console.log({modelCount});
-  setInfo({ level: 0, text: '1 of 12 models have identifier rules' })
+  setInfo({
+    level: modelCount < 3 ? 0 : Math.min(Math.floor((filledCount / modelCount) * 3), 2),
+    text: `${filledCount} of ${modelCount} ${plural('model',modelCount)} with attributes`
+  });
 } 
 
-export const editRulesSensor = (setInfo: Function) => setInfo(
-  { level: 0, text: '1 of 12 models have identifier rules' }
-);
+export const editRulesSensor = (setInfo: Function, state: any) => {
+  const { models, rules } = state;
 
-export const createBucketsSensor = (setInfo: Function) => setInfo(
-  { level: 2, text: '2 buckets created' }
-);
+  if (!models || !rules) return;
+  console.log({rules});
 
-export const addFilesSensor = (setInfo: Function) => setInfo(
-  { level: 2, text: '572 files, 2.03 TB stored'}
-);
+  const modelsWithIds = Object.keys(models).filter(
+    modelName => {
+      const template = models[modelName].template;
+      const id = template.attributes[template.identifier];
+      return (id.attribute_name != 'id' && !id.hidden)
+    }
+  );
 
-export const linkRecordsSensor = (setInfo: Function) => setInfo(
-      { level: 2, text: '200 records created' }
+  const modelsWithNames = modelsWithIds.filter(
+    modelName => modelName in rules
+  );
+    
+  setInfo({
+    level: modelsWithIds.length == 0 ? 0 : Math.min(Math.floor(modelsWithNames.length/modelsWithIds.length*3), 2),
+    text: `${modelsWithNames.length} of ${modelsWithIds.length} models have identifier rules`
+  });
+}
+
+export const createBucketsSensor = (setInfo: Function, state: any) => {
+  const { buckets } = state;
+  if (!buckets) return;
+  setInfo({ level: !buckets.length ? 0 : 2, text: `${buckets.length} ${plural('bucket',buckets.length)} created` });
+};
+
+export const addFilesSensor = (setInfo: Function, state: any) => {
+  const { files, bytes } = state;
+  console.log({state});
+
+  if (files == null || bytes == null) return;
+  setInfo({
+    level: files < 10 ? 0 : (bytes < 10000000000 ? 1 : 2),
+    text: `${files} ${plural('file',files)}, ${byteFormat(bytes)} stored`
+  });
+};
+
+export const linkRecordsSensor = (setInfo: Function, state: any) => setInfo(
+      { level: 0, text: '200 records created' }
     );
 
-export const createLoadersSensor = (setInfo: Function) => setInfo(
-  { level: 2, text: '1 data loader, last run 2025-02-02' }
+export const createLoadersSensor = (setInfo: Function, state: any) => setInfo(
+  { level: 0, text: '1 data loader, last run 2025-02-02' }
 );
 
-export const addWorkflowsSensor = (setInfo: Function) => setInfo(
-  { level: 2, text: '1 workflow' }
+export const addWorkflowsSensor = (setInfo: Function, state: any) => setInfo(
+  { level: 0, text: '1 workflow' }
 );
 
-export const runWorkflowsSensor = (setInfo: Function) => setInfo(
-  { level: 2, text: '1 workspace, last run 2025-03-03' }
+export const runWorkflowsSensor = (setInfo: Function, state: any) => setInfo(
+  { level: 0, text: '1 workspace, last run 2025-03-03' }
 );

--- a/timur/lib/client/jsx/components/dashboard/sensors.tsx
+++ b/timur/lib/client/jsx/components/dashboard/sensors.tsx
@@ -1,45 +1,34 @@
 import {json_get, json_delete} from 'etna-js/utils/fetch';
+import {DashboardContext} from '../../contexts/dashboard_context';
+import React, {useContext} from 'react';
 
-export const addUsersSensor = (setInfo: Function) => json_get(
-  `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
-).then(
-  ({project}) => {
-    const summary = project.permissions.map( ({role}:{role: string}) => role ).reduce(
-      (s: any,r: string) => {
-        s[r] = (s[r] || 0) + 1;
-        s.count = (s.count || 0) + 1;
-        return s
-      }, {}
-    );
-    const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
-    const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
-    const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
-      role => role in summary ? count(summary[role], role) : ''
-    ).filter(_=>_).join(', ')
-    setInfo({level, text})
-  }
-) 
+export const addUsersSensor = (setInfo: Function) => {
+  const { projectInfo } = useContext(DashboardContext);
 
+  const summary = projectInfo.permissions.map( ({role}:{role: string}) => role ).reduce(
+    (s: any,r: string) => {
+      s[r] = (s[r] || 0) + 1;
+      s.count = (s.count || 0) + 1;
+      return s
+    }, {}
+  );
+  const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
+  const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
+  const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
+    role => role in summary ? count(summary[role], role) : ''
+  ).filter(_=>_).join(', ');
 
-export const editModelsSensor = (setInfo: Function) => json_get(
-  `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
-).then(
-  ({project}) => {
-    const summary = project.permissions.map( ({role}:{role: string}) => role ).reduce(
-      (s: any,r: string) => {
-        s[r] = (s[r] || 0) + 1;
-        s.count = (s.count || 0) + 1;
-        return s
-      }, {}
-    );
-    const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
-    const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
-    const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
-      role => role in summary ? count(summary[role], role) : ''
-    ).filter(_=>_).join(', ')
-    setInfo({level, text})
-  }
-) 
+  setInfo({level, text})
+}
+
+export const editModelsSensor = (setInfo: Function) => {
+  const { models } = useContext(DashboardContext);
+
+  const modelCount = Object.values(models).length;
+
+  console.log({modelCount});
+  setInfo({ level: 0, text: '1 of 12 models have identifier rules' })
+} 
 
 export const editRulesSensor = (setInfo: Function) => setInfo(
   { level: 0, text: '1 of 12 models have identifier rules' }
@@ -66,5 +55,5 @@ export const addWorkflowsSensor = (setInfo: Function) => setInfo(
 );
 
 export const runWorkflowsSensor = (setInfo: Function) => setInfo(
-      { level: 2, text: '1 workspace, last run 2025-03-03' }
-    );
+  { level: 2, text: '1 workspace, last run 2025-03-03' }
+);

--- a/timur/lib/client/jsx/components/dashboard/sensors.tsx
+++ b/timur/lib/client/jsx/components/dashboard/sensors.tsx
@@ -1,0 +1,70 @@
+import {json_get, json_delete} from 'etna-js/utils/fetch';
+
+export const addUsersSensor = (setInfo: Function) => json_get(
+  `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
+).then(
+  ({project}) => {
+    const summary = project.permissions.map( ({role}:{role: string}) => role ).reduce(
+      (s: any,r: string) => {
+        s[r] = (s[r] || 0) + 1;
+        s.count = (s.count || 0) + 1;
+        return s
+      }, {}
+    );
+    const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
+    const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
+    const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
+      role => role in summary ? count(summary[role], role) : ''
+    ).filter(_=>_).join(', ')
+    setInfo({level, text})
+  }
+) 
+
+
+export const editModelsSensor = (setInfo: Function) => json_get(
+  `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
+).then(
+  ({project}) => {
+    const summary = project.permissions.map( ({role}:{role: string}) => role ).reduce(
+      (s: any,r: string) => {
+        s[r] = (s[r] || 0) + 1;
+        s.count = (s.count || 0) + 1;
+        return s
+      }, {}
+    );
+    const count = (c: number,r: string) => c == 1 ? `1 ${r}` : `${c} ${r}s`;
+    const level = (summary.count < 3) ? (summary.count < 2 ? 0 : 1) : 2;
+    const text = [ 'administrator', 'editor', 'viewer', 'guest' ].map(
+      role => role in summary ? count(summary[role], role) : ''
+    ).filter(_=>_).join(', ')
+    setInfo({level, text})
+  }
+) 
+
+export const editRulesSensor = (setInfo: Function) => setInfo(
+  { level: 0, text: '1 of 12 models have identifier rules' }
+);
+
+export const createBucketsSensor = (setInfo: Function) => setInfo(
+  { level: 2, text: '2 buckets created' }
+);
+
+export const addFilesSensor = (setInfo: Function) => setInfo(
+  { level: 2, text: '572 files, 2.03 TB stored'}
+);
+
+export const linkRecordsSensor = (setInfo: Function) => setInfo(
+      { level: 2, text: '200 records created' }
+    );
+
+export const createLoadersSensor = (setInfo: Function) => setInfo(
+  { level: 2, text: '1 data loader, last run 2025-02-02' }
+);
+
+export const addWorkflowsSensor = (setInfo: Function) => setInfo(
+  { level: 2, text: '1 workflow' }
+);
+
+export const runWorkflowsSensor = (setInfo: Function) => setInfo(
+      { level: 2, text: '1 workspace, last run 2025-03-03' }
+    );

--- a/timur/lib/client/jsx/components/dashboard/sensors.tsx
+++ b/timur/lib/client/jsx/components/dashboard/sensors.tsx
@@ -82,18 +82,54 @@ export const addFilesSensor = (setInfo: Function, state: any) => {
   });
 };
 
-export const linkRecordsSensor = (setInfo: Function, state: any) => setInfo(
-      { level: 0, text: '200 records created' }
-    );
+export const linkRecordsSensor = (setInfo: Function, state: any) => {
+  const { records } = state;
 
-export const createLoadersSensor = (setInfo: Function, state: any) => setInfo(
-  { level: 0, text: '1 data loader, last run 2025-02-02' }
-);
+  if (records == null) return;
 
-export const addWorkflowsSensor = (setInfo: Function, state: any) => setInfo(
-  { level: 0, text: '1 workflow' }
-);
+  setInfo({
+    level: records < 5 ? 0 : records < 20 ? 1 : 2,
+    text: `${records} ${plural('record',records)} created`
+  });
+}
 
-export const runWorkflowsSensor = (setInfo: Function, state: any) => setInfo(
-  { level: 0, text: '1 workspace, last run 2025-03-03' }
-);
+export const createLoadersSensor = (setInfo: Function, state: any) => {
+  const { loaders } = state;
+
+  if (loaders == null) return;
+
+  const lastRan = Math.max(...loaders.filter( _ => _ ));
+
+  setInfo(
+    {
+      level: loaders.length == 0 ? 0 : lastRan < 0 ? 1 : 2,
+      text: `${loaders.length} data ${plural('loader',loaders.length)}, ${lastRan < 0 ? 'never run' : `last run ${lastRan.slice(0,10)}`}`
+    }
+  );
+}
+
+export const addWorkflowsSensor = (setInfo: Function, state: any) => {
+  const { workflows } = state;
+
+  if (workflows == null) return;
+
+  setInfo({
+    level: workflows == 0 ? 0 : workflows == 1 ? 1 : 2,
+    text: `${workflows} ${plural('workflow',workflows)}`
+  });
+}
+
+export const runWorkflowsSensor = (setInfo: Function, state: any) => {
+  const { workspaces } = state;
+
+  if (workspaces == null) return;
+
+  const lastRan = workspaces.reduce( (min,w) => min < w.updated_at ? w.updated_at : min, '' );
+
+  setInfo(
+    {
+      level: workspaces.length == 0 ? 0 : !lastRan ? 1 : 2,
+      text: `${workspaces.length} ${plural('workspace',workspaces.length)}, ${!lastRan ? 'never run' : `last run ${lastRan.slice(0,10)}`}`
+    }
+  );
+}

--- a/timur/lib/client/jsx/components/model_map.jsx
+++ b/timur/lib/client/jsx/components/model_map.jsx
@@ -45,9 +45,8 @@ const mapStyle = makeStyles((theme) => ({
     overflow: 'auto'
   },
   heading: {
-    position: 'absolute',
-    left: '15px',
-    top: '0px',
+    margin: '0px 10px',
+    width: 'calc(100% - 20px)',
     height: '48px',
     width: '560px',
     background: 'white',

--- a/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_map_graphic.jsx
@@ -5,6 +5,7 @@ import {useReduxState} from 'etna-js/hooks/useReduxState';
 import ModelLink, {Arrowhead} from './model_link';
 import ModelNode from './model_node';
 import Layout from './tree_layout';
+import Grid from '@material-ui/core/Grid';
 
 const ModelMapGraphic = ({
   selected_models,
@@ -26,7 +27,7 @@ const ModelMapGraphic = ({
   let layout = new Layout(templates, width, height);
 
   return (
-    <div style={{ position: 'relative' }}>
+    <Grid style={{ width, height, position: 'relative' }}>
       <svg id='map' width={width} height={height}>
         <defs>
           <Arrowhead />
@@ -67,7 +68,7 @@ const ModelMapGraphic = ({
           />
         );
       })}
-    </div>
+    </Grid>
   );
 };
 

--- a/timur/lib/client/jsx/components/model_map/model_node.jsx
+++ b/timur/lib/client/jsx/components/model_map/model_node.jsx
@@ -45,7 +45,13 @@ const ModelNode = ({model_name, center, size, selected, handler, disabled, numSi
       className={`${classes.model_node} ${selected ? classes.selected : ''} ${
         disabled ? classes.disabled : ''
       }`}
-      style={{top: center.y, left: center.x, '--model-width': `${600 / (numSiblings + 1) - 15}px` }}
+
+      style={{
+        top: center.y,
+        left: center.x,
+        maxWidth: `${600 / (numSiblings + 1) - 15}px`
+      }}
+
       onClick={() => {
         if (!disabled) handler(model_name);
       }}

--- a/timur/lib/client/jsx/components/model_map/tree_layout.jsx
+++ b/timur/lib/client/jsx/components/model_map/tree_layout.jsx
@@ -66,7 +66,7 @@ class LayoutNode {
     let maxdepth = grid.length;
     this.center = {
       x: (this.pos/(maxpos + 1)) * this.layout.width,
-      y: (this.depth / maxdepth) * this.layout.height
+      y: ((this.depth-0.5) / maxdepth) * this.layout.height
     };
     this.size = 40;
   }

--- a/timur/lib/client/jsx/components/timur_nav.jsx
+++ b/timur/lib/client/jsx/components/timur_nav.jsx
@@ -46,8 +46,9 @@ const Logo = connect(({exchanges}) => ({exchanges}))(({exchanges}) => (
 
 const getTabs = ({mode, user, canUseAdvanced}) => {
   let tabs = {
+    project: Routes.dashboard_path(CONFIG.project_name),
     browse: Routes.browse_path(CONFIG.project_name),
-    map: Routes.map_path(CONFIG.project_name),
+    model: Routes.map_path(CONFIG.project_name),
     search: Routes.search_path(CONFIG.project_name),
     query: Routes.query_path(CONFIG.project_name),
     help: `https://mountetna.github.io/timur.html#${mode}`

--- a/timur/lib/client/jsx/components/timur_nav.jsx
+++ b/timur/lib/client/jsx/components/timur_nav.jsx
@@ -46,7 +46,6 @@ const Logo = connect(({exchanges}) => ({exchanges}))(({exchanges}) => (
 
 const getTabs = ({mode, user, canUseAdvanced}) => {
   let tabs = {
-    project: Routes.dashboard_path(CONFIG.project_name),
     browse: Routes.browse_path(CONFIG.project_name),
     model: Routes.map_path(CONFIG.project_name),
     search: Routes.search_path(CONFIG.project_name),

--- a/timur/lib/client/jsx/contexts/dashboard_context.tsx
+++ b/timur/lib/client/jsx/contexts/dashboard_context.tsx
@@ -1,7 +1,8 @@
 import React, {useState, useContext, useEffect, createContext, useCallback} from 'react';
 import { Models } from 'etna-js/models/magma-model';
 import { MagmaContext } from 'etna-js/contexts/magma-context';
-import {getModels} from 'etna-js/api/magma_api';
+import { getModels, magmaPath } from 'etna-js/api/magma_api';
+import {json_get, json_delete} from 'etna-js/utils/fetch';
 
 const defaultDashboardState = {
   models: null as Models | null,
@@ -22,38 +23,57 @@ export type ProviderProps = {params?: {}; children: any};
 export const DashboardProvider = (
   props: ProviderProps & Partial<DashboardContextData>
 ) => {
-  const [state, setState] = useState(props.state || defaultDashboardContext.state);
-
   const { models, setModels } = useContext(MagmaContext);
-
   useEffect( () => {
     if (Object.keys(models).length == 0) {
-      getModels(project_name).then(({models}) => setModels(models));
-    } else {
-      setState({
-        ...state,
-        models: new Models(models)
-      });
+      getModels(CONFIG.project_name).then(({models}) => setModels(models));
     }
   }, [models] );
 
+  const [ rules, setRules ] = useState(null);
   useEffect( () => {
-    if (!('projectInfo' in state)) {
-      json_get(
-        `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
-      ).then(
-        ({project}) => setState({
-          ...state,
-          projectInfo: project
-        })
-      )
-    }
+    json_get(magmaPath(`gnomon/${CONFIG.project_name}/`)).then(
+      ({config: { rules } }) => setRules(rules)
+    );
   }, [] );
 
+  const [ projectInfo, setProjectInfo ] = useState(null);
+  useEffect( () => {
+    json_get(`${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`).then(
+      ({project}) => setProjectInfo(project)
+    );
+  }, [] );
+
+  const [ buckets, setBuckets ] = useState(null);
+  useEffect( () => {
+    json_get(`${CONFIG.metis_host}/${CONFIG.project_name}/list`).then(
+      ({buckets}) => setBuckets(buckets)
+    );
+  }, [] );
+
+  const [ files, setFiles ] = useState(null);
+  useEffect( () => {
+    json_get(`${CONFIG.metis_host}/api/stats/files/${CONFIG.project_name}`).then(
+      ({[CONFIG.project_name]: files}) => setFiles(files)
+    );
+  }, [] );
+
+  const [ bytes, setBytes ] = useState(null);
+  useEffect( () => {
+    json_get(`${CONFIG.metis_host}/api/stats/bytes/${CONFIG.project_name}`).then(
+      ({[CONFIG.project_name]: bytes}) => setBytes(bytes)
+    );
+  }, [] );
+
+  const [ records, setRecords ] = useState(null);
+  useEffect( () => {
+  }, [] );
 
   return (
     <DashboardContext.Provider
-      value={ state }
+      value={ {
+        models, rules, bytes, files, projectInfo, buckets
+      }}
     >
       {props.children}
     </DashboardContext.Provider>

--- a/timur/lib/client/jsx/contexts/dashboard_context.tsx
+++ b/timur/lib/client/jsx/contexts/dashboard_context.tsx
@@ -1,0 +1,61 @@
+import React, {useState, useContext, useEffect, createContext, useCallback} from 'react';
+import { Models } from 'etna-js/models/magma-model';
+import { MagmaContext } from 'etna-js/contexts/magma-context';
+import {getModels} from 'etna-js/api/magma_api';
+
+const defaultDashboardState = {
+  models: null as Models | null,
+};
+
+export type DashboardState = Readonly<typeof defaultDashboardState>;
+
+export const defaultDashboardContext = {
+  state: defaultDashboardState as DashboardState,
+};
+
+export type DashboardContextData = typeof defaultDashboardContext;
+
+export const DashboardContext = createContext(defaultDashboardContext);
+export type DashboardContext = typeof DashboardContext;
+export type ProviderProps = {params?: {}; children: any};
+
+export const DashboardProvider = (
+  props: ProviderProps & Partial<DashboardContextData>
+) => {
+  const [state, setState] = useState(props.state || defaultDashboardContext.state);
+
+  const { models, setModels } = useContext(MagmaContext);
+
+  useEffect( () => {
+    if (Object.keys(models).length == 0) {
+      getModels(project_name).then(({models}) => setModels(models));
+    } else {
+      setState({
+        ...state,
+        models: new Models(models)
+      });
+    }
+  }, [models] );
+
+  useEffect( () => {
+    if (!('projectInfo' in state)) {
+      json_get(
+        `${CONFIG.janus_host}/api/admin/${CONFIG.project_name}/info`
+      ).then(
+        ({project}) => setState({
+          ...state,
+          projectInfo: project
+        })
+      )
+    }
+  }, [] );
+
+
+  return (
+    <DashboardContext.Provider
+      value={ state }
+    >
+      {props.children}
+    </DashboardContext.Provider>
+  );
+};

--- a/timur/lib/client/jsx/timur_ui.jsx
+++ b/timur/lib/client/jsx/timur_ui.jsx
@@ -6,7 +6,6 @@ import {ThemeProvider} from '@material-ui/core/styles';
 
 // Components.
 import Manifests from './components/manifest/manifests';
-import Dashboard from './components/dashboard/dashboard';
 import Browser from './components/browser/browser';
 import Plotter from './components/plotter/plotter';
 import RootView from 'etna-js/components/RootView';
@@ -35,10 +34,10 @@ const ROUTES = [
     mode: 'home'
   },
   {
-    name: 'dashboard',
+    name: 'browse',
     template: ':project_name/',
-    component: Dashboard,
-    mode: 'dashboard'
+    component: Browser,
+    mode: 'browse'
   },
   {
     name: 'browse',

--- a/timur/lib/client/jsx/timur_ui.jsx
+++ b/timur/lib/client/jsx/timur_ui.jsx
@@ -24,6 +24,7 @@ import {Notifications} from 'etna-js/components/Notifications';
 import QueryPage from './components/query/query_page';
 
 import {createEtnaTheme} from 'etna-js/style/theme';
+import { MagmaProvider } from 'etna-js/contexts/magma-context';
 
 const theme = createEtnaTheme('goldenrod', '#066306');
 
@@ -158,7 +159,7 @@ class TimurUI extends React.Component {
     let key = JSON.stringify(params);
 
     return (
-      <React.Fragment>
+      <MagmaProvider>
         <ThemeProvider theme={theme}>
           <ModalDialogContainer>
             <div id='ui-container'>
@@ -171,7 +172,7 @@ class TimurUI extends React.Component {
             </div>
           </ModalDialogContainer>
         </ThemeProvider>
-      </React.Fragment>
+      </MagmaProvider>
     );
   }
 }

--- a/timur/lib/client/jsx/timur_ui.jsx
+++ b/timur/lib/client/jsx/timur_ui.jsx
@@ -6,6 +6,7 @@ import {ThemeProvider} from '@material-ui/core/styles';
 
 // Components.
 import Manifests from './components/manifest/manifests';
+import Dashboard from './components/dashboard/dashboard';
 import Browser from './components/browser/browser';
 import Plotter from './components/plotter/plotter';
 import RootView from 'etna-js/components/RootView';
@@ -34,9 +35,10 @@ const ROUTES = [
     mode: 'home'
   },
   {
+    name: 'dashboard',
     template: ':project_name/',
-    component: Browser,
-    mode: 'browse'
+    component: Dashboard,
+    mode: 'dashboard'
   },
   {
     name: 'browse',

--- a/vulcan/config.yml.template
+++ b/vulcan/config.yml.template
@@ -81,9 +81,20 @@ default: &default
   :vulcan:
     :host: https://vulcan.test
     :hmac_key: haggis
+  :janus:
+    :host: https://janus.test
+    :hmac_key: haggis
   :polyphemus:
     :host: https://polyphemus.test
     :hmac_key: haggis
+  :ssh:
+    :host: vulcan_c4_env
+    :username: root
+    :password: root
+    :use_ssh_config: false
+    :settings:
+      :verify_host_key: :never
+  :conda_env: conda-vulcan
   :data_folder: /app/spec/data
   :workflows_folder: /app/spec/fixtures
   :archimedes_run_image: etnaagent/archimedes

--- a/vulcan/docker-compose.yml
+++ b/vulcan/docker-compose.yml
@@ -150,7 +150,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: '172.16.238.0/24'
+        - subnet: '172.16.240.0/24'
         - subnet: '2001:3984:3989::/64'
 
 services:

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -91,15 +91,17 @@ class VulcanV2Controller < Vulcan::Controller
       rescue => e
         @remote_manager.rmdir(workspace_dir)
         Vulcan.instance.logger.log_error(e)
-        raise Etna::BadRequest.new(e.message)
+        raise Etna::ServerError.new(e.message)
       end
   end
 
   def list_workspaces
     success_json(
-      workspaces: Vulcan::Workspace.all.map do |w|
-        w.to_hash
-      end
+      workspaces: Vulcan::Workspace.where(
+        workflow_id: Vulcan::WorkflowV2.where(
+          project_name: @params[:project_name]
+        ).select(:id)
+      ).all.map(&:to_hash)
     )
   end
 

--- a/vulcan/spec/spec_helper.rb
+++ b/vulcan/spec/spec_helper.rb
@@ -34,7 +34,7 @@ end
 
 AUTH_USERS = {
   superuser: {
-    email: 'zeus@twelve-labors.org', name: 'Zeus', perm: 'a:administration'
+    email: 'zeus@twelve-labors.org', name: 'Zeus', perm: 'a:administration', exp: Time.now.to_i + 6000 , flags: 'vulcan'
   },
   admin: {
     email: 'hera@olympus.org', name: 'Hera', perm: 'a:labors', exp: Time.now.to_i + 6000, flags: 'vulcan'
@@ -98,6 +98,11 @@ RSpec.configure do |config|
 
 end
 
+FactoryBot.define do
+  factory :workflow, class: Vulcan::WorkflowV2 do
+    to_create(&:save)
+  end
+end
 def json_body
   JSON.parse(last_response.body, symbolize_names: true)
 end

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -9,29 +9,36 @@ describe VulcanV2Controller do
     OUTER_APP
   end
 
-  let(:remote_manager) {TestRemoteServerManager.new(Vulcan.instance.ssh_pool)}
-  let(:create_workflow_request) {{
-    project_name: PROJECT ,
-    repo_url: "/test-utils/available-workflows/snakemake-repo",
-    workflow_name: "test-workflow",
-  }}
+  let(:remote_manager) { TestRemoteServerManager.new(Vulcan.instance.ssh_pool) }
 
   before do
     stub_generate_token(PROJECT)
     remove_all_dirs
   end
 
-  def setup_workspace
+  def create_workflow(params={})
+    create(:workflow, {
+      project_name: PROJECT ,
+      repo_remote_url: "/test-utils/available-workflows/snakemake-repo",
+      name: "test-workflow",
+      created_at: Time.now,
+      updated_at: Time.now
+    }.merge(params))
+  end
+
+  def setup_workspace(workflow=nil, params={})
+    workflow = create_workflow unless workflow
+
+    project_name = params.delete(:project_name) || PROJECT
+
     auth_header(:superuser)
-    post("/api/v2/#{PROJECT}/workflows/create", create_workflow_request)
-    auth_header(:editor)
     request = {
-      workflow_id: json_body[:workflow_id],
+      workflow_id: workflow.id,
       workspace_name: "running-tiger",
       branch: "main",
       git_request: "v1"
-    }
-    post("/api/v2/#{PROJECT}/workspace/create", request)
+    }.merge(params)
+    post("/api/v2/#{project_name}/workspace/create", request)
     expect(last_response.status).to eq(200)
   end
 
@@ -41,6 +48,11 @@ describe VulcanV2Controller do
   end
 
   context 'create workflows' do
+    let(:create_workflow_request) {{
+      project_name: PROJECT ,
+      repo_url: "/test-utils/available-workflows/snakemake-repo",
+      workflow_name: "test-workflow",
+    }}
 
     it 'should fail auth if you are not a super user' do
       auth_header(:editor)
@@ -62,9 +74,9 @@ describe VulcanV2Controller do
     end
 
     it 'should inform the user if the workflow exists' do
+      create_workflow
+
       auth_header(:superuser)
-      post("/api/v2/#{PROJECT}/workflows/create", create_workflow_request)
-      expect(last_response.status).to eq(200)
       post("/api/v2/#{PROJECT}/workflows/create", create_workflow_request)
       expect(last_response.status).to eq(200)
       expect(json_body[:msg].include?('exists'))
@@ -75,9 +87,11 @@ describe VulcanV2Controller do
   context 'list workflows' do
 
     it 'list workflows available for a project' do
-      auth_header(:superuser)
-      post("/api/v2/#{PROJECT}/workflows/create", create_workflow_request)
-      get("/api/v2/#{PROJECT}/workflows/")
+      create_workflow
+
+      auth_header(:viewer)
+      get("/api/v2/#{PROJECT}/workflows")
+
       expect(last_response.status).to eq(200)
       expect(json_body[:workflows].count).to eq(1)
     end
@@ -85,84 +99,65 @@ describe VulcanV2Controller do
     it 'should return an empty list when no workflows exist' do
       auth_header(:editor)
       get("/api/v2/#{PROJECT}/workflows/")
+
       expect(last_response.status).to eq(200)
       expect(json_body[:workflows]).to be_empty
     end
-
   end
 
 
   context 'creates workspaces' do
+    let(:workflow) { create_workflow }
+    let(:workspace_request) {
+      {
+        workflow_id: workflow.id,
+        workspace_name: "running-tiger",
+        branch: "main",
+        git_request: "v1",
+      }
+    }
 
-    before do
-      auth_header(:superuser)
-      post("/api/v2/#{PROJECT}/workflows/create", create_workflow_request)
+    def post_workspace_create(params)
+      post("/api/v2/#{PROJECT}/workspace/create", params)
     end
 
     it 'successfully creates the workspace directory' do
       auth_header(:editor)
-      request = {
-        workflow_id: json_body[:workflow_id],
-        workspace_name: "running-tiger",
-        branch: "main",
-        git_request: "v1",
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(remote_manager.dir_exists?("#{obj.path}")).to be_truthy
+      post_workspace_create(workspace_request)
+
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(remote_manager.dir_exists?("#{workspace.path}")).to be_truthy
     end
 
     it 'successfully git clones the workflow' do
       auth_header(:editor)
-      request = {
-        workflow_id: json_body[:workflow_id],
-        workspace_name: "running-tiger",
-        branch: "main",
-        git_request: "v1",
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(remote_manager.dir_exists?("#{obj.path}/.git")).to be_truthy
+      post_workspace_create(workspace_request)
+
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(remote_manager.dir_exists?("#{workspace.path}/.git")).to be_truthy
     end
 
     it 'successfully creates a keep file in the output directory' do
       auth_header(:editor)
-      request = {
-        workflow_id: json_body[:workflow_id],
-        workspace_name: "running-tiger",
-        branch: "main",
-        git_request: "v1",
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(remote_manager.file_exists?("#{obj.path}/output/.keep")).to be_truthy
+      post_workspace_create(workspace_request)
+
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(remote_manager.file_exists?("#{workspace.path}/output/.keep")).to be_truthy
     end
 
     it 'successfully git checkouts the proper tag' do
       auth_header(:editor)
-      request = {
-        workflow_id: json_body[:workflow_id],
-        workspace_name: "running-tiger",
-        branch: "main",
-        git_request: "v1",
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(remote_manager.tag_exists?(obj.path, "v1")).to be_truthy
+      post_workspace_create(workspace_request)
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(remote_manager.tag_exists?(workspace.path, "v1")).to be_truthy
     end
 
     it 'successfully creates the dl_config.yaml file' do
       auth_header(:editor)
-      request = {
-        workflow_id: json_body[:workflow_id],
-        workspace_name: "running-tiger",
-        branch: "main",
-        git_request: "v1",
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(remote_manager.file_exists?("#{obj.path}/dl_config.yaml")).to be_truthy
-      expect(remote_manager.read_yaml_file("#{obj.path}/dl_config.yaml")).to eq({
+      post_workspace_create(workspace_request)
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(remote_manager.file_exists?("#{workspace.path}/dl_config.yaml")).to be_truthy
+      expect(remote_manager.read_yaml_file("#{workspace.path}/dl_config.yaml")).to eq({
         "project_name" => "#{PROJECT}",
         "token" => "stubbed_token",
         "magma_url" => "#{Vulcan.instance.config(:magma)[:host]}",
@@ -186,46 +181,46 @@ describe VulcanV2Controller do
 
     it 'successfully creates the workspace object' do
       auth_header(:editor)
-      request = {
-          workflow_id: json_body[:workflow_id],
-          workspace_name: "running-tiger",
-          branch: "main",
-          git_request: "v1"
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
+      post_workspace_create(workspace_request)
       expect(last_response.status).to eq(200)
-      # DB object exists
-      obj = Vulcan::Workspace.first(id: json_body[:workspace_id])
-      expect(obj).to_not be_nil
-      expect(obj.dag.to_a).to eq(["count", "arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
-      expect(File.basename(obj.path).match?(/\A[a-f0-9]{32}\z/)).to be_truthy
-      expect(obj.git_ref).to eq("v1")
-      expect(obj.git_sha).to_not eq(nil)
+      workspace = Vulcan::Workspace.first(id: json_body[:workspace_id])
+      expect(workspace).to_not be_nil
+      expect(workspace.dag.to_a).to eq(["count", "arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
+      expect(File.basename(workspace.path).match?(/\A[a-f0-9]{32}\z/)).to be_truthy
+      expect(workspace.git_ref).to eq("v1")
+      expect(workspace.git_sha).to_not eq(nil)
     end
 
     it 'successfully sends back vulcan_config and dag' do
       auth_header(:editor)
-      request = {
-          workflow_id: json_body[:workflow_id],
-          workspace_name: "running-tiger",
-          branch: "main",
-          git_request: "v1"
-      }
-      post("/api/v2/#{PROJECT}/workspace/create", request)
+      post_workspace_create(workspace_request)
       expect(last_response.status).to eq(200)
       expect(json_body[:vulcan_config]).to_not be_nil
       expect(json_body[:dag]).to_not be_nil
     end
-
   end
 
-  context 'list all workspaces' do
-
+  context 'list project workspaces' do
     it 'for a user if it exists' do
       setup_workspace
-      get("/api/v2/#{PROJECT}/workspace/")
+      auth_header(:editor)
+      get("/api/v2/#{PROJECT}/workspace")
       expect(last_response.status).to eq(200)
       expect(json_body[:workspaces].count).to eq(1)
+    end
+
+    it 'does not list other projects' do
+      setup_workspace
+
+      stub_generate_token('athena')
+      workflow2 = create_workflow(name: "other-workflow", project_name: "athena")
+      setup_workspace(workflow2, project_name: "athena", workspace_name: "walking-owl")
+
+      auth_header(:editor)
+      get("/api/v2/#{PROJECT}/workspace")
+      expect(last_response.status).to eq(200)
+      expect(json_body[:workspaces].length).to eq(1)
+      expect(json_body[:workspaces]).to all(include(:workspace_path => a_string_starting_with("/workspace/#{PROJECT}")))
     end
 
     it 'should return an empty list if no workspaces exist' do
@@ -233,9 +228,7 @@ describe VulcanV2Controller do
       get("/api/v2/#{PROJECT}/workspace/")
       expect(last_response.status).to eq(200)
       expect(json_body[:workspaces]).to be_empty
-
     end
-
   end
 
   context 'saving configs' do


### PR DESCRIPTION
This adds a tray to the Timur browser view which shows the Project Dashboard widget and a mini Map widget.
- The map supports navigation while browsing and creating queries (still unfinished).
- The dashboard implements a number of sensors which collect data from other library apps about the project.
- Each dashboard widget links to an action and a guide on its subject.
- The widgets (and individual items within each limit) are visible based on project role, with viewers seeing the least and admins the most.

Three of the guides remain unwritten; I will make a separate PR on mountetna/mountetna.github.io for those.

A few new APIs/changes to existing APIs were required, but not many.