### PR TITLE
Various small Vulcan front-end updates and delete_workspace hookup

### DIFF
--- a/vulcan/lib/client/jsx/components/dashboard/loading_icon.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/loading_icon.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import {makeStyles} from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const useStyles = makeStyles((theme) => ({
     loadingIcon: {
@@ -20,3 +22,14 @@ export default function LoadingIcon({}) {
         <AutorenewIcon className={classes.loadingIcon}/>
     )
 }
+
+export function LoadingIconWithText({text=''}: {text:string}) {
+    return <Grid container>
+        <Grid item>
+            <LoadingIcon/>
+        </Grid>
+        <Grid item>
+            <Typography>{text}</Typography>
+        </Grid>
+    </Grid>
+};

--- a/vulcan/lib/client/jsx/components/dashboard/loading_icon.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/loading_icon.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import {makeStyles} from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import Tooltip from '@material-ui/core/Tooltip';
 import Grid from '@material-ui/core/Grid';
+import Icon from 'etna-js/components/icon';
 
 const useStyles = makeStyles((theme) => ({
     loadingIcon: {
@@ -32,4 +34,23 @@ export function LoadingIconWithText({text=''}: {text:string}) {
             <Typography>{text}</Typography>
         </Grid>
     </Grid>
+};
+
+export function FlatLoadbleIcon({label, tooltip, loading=false, disabled=false}: {
+    label: string;
+    tooltip: string;
+    loading: boolean;
+    disabled; boolean;
+}) {
+    const classes = useStyles();
+    return <div title={tooltip}>
+        <Grid container>
+            <Grid item>
+                { label && <span className='flat-label'>{label}</span> }
+            </Grid>
+            <Grid item>
+                    { loading ? <Icon disabled={disabled} icon={'spinner fa-spin'} /> : <AutorenewIcon color={'disabled'}/> }
+            </Grid>
+        </Grid>
+    </div>
 };

--- a/vulcan/lib/client/jsx/components/dashboard/workspace_control/workspaces_grid.tsx
+++ b/vulcan/lib/client/jsx/components/dashboard/workspace_control/workspaces_grid.tsx
@@ -93,15 +93,7 @@ export default function WorkspacesGrid({
 
       showErrors(
         updateWorkspace(project_name, workspace.workspace_id, newTitle, undefined)
-        .then((updatedWorkspace) => {
-          const updated = accessibleWorkspaces.map((oldWorkspace) => {
-            if (oldWorkspace.workspace_id === updatedWorkspace.workspace_id) {
-              return updatedWorkspace;
-            }
-
-            return oldWorkspace;
-          });
-        })
+        .then((updatedWorkspace) => {dispatch(updateWorkflowsWorkspaces())})
       );
       dispatch(updateWorkflowsWorkspaces());
     },
@@ -112,11 +104,11 @@ export default function WorkspacesGrid({
     (workspace: WorkspaceMinimal) => {
       if (!workspace.workspace_id) return;
       const doDelete = confirm(
-        'This action will permanently delete this workspace its files, a non-reversible action.'
+        'This action will permanently delete this workspace and all of its files, a non-reversible action.'
       );
       if (!doDelete) return
-      showErrors(deleteWorkspace(project_name, workspace.workspace_id));
-      dispatch(updateWorkflowsWorkspaces());
+      showErrors(deleteWorkspace(project_name, workspace.workspace_id))
+      .then(() => {dispatch(updateWorkflowsWorkspaces())});
     },
     [dispatch, showErrors, deleteWorkspace, project_name, accessibleWorkspaces]
   );

--- a/vulcan/lib/client/jsx/components/workspace/drawers/param_user_inputs.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/drawers/param_user_inputs.tsx
@@ -28,6 +28,7 @@ import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import Accordion from '@material-ui/core/Accordion';
 import {makeStyles} from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const useStyles = makeStyles((theme) => ({
   card: {
@@ -167,26 +168,28 @@ export default function ParamInputs() {
 
   return (
     <Card className={classes.card}>
-      <Grid
-        className={classes.header}
-        container
-        alignItems='center'
-        justifyContent='space-between'
-        onClick={() => setOpen(!open)}
-      >
-        <Grid item>
-          <Typography variant='h6'>Analysis Setup</Typography>
+      <Tooltip title={`${open ? 'hide' : 'show'} output-independent parameters`}>
+        <Grid
+          className={classes.header}
+          container
+          alignItems='center'
+          justifyContent='space-between'
+          onClick={() => setOpen(!open)}
+        >
+          <Grid item>
+            <Typography variant='h6'>Analysis Setup</Typography>
+          </Grid>
+          <Grid item>
+            <IconButton size='small'>
+              {open ? (
+                <ExpandLessIcon fontSize='small' />
+              ) : (
+                <ExpandMoreIcon fontSize='small' />
+              )}
+            </IconButton>
+          </Grid>
         </Grid>
-        <Grid item>
-          <IconButton size='small'>
-            {open ? (
-              <ExpandLessIcon fontSize='small' />
-            ) : (
-              <ExpandMoreIcon fontSize='small' />
-            )}
-          </IconButton>
-        </Grid>
-      </Grid>
+      </Tooltip>
       <Collapse in={open}>
         {Object.keys(groupedInputs)
           .sort()

--- a/vulcan/lib/client/jsx/components/workspace/drawers/step_error.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/drawers/step_error.tsx
@@ -22,7 +22,7 @@ export default function StepError({step}: {step: WorkspaceStep}) {
 
   if (!stepStatus) return null;
 
-  let message = stepStatus.error || 'Something went wrong with this step.';
+  let message = stepStatus.error || 'Something went wrong with this step.  We haven\'t automated log retrieval yet, so reach out to Dan for help.';
 
   return (
     <Card

--- a/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
@@ -14,12 +14,6 @@ export default function Vignette({}) {
         state.status.file_contents['vignette.md']
       );
     }
-
-    if ('readme.md' in state.status.file_contents) {
-      setText(
-        state.status.file_contents['readme.md']
-      );
-    }
   }, [state.status.file_contents]);
 
   return (

--- a/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
@@ -3,22 +3,24 @@ import React, {useContext, useEffect, useState} from 'react';
 import markdown from 'etna-js/utils/markdown';
 
 import {VulcanContext} from '../../../contexts/vulcan_context';
-import {workflowByName} from '../../../selectors/workflow_selectors';
 
-export default function Vignette({workflowName}: {workflowName: string}) {
+export default function Vignette({}) {
   let {state} = useContext(VulcanContext);
-  const workflow = workflowByName(workflowName, state);
   const [text, setText] = useState('');
 
   useEffect(() => {
-    if (workflow) {
+    if ('vignette.md' in state.status.file_contents) {
       setText(
-        workflow.vignette
-          ? workflow.vignette
-          : 'No vignette provided.'
+        state.status.file_contents['vignette.md']
       );
     }
-  }, [workflow, setText]);
+
+    if ('readme.md' in state.status.file_contents) {
+      setText(
+        state.status.file_contents['readme.md']
+      );
+    }
+  }, [state.status.file_contents]);
 
   return (
     <div

--- a/vulcan/lib/client/jsx/components/workspace/input_feed.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/input_feed.tsx
@@ -16,7 +16,7 @@ import {
   stepOfName
 } from '../../selectors/workflow_selectors';
 import GroupedStepUI from './drawers/step_user_input';
-import LoadingIcon from '../dashboard/loading_icon';
+import { LoadingIconWithText } from '../dashboard/loading_icon';
 import { makeStyles } from '@material-ui/core/styles';
 
 export const useInputFeedStyles = makeStyles((theme) => ({
@@ -54,10 +54,7 @@ export default function InputFeed() {
 
   const stepInputs = useMemo(() => {
     return update_files ?
-      <div>
-        <LoadingIcon/>
-        Refreshing Files
-      </div> :
+      <LoadingIconWithText text='Refreshing Files'/>:
       groupedSteps.map((s, index) => (
         <GroupedStepUI key={index} group={s} />
       ));

--- a/vulcan/lib/client/jsx/components/workspace/output_feed.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/output_feed.tsx
@@ -5,7 +5,7 @@ import {VulcanContext} from '../../contexts/vulcan_context';
 import OutputUI from './drawers/output_user_input';
 import { outputUIsWithInputsReady } from '../../selectors/workflow_selectors';
 import {useWorkspace} from '../../contexts/workspace_context';
-import LoadingIcon from '../dashboard/loading_icon';
+import { LoadingIconWithText } from '../dashboard/loading_icon';
 
 export default function OutputFeed() {
   // Shows stream of Output, Plots, etc.,
@@ -16,10 +16,7 @@ export default function OutputFeed() {
 
   const outputFeed = useMemo(() => {
     return state.update_files ?
-      <div>
-        <LoadingIcon/>
-        Refreshing Files
-      </div> :
+      <LoadingIconWithText text='Refreshing Files'/> :
       outputUIsWithInputsReady(workspace, status.file_contents).map((s, index) => (
         <OutputUI key={index} step={s}/>
       ));

--- a/vulcan/lib/client/jsx/components/workspace/steps_list.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/steps_list.tsx
@@ -44,18 +44,7 @@ export default function StepsList() {
       <div className='steps-list-wrapper'>
         {workspace.dag.map(stepNamesToStepIconNames)}
       </div>
-      <Grid className='steps-list-subheader' container direction='row' justifyContent='space-between' alignItems='flex-end'>
-        <Grid item>Output</Grid>
-        <Grid item><FlatButton
-          className='header-btn-name-save'
-          icon={false? 'spinner fa-spin' : 'circle-notch'}
-          label='Refresh'
-          title={false? 'Coming Soon: Assess Output Validity' : 'Coming Soon: Assessing Output Validity'}
-          disabled={true}
-          onClick={() => {
-          }}
-        /></Grid>
-      </Grid>
+      <div className='steps-list-subheader'>Output</div>
       <div className='steps-list-wrapper'>
         {outputUINames(workspace).map(stepNamesToStepIconNames)}
       </div>

--- a/vulcan/lib/client/jsx/components/workspace/steps_list.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/steps_list.tsx
@@ -6,11 +6,13 @@ import {outputUINames, outputUIsWithInputsReady, stepOfName} from '../../selecto
 import {useWorkspace} from '../../contexts/workspace_context';
 import { VulcanConfig } from '../../api_types';
 import StepIconName from './drawers/step_elements/step_icon_name';
+import FlatButton from 'etna-js/components/flat-button'
+import Grid from '@material-ui/core/Grid';
 
 export default function StepsList() {
   const [open, setOpen] = useState(false);
   const {state} = useContext(VulcanContext);
-  const {status, workspace} = state;
+  const {status, workspace, refreshingProgress} = state;
 
   function handleToggle() {
     setOpen(!open);
@@ -42,10 +44,21 @@ export default function StepsList() {
       <div className='steps-list-wrapper'>
         {workspace.dag.map(stepNamesToStepIconNames)}
       </div>
-      <div className='steps-list-subheader'>Outputs</div>
+      <Grid className='steps-list-subheader' container direction='row' justifyContent='space-between' alignItems='flex-end'>
+        <Grid item>Output</Grid>
+        <Grid item><FlatButton
+          className='header-btn-name-save'
+          icon={false? 'spinner fa-spin' : 'circle-notch'}
+          label='Refresh'
+          title={false? 'Coming Soon: Assess Output Validity' : 'Coming Soon: Assessing Output Validity'}
+          disabled={true}
+          onClick={() => {
+          }}
+        /></Grid>
+      </Grid>
       <div className='steps-list-wrapper'>
         {outputUINames(workspace).map(stepNamesToStepIconNames)}
       </div>
     </div>
   );
-}
+};

--- a/vulcan/lib/client/jsx/components/workspace/ui_definitions/inputs/pieces/magma_pickers.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/ui_definitions/inputs/pieces/magma_pickers.tsx
@@ -40,12 +40,15 @@ export function SingleMagmaRecordSelectionPieceRct({
     const targets = !hasAttributes ? 
       arrayLevels(attributesDisplay.concat(targetAttribute)) :
       arrayLevels(attributesDisplay.concat(hasAttributes).concat(targetAttribute));
-    getDocuments({
-      project_name: projectName,
-      model_name: modelName,
-      record_names: 'all',
-      attribute_names: targets
-    }).then((recs) => {
+    getDocuments(
+      {
+        project_name: projectName,
+        model_name: modelName,
+        record_names: 'all',
+        attribute_names: targets
+      },
+      fetch
+    ).then((recs) => {
       const allRecs = recs.models[modelName].documents
       setAllRecords(recs.models[modelName].documents)
     }).catch((e) => showError(e));

--- a/vulcan/lib/client/jsx/components/workspace/workspace_initializer.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/workspace_initializer.tsx
@@ -22,6 +22,7 @@ import {
   defaultStepStatus,
 } from '../../api_types';
 import {runPromise, useAsyncCallback} from 'etna-js/utils/cancellable_helpers';
+import { LoadingIconWithText } from '../dashboard/loading_icon';
 
 export default function WorkspaceInitializer({
   workspaceId,
@@ -126,8 +127,10 @@ export default function WorkspaceInitializer({
     }
   }, [state.workspace, state.workflow.name]);
 
-  if (!state.workflow) {
-    return null;
+  if (!state.workspace) {
+    return (
+      <LoadingIconWithText text='Retrieving Workspace Context'/>
+    );
   }
 
   return (

--- a/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
@@ -407,7 +407,8 @@ export default function WorkspaceManager() {
             icon='book'
             className='header-btn vignette'
             label='Workflow'
-            title={'Coming Soon: Workspace Readme'}
+            title={'vignette.md' in state.status.file_contents ? 'Workflow Readme' : 'Workflow Readme Unavailable'}
+            disabled={!('vignette.md' in state.status.file_contents)}
             onClick={() => {setWorkspaceHelpIsOpen(true)}}
           />
           <ReactModal

--- a/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
@@ -44,6 +44,7 @@ import useUserHooks from '../../contexts/useUserHooks';
 import Tag from '../dashboard/tag';
 import Grid from '@material-ui/core/Grid';
 import { useDataSync, useRunSyncing } from './data_sync';
+import Vignette from './drawers/vignette';
 
 // import RevisionHistory from 'etna-js/components/revision-history';
 
@@ -100,6 +101,7 @@ export default function WorkspaceManager() {
 
   // const [modalIsOpen, setIsOpen] = useState(false);
   const [vulcanHelpIsOpen, setVulcanHelpIsOpen] = useState(false);
+  const [workspaceHelpIsOpen, setWorkspaceHelpIsOpen] = useState(false);
   const {workQueueable: committedStepPending, projectName, configId, isRunning} = state;
 
   const [localTags, setLocalTags] = useState<string[]>(workspace.tags || []);
@@ -147,7 +149,7 @@ export default function WorkspaceManager() {
     .then(runResponse => {
       dispatch(setRunning(runResponse.run_id));
     })
-  }, [workspaceId, configId])
+  }, [workspaceId, configId, isRunning, projectName])
   useEffect(() => {
     if (state.isRunning) {
       showErrors(requestRunPolling());

--- a/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
@@ -404,14 +404,32 @@ export default function WorkspaceManager() {
           <FlatButton
             icon='book'
             className='header-btn vignette'
+            label='Workflow'
+            title={'Coming Soon: Workspace Readme'}
+            onClick={() => {setWorkspaceHelpIsOpen(true)}}
+          />
+          <ReactModal
+            isOpen={workspaceHelpIsOpen}
+            onRequestClose={() => setWorkspaceHelpIsOpen(false)}
+            style={modalStyles}
+            contentLabel='Workspace Vignette'
+          >
+            <Vignette/>
+          </ReactModal>
+        </React.Fragment>
+        <React.Fragment>
+          <FlatButton
+            icon='book'
+            className='header-btn vignette'
             label='Vulcan'
+            title='Vulcan Interface Overview'
             onClick={() => setVulcanHelpIsOpen(true)}
           />
           <ReactModal
             isOpen={vulcanHelpIsOpen}
             onRequestClose={() => setVulcanHelpIsOpen(false)}
             style={modalStyles}
-            contentLabel='Vignette'
+            contentLabel='Vulcan Interface Overview'
           >
             <VulcanHelp/>
           </ReactModal>

--- a/vulcan/lib/client/jsx/contexts/api.ts
+++ b/vulcan/lib/client/jsx/contexts/api.ts
@@ -162,6 +162,9 @@ export function useApi(
 
   const showError = useCallback((e: any, dismissOld: boolean = false) => {
     if (dismissOld) invoke(dismissMessages());
+    if (!(e instanceof Array)) {
+      e = [`${e}`];
+    }
     console.error(e);
     invoke(showMessages(e));
   }, [invoke]);
@@ -234,7 +237,7 @@ export function useApi(
 
   const deleteWorkspace = useCallback(
     (projectName: string, workspaceId: number): Promise<Response> => {
-      return vulcanGet(vulcanPath(`/api/v2/${projectName}/workspace/${workspaceId}/delete`));
+      return vulcanDelete(vulcanPath(`/api/v2/${projectName}/workspace/${workspaceId}`));
   }, [vulcanGet, vulcanPath]);
 
   const getFileNames = useCallback(

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -19,6 +19,7 @@ class VulcanV2Controller < Vulcan::Controller
   def create_workflow
     workflow = Vulcan::WorkflowV2.first(
       repo_remote_url: @params[:repo_url],
+      project_name: @params[:project_name]
     )
     if workflow
       return success_json({'msg': "Workflow: #{workflow.name} for project: #{@params[:project_name]} already exists."})


### PR DESCRIPTION
Front-End Changes here:
- Front-end hookup for workspace_deletion endpoint - makes it available from the project dashboard
- Adds a loading icon while workspace context is getting retrieved for the first time. This takes 10+ sec, so seems important to make the user know something is happening!
  - Adjusts the loading icon code to include the label internally, so I also adjust all other uses of the icon in the PR to follow that
- Adds a tooltip on the "Analysis Setup" label at the top of the inputs feed explaining that clicking there shows or hides the "output-independent parameters"
- Some future feature signaling:
  - Adds a vignette button that looks for an `output/vignette.md` file.  (awaiting back-end hookup where the file would get copied from an original `resources/vignette.md` location in workflow repos.)

Back-End Changes here:
- Fixes workflow_creation to check for a matching workflow repo + project pair when throwing its 'this workflow already exists' error => so we can have the same workflow available on multiple projects