### PR TITLE
vulcan - expose workspace vignettes via the 'get_workspace' endpoint

### DIFF
--- a/vulcan/lib/client/jsx/api_types.ts
+++ b/vulcan/lib/client/jsx/api_types.ts
@@ -137,6 +137,7 @@ interface WorkspaceMinusInconsistent {
   last_job_status: {[k: string]: StatusStringFine} | null;
   last_run_id: number | null;
   tags: string[] | null;
+  vignette?: string
 }
 export interface WorkspaceRaw extends WorkspaceMinusInconsistent {
   vulcan_config: VulcanConfigElement[];
@@ -145,7 +146,6 @@ export interface WorkspaceRaw extends WorkspaceMinusInconsistent {
 export interface Workspace extends WorkspaceMinusInconsistent {
   vulcan_config: VulcanConfig;
   // project?: string;
-  vignette?: string;
   thumbnails?: string[];
 }
 

--- a/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/drawers/vignette.tsx
@@ -9,12 +9,12 @@ export default function Vignette({}) {
   const [text, setText] = useState('');
 
   useEffect(() => {
-    if ('vignette.md' in state.status.file_contents) {
+    if (!!state.workspace && !!state.workspace.vignette) {
       setText(
-        state.status.file_contents['vignette.md']
+        state.workspace.vignette
       );
     }
-  }, [state.status.file_contents]);
+  }, [state.workspace]);
 
   return (
     <div

--- a/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
+++ b/vulcan/lib/client/jsx/components/workspace/workspace_manager.tsx
@@ -409,8 +409,8 @@ export default function WorkspaceManager() {
             icon='book'
             className='header-btn vignette'
             label='Workflow'
-            title={'vignette.md' in state.status.file_contents ? 'Workflow Readme' : 'Workflow Readme Unavailable'}
-            disabled={!('vignette.md' in state.status.file_contents)}
+            title={!!state.workspace?.vignette ? 'Workflow Readme' : 'Workflow Readme Unavailable'}
+            disabled={!state.workspace?.vignette}
             onClick={() => {setWorkspaceHelpIsOpen(true)}}
           />
           <ReactModal

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -148,6 +148,11 @@ class VulcanV2Controller < Vulcan::Controller
       last_run_id: last_run ? last_run.id : nil,
       last_job_status: last_run ? slurm_status : nil
     })
+    # Fetch vignette
+    vignette_path = "#{workspace.path}/resources/vignette.md"
+    if @remote_manager.file_exists?(vignette_path)
+      response[:vignette] = @remote_manager.read_file_to_memory(vignette_path)
+    end
     success_json(response)
   end
   # Update workspace name and tags

--- a/vulcan/spec/fixtures/v2/snakemake-repo/resources/vignette.md
+++ b/vulcan/spec/fixtures/v2/snakemake-repo/resources/vignette.md
@@ -1,0 +1,3 @@
+## Workflow Vignette
+
+This workflow does... stuff!

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -697,6 +697,7 @@ describe VulcanV2Controller do
       expect(json_body[:dag_flattened]).to_not be_nil
       expect(json_body[:vulcan_config]).to_not be_nil
       expect(json_body[:last_run_id]).to be_nil
+      expect(json_body[:vignette]).to_not be_nil
     end
 
     it 'returns the last run and last config' do

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -393,7 +393,7 @@ describe VulcanV2Controller do
       expect(json_body[:files][:completed]).to match_array([])
        
       config = Vulcan::Config.first(id: json_body[:config_id])
-      expect(config.input_files).to eq(["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt"])
+      expect(config.input_files).to eq(["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt", "resources/vignette.md"])
       expect(config.input_params.to_h.transform_values(&:to_s)).to eq(request[:params].transform_keys(&:to_s).transform_values(&:to_s))
     end
 
@@ -427,7 +427,7 @@ describe VulcanV2Controller do
       expect(json_body[:files][:unscheduled]).to match_array(["output/ui_job_one.txt", "output/ui_job_two.txt", "output/summary.txt", "output/ui_summary.txt", "output/final.txt"])
 
       config = Vulcan::Config.first(id: json_body[:config_id])
-      expect(config.input_files).to eq(["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt"])
+      expect(config.input_files).to eq(["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt", "resources/vignette.md"])
       expect(config.input_params.to_h.transform_values(&:to_s)).to eq(request[:params].transform_keys(&:to_s).transform_values(&:to_s))
     end
 


### PR DESCRIPTION
PR hooks up workflow vignettes for display from the workspace interface:
- Adds the content of the file to a vignette key in the `get_workspace` endpoint return, if the file exists in the workspace.
    - This endpoint is called only when the user first loads or refreshes the workspace page, so it's a low usage endpoint that is safe to bloat a bit!
- Tweaks the already in-place '<book> Workflow' button to target this content
- Adds a vignette to the tests 'snakemake-repo', and a line in one of the current get_workflow tests which ensure this vignette return is added.

<img width="1241" height="792" alt="vulcan-vignette" src="https://github.com/user-attachments/assets/6ae1af2f-dd84-4524-ae3e-62c5f50b9fb0" />
