### PR TITLE
Support inactive flags for janus users

### DIFF
--- a/janus/db/migrations/016_change_flags_to_jsonb.rb
+++ b/janus/db/migrations/016_change_flags_to_jsonb.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table(:users) do
+      set_column_type :flags, :jsonb
+    end
+  end
+
+  down do
+    alter_table(:users) do
+      set_column_type :flags, :json
+    end
+  end
+end

--- a/janus/lib/janus.rb
+++ b/janus/lib/janus.rb
@@ -11,6 +11,7 @@ class Janus
 
     @db.extension :connection_validator
     @db.extension :pg_json
+    Sequel.extension :pg_array_ops
     @db.pool.connection_validation_timeout = -1
 
     require_relative 'models' if load_models

--- a/janus/lib/models/project.rb
+++ b/janus/lib/models/project.rb
@@ -18,4 +18,10 @@ class Project < Sequel::Model
       contact_email: contact_email
     }
   end
+
+  def active_permissions
+    permissions.filter do |perm|
+      !perm.user.has_flag?('inactive')
+    end
+  end
 end

--- a/janus/lib/models/user.rb
+++ b/janus/lib/models/user.rb
@@ -14,20 +14,20 @@ class User < Sequel::Model
     end
 
     # validate the nonce
-    return "invalid nonce #{nonce}" unless Janus::Nonce.valid_nonce?(nonce)
+    raise "Invalid nonce #{nonce}" unless Janus::Nonce.valid_nonce?(nonce)
 
     # validate the email
-    return "invalid email" if email =~ /[^[:print:]]/
+    raise "Invalid email" if email =~ /[^[:print:]]/
 
     # find the user
     user = User[email: email]
 
-    return "no user" unless user
+    raise "No user" unless user
 
     # check the user's signature
     txt_to_sign = signed_nonce.split('.')[0..1].join('.')
 
-    return "invalid signature" unless user.valid_signature?(txt_to_sign, signature)
+    raise "Invalid signature" unless user.valid_signature?(txt_to_sign, signature)
 
     return user
   end
@@ -39,9 +39,22 @@ class User < Sequel::Model
 
     user = User[email: payload[:email]]
 
-    return nil unless user and payload == user.jwt_payload
+    raise "Invalid user #{payload[:email]}" unless user
+    raise "Invalid token" unless payload == user.jwt_payload
 
     return user
+  end
+
+  def self.active
+    self.exclude(Sequel.lit("flags IS NOT NULL AND flags ? 'inactive'"))
+  end
+
+  def self.inactive
+    self.where(Sequel.lit("flags IS NOT NULL AND flags ? 'inactive'"))
+  end
+
+  def has_flag?(flag)
+    flags&.include?(flag)
   end
 
   def to_hash

--- a/janus/lib/server/controllers/admin_controller.rb
+++ b/janus/lib/server/controllers/admin_controller.rb
@@ -9,8 +9,16 @@ class AdminController < Janus::Controller
 
     raise Etna::BadRequest, "No such project #{@params[:project_name]}" unless @project
 
+    project_hash = @project.to_hash
+
+    unless @user.is_superviewer?
+      project_hash.update(
+        permissions: @project.active_permissions
+      )
+    end
+
     success_json(
-      project: @project.to_hash
+      project: project_hash
     )
   end
 

--- a/janus/lib/server/controllers/authorization_controller.rb
+++ b/janus/lib/server/controllers/authorization_controller.rb
@@ -83,9 +83,13 @@ class AuthorizationController < Janus::Controller
 
     token_type = @params[:token_type] || 'login'
 
-    user = @user ? User[email: @user.email] : signed_nonce ? User.from_signed_nonce(signed_nonce) : User.from_token(token)
+    begin
+      user = @user ? User[email: @user.email] : signed_nonce ? User.from_signed_nonce(signed_nonce) : User.from_token(token)
+    rescue Exception => e
+      raise Etna::Unauthorized, e.message
+    end
 
-    raise Etna::Unauthorized, user if user.is_a?(String)
+    raise Etna::Unauthorized if user.has_flag?('inactive')
 
     if token_type == 'task'
       raise Etna::BadRequest, "No project_name specified!" unless @params[:project_name]

--- a/janus/lib/server/controllers/stats_controller.rb
+++ b/janus/lib/server/controllers/stats_controller.rb
@@ -28,11 +28,13 @@ class StatsController < Janus::Controller
       }
     end
 
+    inactive_users = Set.new( User.inactive.select_map(:id) )
+
     permissions.each do |perm|
       project_name = perm.project.project_name
       proj = projects.find { |proj| proj[:project_name] == project_name }
 
-      proj[:user_count] += 1
+      proj[:user_count] += 1 unless inactive_users.include?(perm.user_id)
 
       if perm[:affiliation] == 'PI'
 
@@ -45,7 +47,7 @@ class StatsController < Janus::Controller
       end
     end
 
-    user_count = User.count
+    user_count = User.active.count
 
     success_json({projects: projects, user_count: user_count})
   end

--- a/janus/lib/server/controllers/user_controller.rb
+++ b/janus/lib/server/controllers/user_controller.rb
@@ -33,8 +33,6 @@ class UserController < Janus::Controller
 
     raise Etna::Forbidden, 'User not found' unless @janus_user
 
-    cannotCommunity = ! @janus_user.flags.nil? && @janus_user.flags.include?('external')
-
     projects = @janus_user.permissions.map do |perm|
       # Don't use proj.to_hash because we don't necessarily want to send back
       #   all the information.
@@ -47,7 +45,12 @@ class UserController < Janus::Controller
         requires_agreement: perm.project.requires_agreement,
         cc_text: perm.project.cc_text,
       }
-    end.concat( (cannotCommunity ? Project.where(resource: true, requires_agreement: false) : Project.where(resource: true)).all.map do |proj|
+    end.concat(
+      (
+        @janus_user.has_flag?('external') ? 
+          Project.where(resource: true, requires_agreement: false) :
+          Project.where(resource: true)
+      ).all.map do |proj|
       {
         project_name: proj.project_name,
         project_name_full: proj.project_name_full,

--- a/janus/spec/admin_spec.rb
+++ b/janus/spec/admin_spec.rb
@@ -54,6 +54,39 @@ describe AdminController do
       expect(last_response.status).to eq(200)
     end
 
+    context 'inactive users' do
+      it 'excludes inactive users' do
+        user = create(:user, name: 'Janus Bifrons', email: 'janus@two-faces.org')
+        user2 = create(:user, name: 'Lar Familiaris', email: 'lar@two-faces.org', flags: [ 'inactive' ])
+
+        door = create(:project, project_name: 'door', project_name_full: 'Door')
+        create(:permission, project: door, user: user, role: 'administrator')
+        create(:permission, project: door, user: user2, role: 'viewer')
+
+        auth_header(:janus)
+        get('/api/admin/door/info')
+
+        expect(last_response.status).to eq(200)
+        expect(json_body[:project][:permissions].length).to eq(1)
+        expect(json_body[:project][:permissions].first[:user_email]).to eq('janus@two-faces.org')
+      end
+
+      it 'shows inactive users to admins' do
+        user = create(:user, name: 'Janus Bifrons', email: 'janus@two-faces.org')
+        user2 = create(:user, name: 'Lar Familiaris', email: 'lar@two-faces.org', flags: [ 'inactive' ])
+
+        door = create(:project, project_name: 'door', project_name_full: 'Door')
+        create(:permission, project: door, user: user, role: 'administrator')
+        create(:permission, project: door, user: user2, role: 'viewer')
+
+        auth_header(:zeus)
+        get('/api/admin/door/info')
+
+        expect(last_response.status).to eq(200)
+        expect(json_body[:project][:permissions].length).to eq(2)
+      end
+    end
+
     it 'forbids the project data to viewers' do
       user = create(:user, name: 'Lar Familiaris', email: 'lar@two-faces.org')
 

--- a/janus/spec/stats_spec.rb
+++ b/janus/spec/stats_spec.rb
@@ -9,6 +9,7 @@ describe StatsController do
     it "returns stats for all projects if none specified" do
       user1 = create(:user, name: 'Janus Bifrons', email: 'janus@two-faces.org')
       user2 = create(:user, name: 'Vesta Bule', email: 'vesta@two-faces.org')
+      user3 = create(:user, name: 'Xenos Interloper', email: 'xenos@strangers.org', flags: ['inactive'])
 
       admin = create(:project, project_name: 'administration', project_name_full: 'Administration')
       gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway')
@@ -21,6 +22,9 @@ describe StatsController do
       create(:permission, project: tunnel, user: user2, role: 'viewer')
       create(:permission, project: mirror, user: user1, role: 'editor')
       create(:permission, project: gateway, user: user1, role: 'editor')
+
+      create(:permission, project: mirror, user: user3, role: 'editor')
+      create(:permission, project: gateway, user: user3, role: 'editor')
 
       header('Authorization', "Etna #{user1.create_token!}")
       get('/api/stats/projects')

--- a/janus/spec/token_spec.rb
+++ b/janus/spec/token_spec.rb
@@ -103,6 +103,21 @@ describe "Token Generation" do
     expect(last_response.status).to eq(401)
   end
 
+  it "rejects token generation with an inactive user" do
+    @user.flags = [ 'inactive' ]
+    @user.save
+
+    get('/api/tokens/nonce')
+
+    request = request_token(@rsa_key, last_response.body, @user.email)
+
+    header 'Authorization', "Signed-Nonce #{request}"
+    post('/api/tokens/generate')
+
+    # The request is rejected
+    expect(last_response.status).to eq(401)
+  end
+
   it "rejects token generation with an invalid signature" do
     # We get the valid nonce
     get('/api/tokens/nonce')


### PR DESCRIPTION
This PR adds support for inactivating users via a Janus flag 'inactive'. Users with this flag:
- cannot login
- cannot generate a token
- are excluded from the janus projects page for non-superusers (they still show for superusers)
- do not show up in Janus stats