### PR TITLE
Some ledger improvements

### DIFF
--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "json"
+require "csv"
 
 class Metis
   class Console < Etna::Command
@@ -876,6 +877,55 @@ class Metis
       else
         "#{(bytes / 1024.0 / 1024.0 / 1024.0).round(2)} GB"
       end
+    end
+  end
+
+  class ChangeDatablockDescription < Etna::Command
+    usage "Usage: bin/metis change_datablock_description <md5_csv_path> --description <description>
+           # Update datablock descriptions for MD5 hashes listed in a CSV file"
+
+    string_flags << "--description"
+
+    def execute(csv_path, description: nil)
+      if csv_path.nil? || csv_path.strip.empty?
+        puts "Error: csv file path is required."
+        return
+      end
+
+      if description.nil? || description.strip.empty?
+        puts "Error: --description is required."
+        return
+      end
+
+      unless ::File.exist?(csv_path)
+        puts "Error: csv file not found at #{csv_path}."
+        return
+      end
+
+      normalized_md5_hashes = CSV.read(csv_path).flatten
+        .map { |value| value.to_s.strip }
+        .reject(&:empty?)
+        .uniq
+
+      if normalized_md5_hashes.empty?
+        puts "Found 0 unique md5 hashes."
+        puts "Updated 0 data blocks."
+        return
+      end
+
+      puts "Found #{normalized_md5_hashes.length} unique md5 hash#{'es' if normalized_md5_hashes.length != 1}."
+
+      changed_count = Metis::DataBlock
+        .where(md5_hash: normalized_md5_hashes)
+        .exclude(description: description)
+        .update(description: description, updated_at: DateTime.now)
+
+      puts "Updated #{changed_count} data block#{'s' if changed_count != 1}."
+    end
+
+    def setup(config)
+      super
+      Metis.instance.load_models
     end
   end
 end

--- a/metis/lib/commands.rb
+++ b/metis/lib/commands.rb
@@ -1,3 +1,6 @@
+require "fileutils"
+require "json"
+
 class Metis
   class Console < Etna::Command
     usage "Open a console with a connected magma instance."
@@ -529,23 +532,26 @@ class Metis
   end
 
   class LedgerStats < Etna::Command
-    usage "Usage: bin/metis ledger_stats [--project_name <project_name>] [--backfilled]
+    usage "Usage: bin/metis ledger_stats [--project_name <project_name>] [--backfilled] [--dump]
            # Query ledger statistics and vacuum candidates
            # --project_name: Query stats for a specific project (tracked mode)
-           # --backfilled: Query stats for backfilled datablocks"
+           # --backfilled: Query stats for backfilled datablocks
+           # --dump: Write backfilled full_metadata records to disk as JSON"
 
     string_flags << "--project_name"
     boolean_flags << "--backfilled"
+    boolean_flags << "--dump"
 
-    def execute(project_name: nil, backfilled: false)
+    def execute(project_name: nil, backfilled: false, dump: false)
       if !project_name && !backfilled
         puts "Error: Must specify either --project_name or --backfilled"
         puts ""
-        puts "Usage: bin/metis ledger_stats [--project_name <project_name>] [--backfilled]"
+        puts "Usage: bin/metis ledger_stats [--project_name <project_name>] [--backfilled] [--dump]"
         puts ""
         puts "Examples:"
         puts "  bin/metis ledger_stats --project_name athena"
         puts "  bin/metis ledger_stats --backfilled"
+        puts "  bin/metis ledger_stats --backfilled --dump"
         return
       end
 
@@ -606,29 +612,59 @@ class Metis
         end
       end
 
+      if vacuum[:date_distribution] && !vacuum[:date_distribution].empty?
+        puts ""
+        puts "  Date distribution (datablocks by date):"
+        vacuum[:date_distribution].sort.each do |date, count|
+          puts "    #{date.to_s.ljust(25)} #{count}"
+        end
+      end
+
+      if vacuum[:size_distribution] && !vacuum[:size_distribution].empty?
+        puts ""
+        puts "  Size distribution (datablock count):"
+        vacuum[:size_distribution].each do |bucket, count|
+          puts "    #{bucket.to_s.ljust(25)} #{count}"
+        end
+      end
+
+      if vacuum[:extension_distribution] && !vacuum[:extension_distribution].empty?
+        puts ""
+        puts "  Extension distribution (datablock count):"
+        vacuum[:extension_distribution].sort_by { |type, _| type.to_s }.each do |type, count|
+          puts "    #{type.to_s.ljust(25)} #{count}"
+        end
+      end
+
       puts ""
 
-      if vacuum[:details] && !vacuum[:details].empty?
-        puts "VACUUM DETAILS (first 10 datablocks):"
+      if dump
+        dump_path = dump_full_metadata(data: data, backfilled: backfilled)
+        puts "full_metadata dump written to: #{dump_path}" if dump_path
+      end
+
+      records = vacuum[:full_metadata]
+      if records && !records.empty?
+        puts "VACUUM DATABLOCKS (first 10):"
         puts "-" * 70
-        vacuum[:details].first(10).each do |detail|
-          puts "  MD5: #{detail[:md5_hash]}"
-          puts "  Size: #{format_size(detail[:size])}"
-          puts "  Datablock ID: #{detail[:data_block_id]}"
-          if detail[:description]
-            puts "  Description: #{detail[:description]}"
+        records.first(10).each do |record|
+          puts "  MD5: #{record[:md5_hash]}"
+          puts "  Size: #{format_size(record[:size])}"
+          puts "  Datablock ID: #{record[:data_block_id]}"
+          if record[:description]
+            puts "  Description: #{record[:description]}"
           end
-          if detail[:files] && !detail[:files].empty?
+          if record[:files] && !record[:files].empty?
             puts "  Files:"
-            detail[:files].first(3).each do |file|
+            record[:files].first(3).each do |file|
               puts "    - #{file[:bucket_name]}/#{file[:file_path]}" if file[:file_path]
             end
           end
           puts ""
         end
 
-        if vacuum[:details].length > 10
-          puts "  ... and #{vacuum[:details].length - 10} more datablocks"
+        if records.length > 10
+          puts "  ... and #{records.length - 10} more datablocks"
           puts ""
         end
       end
@@ -664,6 +700,38 @@ class Metis
     end
 
     private
+
+    def dump_full_metadata(data:, backfilled:)
+      unless backfilled
+        puts "Skipping --dump: full_metadata dump is currently available only with --backfilled."
+        return nil
+      end
+
+      full_metadata = data.dig(:vacuum, :full_metadata)
+      if full_metadata.nil? || full_metadata.empty?
+        puts "No full_metadata records available to dump."
+        return nil
+      end
+
+      dump_dir = ::File.join("tmp", "ledger_stats_dumps")
+      FileUtils.mkdir_p(dump_dir)
+
+      timestamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+      output_path = ::File.join(dump_dir, "ledger_full_metadata_backfilled_#{timestamp}.json")
+
+      ::File.write(
+        output_path,
+        JSON.pretty_generate(
+          {
+            project_name: data[:project_name],
+            generated_at: Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            full_metadata: full_metadata
+          }
+        )
+      )
+
+      output_path
+    end
 
     def format_size(bytes)
       return "0 bytes" if bytes.nil? || bytes == 0

--- a/metis/lib/models/data_block_ledger.rb
+++ b/metis/lib/models/data_block_ledger.rb
@@ -108,31 +108,31 @@ class Metis
     def self.orphaned_datablock_ids_for_project(project_name)
       linked_datablock_ids = where(project_name: project_name)
         .where(event_type: [LINK_FILE_TO_DATABLOCK, REUSE_DATABLOCK, RESTORE_DATABLOCK])
+        .distinct(:data_block_id)
         .select_map(:data_block_id)
-        .uniq
 
       unlinked_datablock_ids = where(
         project_name: project_name,
         event_type: UNLINK_FILE_FROM_DATABLOCK
-      ).select_map(:data_block_id)
-        .uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       live_datablock_ids = Metis::File
         .where(project_name: project_name)
+        .distinct(:data_block_id)
         .select_map(:data_block_id)
-        .uniq
 
       vacuumed_datablock_ids = where(
         project_name: project_name,
         event_type: REMOVE_DATABLOCK
-      ).select_map(:data_block_id)
-        .uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       restored_datablock_ids = where(
         project_name: project_name,
         event_type: RESTORE_DATABLOCK
-      ).select_map(:data_block_id)
-        .uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       # A block that was vacuumed but later restored is eligible again
       already_removed_ids = vacuumed_datablock_ids - restored_datablock_ids
@@ -141,8 +141,8 @@ class Metis
 
       used_by_other_projects = Metis::File
         .exclude(project_name: project_name)
+        .distinct(:data_block_id)
         .select_map(:data_block_id)
-        .uniq
 
       [orphaned_by_project, used_by_other_projects]
     end
@@ -154,7 +154,9 @@ class Metis
 
     def self.find_orphaned_datablocks_backfilled_for_vacuum
       candidate_ids = backfilled_orphan_candidate_ids
-      live_datablock_ids = Metis::File.select_map(:data_block_id).uniq
+      live_datablock_ids = Metis::File
+        .distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       # Block if any project has a live file — vacuum is only safe when no one points to the datablock
       Metis::DataBlock.exclude_removed_and_temp_blocks(candidate_ids - live_datablock_ids)
@@ -164,15 +166,18 @@ class Metis
       backfilled_datablock_ids = where(
         triggered_by: SYSTEM_BACKFILL,
         event_type: UNLINK_FILE_FROM_DATABLOCK
-      ).select_map(:data_block_id).uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       vacuumed_datablock_ids = where(
         event_type: REMOVE_DATABLOCK
-      ).select_map(:data_block_id).uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       restored_datablock_ids = where(
         event_type: RESTORE_DATABLOCK
-      ).select_map(:data_block_id).uniq
+      ).distinct(:data_block_id)
+        .select_map(:data_block_id)
 
       # A block that was vacuumed but later restored is eligible again
       already_removed_ids = vacuumed_datablock_ids - restored_datablock_ids

--- a/metis/lib/services/ledger_stats_service.rb
+++ b/metis/lib/services/ledger_stats_service.rb
@@ -1,5 +1,13 @@
 class Metis
   class LedgerStatsService
+    SIZE_DISTRIBUTION_BUCKETS = [
+      { label: "0B-1MB", max: 1 * 1024 * 1024 },
+      { label: "1MB-10MB", max: 10 * 1024 * 1024 },
+      { label: "10MB-100MB", max: 100 * 1024 * 1024 },
+      { label: "100MB-1GB", max: 1 * 1024 * 1024 * 1024 },
+      { label: "1GB+", max: nil }
+    ].freeze
+
     def initialize(project_name: nil, backfilled: false)
       @project_name = project_name
       @backfilled = backfilled
@@ -25,6 +33,7 @@ class Metis
       ready_ids = ready_datablocks.map(&:id).to_set
       blocked_datablocks = stats_datablocks.reject { |db| ready_ids.include?(db.id) }
       blocked_by_project = backfilled_blocked_by_project(blocked_datablocks)
+      full_metadata = build_backfilled_metadata(stats_datablocks)
 
       vacuum_stats = {
         datablocks_ready: ready_datablocks.length,
@@ -32,7 +41,10 @@ class Metis
         datablocks_blocked: blocked_datablocks.length,
         space_blocked: blocked_datablocks.sum(&:size),
         blocked_by_project: blocked_by_project,
-        details: Metis::DataBlockLedger.build_vacuum_details(stats_datablocks)
+        full_metadata: full_metadata,
+        date_distribution: build_date_distribution(full_metadata),
+        size_distribution: build_size_distribution(full_metadata),
+        extension_distribution: build_extension_distribution(full_metadata)
       }
 
       {
@@ -56,7 +68,7 @@ class Metis
         datablocks_blocked: blocked_datablocks.length,
         space_blocked: blocked_datablocks.sum(&:size),
         blocked_by_project: build_blocked_by_project_summary(blocked_datablocks, blocked_by),
-        details: Metis::DataBlockLedger.build_vacuum_details(ready_datablocks, @project_name)
+        full_metadata: Metis::DataBlockLedger.build_vacuum_details(ready_datablocks, @project_name)
       }
 
       {
@@ -75,6 +87,95 @@ class Metis
         summary[file.project_name] += 1
       end
       summary
+    end
+
+    def build_backfilled_metadata(datablocks)
+      datablock_ids = datablocks.map(&:id)
+      return [] if datablock_ids.empty?
+
+      events_by_id = Metis::DataBlockLedger
+        .where(data_block_id: datablock_ids)
+        .all
+        .group_by(&:data_block_id)
+
+      datablocks.map do |datablock|
+        files = build_files_from_events(events_by_id[datablock.id] || [])
+
+        {
+          data_block_id: datablock.id,
+          md5_hash: datablock.md5_hash,
+          size: datablock.size,
+          created_at: datablock.created_at&.iso8601,
+          description: datablock.description,
+          files: files,
+          file_types: extract_extensions(files: files, description: datablock.description)
+        }
+      end
+    end
+
+    def build_files_from_events(events)
+      events.map do |event|
+        next if event.file_path.nil? && event.bucket_name.nil?
+
+        {
+          file_path: event.file_path,
+          bucket_name: event.bucket_name
+        }
+      end.compact.uniq
+    end
+
+    def build_date_distribution(full_metadata)
+      full_metadata.each_with_object(Hash.new(0)) do |record, distribution|
+        key = record[:created_at]&.split("T")&.first || "unknown"
+        distribution[key] += 1
+      end
+    end
+
+    def build_size_distribution(full_metadata)
+      distribution = SIZE_DISTRIBUTION_BUCKETS.each_with_object({}) { |bucket, h| h[bucket[:label]] = 0 }
+
+      full_metadata.each do |record|
+        size = record[:size].to_i
+        bucket = SIZE_DISTRIBUTION_BUCKETS.find { |b| b[:max].nil? || size < b[:max] }
+        distribution[bucket[:label]] += 1
+      end
+
+      distribution
+    end
+
+    def build_extension_distribution(full_metadata)
+      full_metadata.each_with_object(Hash.new(0)) do |record, distribution|
+        extensions = record[:file_types] || []
+        if extensions.empty?
+          distribution["unknown"] += 1
+        else
+          extensions.each { |ext| distribution[ext] += 1 }
+        end
+      end
+    end
+
+    def extract_extensions(files:, description:)
+      extensions = []
+
+      files.each do |file|
+        ext = normalize_extension(file[:file_path])
+        extensions << ext if ext
+      end
+
+      if extensions.empty?
+        described_file = description&.match(/Originally for (.+)\z/)&.captures&.first
+        ext = normalize_extension(described_file)
+        extensions << ext if ext
+      end
+
+      extensions.uniq
+    end
+
+    def normalize_extension(file_name)
+      return nil if file_name.nil? || file_name.empty?
+
+      ext = ::File.extname(file_name).downcase.delete_prefix(".")
+      ext.empty? ? "no_extension" : ext
     end
 
     # Summarizes blocked_by as { project_name => count_of_datablocks_it_blocks }

--- a/metis/spec/metis_commands_spec.rb
+++ b/metis/spec/metis_commands_spec.rb
@@ -91,6 +91,35 @@ describe 'Metis Commands' do
       end
     end
   end
+
+  describe Metis::ChangeDatablockDescription do
+    let(:description) { "Updated by command" }
+    let(:csv) { Tempfile.new(["md5s", ".csv"]) }
+
+    let!(:db1) { create(:data_block, md5_hash: "md5_one", description: "To Update", size: 10) }
+    let!(:db2) { create(:data_block, md5_hash: "md5_two", description: "To Update", size: 20) }
+    let!(:db3) { create(:data_block, md5_hash: "md5_three", description: "To Update", size: 30) }
+
+    before do
+      csv.write("md5_one\nmd5_two\nmd5_three\nmd5_one\n")
+      csv.rewind
+    end
+
+    after do
+      csv.close
+      csv.unlink
+    end
+
+    it "updates datablock descriptions from csv md5s" do
+      expect {
+        described_class.new.execute(csv.path, description: description)
+      }.to output("Found 3 unique md5 hashes.\nUpdated 3 data blocks.\n").to_stdout
+
+      expect(db1.refresh.description).to eq("Updated by command")
+      expect(db2.refresh.description).to eq("Updated by command")
+      expect(db3.refresh.description).to eq("Updated by command")
+    end
+  end
 end
 
 describe Metis::BackfillDataBlockLedger do

--- a/metis/spec/stats_spec.rb
+++ b/metis/spec/stats_spec.rb
@@ -34,22 +34,29 @@ describe StatsController do
       expect(response[:vacuum][:datablocks_ready]).to be >= 2
       expect(response[:vacuum][:space_ready]).to be >= (WISDOM.bytesize + HELMET.bytesize)
       expect(response[:vacuum][:datablocks_blocked]).to eq(0)
-      expect(response[:vacuum][:details].length).to eq(2)
+      full_metadata = response[:vacuum][:full_metadata]
+      expect(full_metadata.length).to eq(2)
+      expect(response[:vacuum][:date_distribution].values.sum).to eq(2)
+      size_distribution = response[:vacuum][:size_distribution].transform_keys(&:to_s)
+      extension_distribution = response[:vacuum][:extension_distribution].transform_keys(&:to_s)
+      expect(size_distribution["0B-1MB"]).to eq(2)
+      expect(extension_distribution["txt"]).to eq(1)
+      expect(extension_distribution["jpg"]).to eq(1)
       
-      # Verify the two datablock details
-      wisdom_detail = response[:vacuum][:details].find { |d| d[:data_block_id] == wisdom_datablock.id }
-      expect(wisdom_detail).not_to be_nil
-      expect(wisdom_detail[:md5_hash]).to eq(wisdom_datablock.md5_hash)
-      expect(wisdom_detail[:size]).to eq(WISDOM.bytesize)
-      expect(wisdom_detail[:description]).to eq("Originally for wisdom.txt")
-      expect(wisdom_detail[:files]).to eq([])
+      # Verify the two datablock metadata records
+      wisdom_record = full_metadata.find { |d| d[:data_block_id] == wisdom_datablock.id }
+      expect(wisdom_record).not_to be_nil
+      expect(wisdom_record[:md5_hash]).to eq(wisdom_datablock.md5_hash)
+      expect(wisdom_record[:size]).to eq(WISDOM.bytesize)
+      expect(wisdom_record[:description]).to eq("Originally for wisdom.txt")
+      expect(wisdom_record[:files]).to eq([])
       
-      helmet_detail = response[:vacuum][:details].find { |d| d[:data_block_id] == helmet_datablock.id }
-      expect(helmet_detail).not_to be_nil
-      expect(helmet_detail[:md5_hash]).to eq(helmet_datablock.md5_hash)
-      expect(helmet_detail[:size]).to eq(HELMET.bytesize)
-      expect(helmet_detail[:description]).to eq("Originally for helmet.jpg")
-      expect(helmet_detail[:files]).to eq([])
+      helmet_record = full_metadata.find { |d| d[:data_block_id] == helmet_datablock.id }
+      expect(helmet_record).not_to be_nil
+      expect(helmet_record[:md5_hash]).to eq(helmet_datablock.md5_hash)
+      expect(helmet_record[:size]).to eq(HELMET.bytesize)
+      expect(helmet_record[:description]).to eq("Originally for helmet.jpg")
+      expect(helmet_record[:files]).to eq([])
     end
 
     it "returns details for multiple projects" do
@@ -76,15 +83,21 @@ describe StatsController do
       expect(response[:vacuum][:datablocks_ready]).to eq(1)
       expect(response[:vacuum][:space_ready]).to eq(WISDOM.bytesize)
       expect(response[:vacuum][:datablocks_blocked]).to eq(0)
-      expect(response[:vacuum][:details].length).to eq(1)
+      full_metadata = response[:vacuum][:full_metadata]
+      expect(full_metadata.length).to eq(1)
+      expect(response[:vacuum][:date_distribution].values.sum).to eq(1)
+      size_distribution = response[:vacuum][:size_distribution].transform_keys(&:to_s)
+      extension_distribution = response[:vacuum][:extension_distribution].transform_keys(&:to_s)
+      expect(size_distribution["0B-1MB"]).to eq(1)
+      expect(extension_distribution["txt"]).to eq(1)
       
-      # Verify the wisdom datablock detail (shared across projects, now orphaned)
-      wisdom_detail = response[:vacuum][:details].find { |d| d[:data_block_id] == wisdom_datablock.id }
-      expect(wisdom_detail).not_to be_nil
-      expect(wisdom_detail[:md5_hash]).to eq(wisdom_datablock.md5_hash)
-      expect(wisdom_detail[:size]).to eq(WISDOM.bytesize)
-      expect(wisdom_detail[:description]).to eq("Originally for wisdom.txt")
-      expect(wisdom_detail[:files]).to eq([]) # no files are associated with the datablock
+      # Verify the wisdom datablock metadata (shared across projects, now orphaned)
+      wisdom_record = full_metadata.find { |d| d[:data_block_id] == wisdom_datablock.id }
+      expect(wisdom_record).not_to be_nil
+      expect(wisdom_record[:md5_hash]).to eq(wisdom_datablock.md5_hash)
+      expect(wisdom_record[:size]).to eq(WISDOM.bytesize)
+      expect(wisdom_record[:description]).to eq("Originally for wisdom.txt")
+      expect(wisdom_record[:files]).to eq([]) # no files are associated with the datablock
     end
 
 
@@ -155,8 +168,8 @@ describe StatsController do
       # No include_projects in the response
       expect(response[:vacuum]).not_to have_key(:include_projects)
 
-      response[:vacuum][:details].each do |detail|
-        expect(detail).not_to have_key(:project_name)
+      response[:vacuum][:full_metadata].each do |record|
+        expect(record).not_to have_key(:project_name)
       end
     end
   end
@@ -227,18 +240,25 @@ describe StatsController do
       expect(backfilled_response[:vacuum][:datablocks_ready]).to eq(2)
       expect(backfilled_response[:vacuum][:space_ready]).to eq(WISDOM.bytesize + HELMET.bytesize)
       expect(backfilled_response[:vacuum][:datablocks_blocked]).to eq(0)
+      full_metadata = backfilled_response[:vacuum][:full_metadata]
+      expect(full_metadata.length).to eq(2)
+      expect(backfilled_response[:vacuum][:date_distribution].values.sum).to eq(2)
+      size_distribution = backfilled_response[:vacuum][:size_distribution].transform_keys(&:to_s)
+      extension_distribution = backfilled_response[:vacuum][:extension_distribution].transform_keys(&:to_s)
+      expect(size_distribution["0B-1MB"]).to eq(2)
+      expect(extension_distribution["txt"]).to eq(1)
+      expect(extension_distribution["jpg"]).to eq(1)
       
-      # Verify vacuum details for backfilled datablocks
-      expect(backfilled_response[:vacuum][:details].length).to eq(2)
+      # Verify backfilled full metadata records
       # Verify wisdom datablock has the tracked file associated with it (since tracked_file_1 reused it)
-      wisdom_detail = backfilled_response[:vacuum][:details].find { |d| d[:data_block_id] == backfilled_wisdom_datablock_id }
-      expect(wisdom_detail).not_to be_nil
-      expect(wisdom_detail[:files]).to eq([{file_path: "tracked_file_1.txt", bucket_name: "files"}])
+      wisdom_record = backfilled_response[:vacuum][:full_metadata].find { |d| d[:data_block_id] == backfilled_wisdom_datablock_id }
+      expect(wisdom_record).not_to be_nil
+      expect(wisdom_record[:files]).to eq([{file_path: "tracked_file_1.txt", bucket_name: "files"}])
       
       # Verify helmet datablock has an empty files array (no files are using it)
-      helmet_detail = backfilled_response[:vacuum][:details].find { |d| d[:data_block_id] == backfilled_helmet_datablock_id }
-      expect(helmet_detail).not_to be_nil
-      expect(helmet_detail[:files]).to eq([])
+      helmet_record = backfilled_response[:vacuum][:full_metadata].find { |d| d[:data_block_id] == backfilled_helmet_datablock_id }
+      expect(helmet_record).not_to be_nil
+      expect(helmet_record[:files]).to eq([])
       
       # Query tracked stats for athena - should ONLY show tracked events for athena
       get('/api/stats/ledger', project_name: 'athena')
@@ -256,13 +276,13 @@ describe StatsController do
       expect(tracked_response[:event_counts][:unlink_file_from_datablock]).to eq(1) # tracked_file_1 deleted
       expect(tracked_response[:event_counts][:remove_datablock]).to eq(0)
 
-      # Verify tracked vacuum details
-      expect(tracked_response[:vacuum][:details].length).to eq(1)
+      # Verify tracked vacuum metadata
+      expect(tracked_response[:vacuum][:full_metadata].length).to eq(1)
       
       # Verify wisdom datablock shows tracked_file_1.txt as orphaned
-      tracked_wisdom_detail = tracked_response[:vacuum][:details].find { |d| d[:data_block_id] == backfilled_wisdom_datablock_id }
-      expect(tracked_wisdom_detail).not_to be_nil
-      expect(tracked_wisdom_detail[:files]).to eq([{file_path: "tracked_file_1.txt", bucket_name: "files"}])
+      tracked_wisdom_record = tracked_response[:vacuum][:full_metadata].find { |d| d[:data_block_id] == backfilled_wisdom_datablock_id }
+      expect(tracked_wisdom_record).not_to be_nil
+      expect(tracked_wisdom_record[:files]).to eq([{file_path: "tracked_file_1.txt", bucket_name: "files"}])
       
     end
 


### PR DESCRIPTION
- [x] More efficient queries
- [x] More details of records that are going to be backfilled. 


Specifically: we now create a in-memory source of truth metadata object for all the records that are going to be backfilled - and then can compute distributions on top of them. There is also now the option to dump the metadata file. 

BONUS:

- [x] Command to update datablock description
