### PR TITLE
Use identifier 'id' to detect temp ids in redcap loader

### DIFF
--- a/polyphemus/lib/etls/redcap/lib/model.rb
+++ b/polyphemus/lib/etls/redcap/lib/model.rb
@@ -82,7 +82,7 @@ module Redcap
     end
 
     def identifier(*record_id, identifier_fields: nil)
-      unless @magma_template.identifier.present?
+      if !@magma_template.identifier.present? || @magma_template.identifier == 'id'
         return [
             "::temp", *record_id, rand(36**8).to_s(36)
         ].compact.join('-')

--- a/polyphemus/spec/fixtures/magma_test_models.json
+++ b/polyphemus/spec/fixtures/magma_test_models.json
@@ -221,6 +221,7 @@
       "documents": {},
       "template": {
         "parent": "model_two",
+        "identifier": "id",
         "attributes": {
           "height": {
             "name": "height",


### PR DESCRIPTION
Fixes a regression in Polyphemus redcap loader which assumed table models would have a blank template.identifier instead of 'id'. Still somewhat brittle, but hopefully repairs the loader.