### PR TITLE
Vulcan - Expose workflow vignettes

### DIFF
--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -63,7 +63,12 @@ class VulcanV2Controller < Vulcan::Controller
         git_sha = @remote_manager.checkout_version(workspace_dir, @escaped_params[:git_request])
         @remote_manager.mkdir(Vulcan::Path.workspace_tmp_dir(workspace_dir))
         @remote_manager.mkdir(Vulcan::Path.workspace_output_dir(workspace_dir))
-        @remote_manager.touch("#{Vulcan::Path.workspace_output_dir(workspace_dir)}/.keep")
+        if @remote_manager.file_exists?("#{Vulcan::Path.workspace_resources_dir(workspace_dir)}/vignette.md", false)
+          vignette = @remote_manager.read_file_to_memory("#{Vulcan::Path.workspace_resources_dir(workspace_dir)}/vignette.md")
+          @remote_manager.write_file("#{Vulcan::Path.workspace_output_dir(workspace_dir)}/vignette.md", vignette)
+        else
+          @remote_manager.touch("#{Vulcan::Path.workspace_output_dir(workspace_dir)}/.keep")
+        end
         # @remote_manager.upload_dir(Vulcan.instance.config(:snakemake_profile_dir), workspace_dir, true) # TODO: for now we are just using the default profile
         @remote_manager.write_file(
           Vulcan::Path.dl_config(workspace_dir), 


### PR DESCRIPTION
This PR enacts the back-end side of enabling workflows to host a vignette from their git repo.

Specifically, it adds a step of copying the `resources/vignette.md` file, if it exists, into the `output/` folder that the front-end can access via the #read_files api.  (This file location is already hooked up in front-end code to power a "Workflow"-helpdoc button in the screenshot.)
<img width="107" height="39" alt="image" src="https://github.com/user-attachments/assets/2b9dc5f5-3dd1-46b7-b70b-b831e7f04ba9" />