### PR TITLE
vulcan - Initialize workspace with config defaults fully set

### DIFF
--- a/vulcan/lib/path.rb
+++ b/vulcan/lib/path.rb
@@ -38,7 +38,7 @@ class Vulcan
       "#{workspace_dir}/dl_config.yaml"
     end
 
-    def self.default_snakemake_config(workspace_dir)
+    def self.stub_snakemake_config(workspace_dir)
       "#{workspace_dir}/default-config.json"
     end
 

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -69,8 +69,8 @@ class VulcanV2Controller < Vulcan::Controller
           Vulcan::Path.dl_config(workspace_dir), 
           Vulcan::Path.dl_config_yaml(@escaped_params[:project_name], task_token, Vulcan.instance.config(:magma)[:host])
         )
-        config = @remote_manager.read_yaml_file(Vulcan::Path.default_snakemake_config(workspace_dir))
-        target_mapping = @snakemake_manager.generate_target_mapping(workspace_dir, config)
+        default_config = @remote_manager.read_yaml_file(Vulcan::Path.default_snakemake_config(workspace_dir))
+        target_mapping = @snakemake_manager.generate_target_mapping(workspace_dir, default_config)
         obj = Vulcan::Workspace.create(
           workflow_id: workflow.id,
           name: @params[:workspace_name],
@@ -83,10 +83,33 @@ class VulcanV2Controller < Vulcan::Controller
           created_at: Time.now,
           updated_at: Time.now
         )
+        # Set first config with defaults, if any are established in the vulcan_config
+        vulcan_config = @remote_manager.read_yaml_file(Vulcan::Path.vulcan_config(workspace_dir))
+        config_defaults = vulcan_config.select{|c| c.key?("default") && c.key?("output") && c["output"].key?("params")}
+        .map{ |c| [c["output"]["params"][0], c["default"]]}
+        .to_h
+        if !config_defaults.empty?
+          config_hash = Digest::MD5.hexdigest("initial_config" + Time.now.to_i.to_s)
+          config_path = Vulcan::Path.workspace_config_path(workspace_dir, config_hash)
+          @remote_manager.write_file(config_path, config_defaults.to_json)
+          workspace_state = Vulcan::WorkspaceState.new(obj, @snakemake_manager, @remote_manager)
+          available_files = workspace_state.get_available_files
+          state = workspace_state.state(config_defaults.keys.map(&:to_s), Vulcan::Path.default_snakemake_config(workspace_dir), available_files)
+          Vulcan::Config.create(
+            workspace_id: obj.id,
+            path: config_path,
+            hash: config_hash,
+            input_files: "{#{available_files.join(',')}}",
+            input_params: config_defaults,
+            state: state.to_json,
+            created_at: Time.now,
+            updated_at: Time.now
+          )
+        end
         response = {
           workspace_id: obj.id,
           workflow_id: obj.workflow_id,
-          vulcan_config: @remote_manager.read_yaml_file(Vulcan::Path.vulcan_config(workspace_dir)),
+          vulcan_config: vulcan_config,
           dag: obj.dag,
           dag_flattened: Vulcan::Snakemake::Inference.flatten_adjacency_list(obj.dag),
           file_dag: Vulcan::Snakemake::Inference.file_graph(target_mapping)

--- a/vulcan/lib/server/controllers/vulcan_v2_controller.rb
+++ b/vulcan/lib/server/controllers/vulcan_v2_controller.rb
@@ -69,8 +69,8 @@ class VulcanV2Controller < Vulcan::Controller
           Vulcan::Path.dl_config(workspace_dir), 
           Vulcan::Path.dl_config_yaml(@escaped_params[:project_name], task_token, Vulcan.instance.config(:magma)[:host])
         )
-        default_config = @remote_manager.read_yaml_file(Vulcan::Path.default_snakemake_config(workspace_dir))
-        target_mapping = @snakemake_manager.generate_target_mapping(workspace_dir, default_config)
+        stub_config = @remote_manager.read_yaml_file(Vulcan::Path.stub_snakemake_config(workspace_dir))
+        target_mapping = @snakemake_manager.generate_target_mapping(workspace_dir, stub_config)
         obj = Vulcan::Workspace.create(
           workflow_id: workflow.id,
           name: @params[:workspace_name],
@@ -83,28 +83,14 @@ class VulcanV2Controller < Vulcan::Controller
           created_at: Time.now,
           updated_at: Time.now
         )
-        # Set first config with defaults, if any are established in the vulcan_config
         vulcan_config = @remote_manager.read_yaml_file(Vulcan::Path.vulcan_config(workspace_dir))
         config_defaults = vulcan_config.select{|c| c.key?("default") && c.key?("output") && c["output"].key?("params")}
         .map{ |c| [c["output"]["params"][0], c["default"]]}
         .to_h
         if !config_defaults.empty?
-          config_hash = Digest::MD5.hexdigest("initial_config" + Time.now.to_i.to_s)
-          config_path = Vulcan::Path.workspace_config_path(workspace_dir, config_hash)
-          @remote_manager.write_file(config_path, config_defaults.to_json)
           workspace_state = Vulcan::WorkspaceState.new(obj, @snakemake_manager, @remote_manager)
-          available_files = workspace_state.get_available_files
-          state = workspace_state.state(config_defaults.keys.map(&:to_s), Vulcan::Path.default_snakemake_config(workspace_dir), available_files)
-          Vulcan::Config.create(
-            workspace_id: obj.id,
-            path: config_path,
-            hash: config_hash,
-            input_files: "{#{available_files.join(',')}}",
-            input_params: config_defaults,
-            state: state.to_json,
-            created_at: Time.now,
-            updated_at: Time.now
-          )
+          config_hash = Digest::MD5.hexdigest(config_defaults.to_json + Time.now.to_i.to_s)
+          workspace_state.set_config(config_defaults, config_hash)
         end
         response = {
           workspace_id: obj.id,
@@ -220,34 +206,13 @@ class VulcanV2Controller < Vulcan::Controller
       # We always create a new config, even if the params / files are the same for a previous config.
       # It is safest to let snakemake figure out what the "current state" is.
 
-      params_hash = Digest::MD5.hexdigest(workflow_params_json + Time.now.to_i.to_s) # generate random hash 
-      config = Vulcan::Config.first(workspace_id: workspace.id, hash: params_hash)
-
-      # We always overwrite the default config with the incoming params
-      default_config = @remote_manager.read_json_file(Vulcan::Path.default_snakemake_config(workspace.path))
-      config_values = JSON.parse(default_config.to_json).merge(JSON.parse(workflow_params_json))
-      config_path = Vulcan::Path.workspace_config_path(workspace.path, params_hash)
-      @remote_manager.write_file(config_path, config_values.to_json)
-        
       # Anytime a config is saved, we need to clean up UI targets
       workspace_state = Vulcan::WorkspaceState.new(workspace, @snakemake_manager, @remote_manager)
       workspace_state.remove_existing_ui_targets(@params[:uiFilesSent], @params[:paramsChanged])
 
-      # Generate the future state
-      available_files = workspace_state.get_available_files
-      state = workspace_state.state(workflow_params.keys.map(&:to_s), config_path, available_files)
-        
-      config = Vulcan::Config.create(
-          workspace_id: workspace.id,
-          path: config_path,
-          hash: params_hash,
-          input_files: "{#{available_files.join(',')}}",
-          input_params: JSON.parse(workflow_params_json),
-          state: state.to_json,
-          created_at: Time.now,
-          updated_at: Time.now
-        )
-      
+      params_hash = Digest::MD5.hexdigest(workflow_params_json + Time.now.to_i.to_s) # generate random hash
+      config_values = JSON.parse(workflow_params_json)
+      config = workspace_state.set_config(config_values, params_hash)
       success_json(
         {
           config_id: config.id,
@@ -275,15 +240,19 @@ class VulcanV2Controller < Vulcan::Controller
     begin
       raise Etna::TooManyRequests.new("workflow is still running...") if @snakemake_manager.snakemake_is_running?(workspace.path)
       config = Vulcan::Config.where(id: @params[:config_id]).first
+      ### Todo: We don't actually check if the workspace is in a similar state to when the given config was established
       unless config
         msg = "Config for workspace: #{workspace.path} does not exist."
         raise Etna::BadRequest.new(msg)
       end
       # Build snakemake command for execution using stored future_state
       state = config.state
+      # Ensure stub config has proper values, and stubbed other values needed for successfully running.
+      stub_path = Vulcan::Path.stub_snakemake_config(workspace.path)
+      @remote_manager.write_file(stub_path, @remote_manager.read_json_file(stub_path).merge(config.input_params).to_json)
       command = Vulcan::Snakemake::CommandBuilder.new
       command.targets = state['files']['planned']
-      command.options[:config_path] = config.path
+      command.options[:config_path] = stub_path
       command.options[:profile_path] = Vulcan::Path.profile_dir(workspace.path, "default") # only one profile for now
       slurm_run_uuid = @snakemake_manager.run_snakemake(workspace.path, command.build)
       log = @snakemake_manager.get_snakemake_log(workspace.path, slurm_run_uuid)
@@ -436,7 +405,9 @@ class VulcanV2Controller < Vulcan::Controller
     begin
       workspace_state = Vulcan::WorkspaceState.new(workspace, @snakemake_manager, @remote_manager)
       available_files = workspace_state.get_available_files
-      state = workspace_state.state(config.input_params.keys.map(&:to_s), config.path, available_files)
+      stub_path = Vulcan::Path.stub_snakemake_config(workspace.path)
+      @remote_manager.write_file(stub_path, @remote_manager.read_json_file(stub_path).merge(config.input_params).to_json)
+      state = workspace_state.state(config.input_params.keys.map(&:to_s), stub_path, available_files)
       success_json(state)
     rescue => e
       Vulcan.instance.logger.log_error(e)
@@ -462,7 +433,7 @@ class VulcanV2Controller < Vulcan::Controller
 
     begin
       # Read the current default config from the workspace
-      config = @remote_manager.read_yaml_file(Vulcan::Path.default_snakemake_config(workspace.path))
+      config = @remote_manager.read_yaml_file(Vulcan::Path.stub_snakemake_config(workspace.path))
       
       # Regenerate the target mapping
       target_mapping = @snakemake_manager.generate_target_mapping(workspace.path, config)

--- a/vulcan/lib/snakemake_remote_manager.rb
+++ b/vulcan/lib/snakemake_remote_manager.rb
@@ -161,7 +161,7 @@ class Vulcan
         # Therefore, we adopt a convention in the config.yaml - such that all input files
         # be defined starting with the string "output/". We can then create dummy files and run
         # our meta commands.
-        config_path = Vulcan::Path.default_snakemake_config(Shellwords.escape(dir))
+        config_path = Vulcan::Path.stub_snakemake_config(Shellwords.escape(dir))
         config = @remote_manager.read_yaml_file(config_path)
 
         # Identify input files and create them with "DUMMY FILE" content

--- a/vulcan/lib/workspace_state.rb
+++ b/vulcan/lib/workspace_state.rb
@@ -13,23 +13,30 @@ class Vulcan
         params, 
         available_files
       )
-      # Use dry run to get the all the files, jobs that snakemake ACTUALLY plans to generate
-      # This gets us the files and jobs planned and completed, also note that these are just the compute jobs and files, not the UI jobs and files.
-      command = Vulcan::Snakemake::CommandBuilder.new
-      command.targets = all_targets
-      command.options[:config_path] = config_path
-      command.options[:profile_path] = Vulcan::Path.profile_dir(@workspace.path, "default")
-      command.options[:dry_run] = true
-      command.options[:summary] = true
-      # === COMPUTE STATE (from snakemake dry run) ===
-      # Get compute files/jobs in all three states: planned, completed, unscheduled
-      # Note that these are just the compute jobs and files, not the UI jobs and files.
+      if all_targets.empty?
+        files_planned = []
+        jobs_planned = []
+        files_completed = []
+        jobs_completed = []
+      else
+        # Use dry run to get the all the files, jobs that snakemake ACTUALLY plans to generate
+        # This gets us the files and jobs planned and completed, also note that these are just the compute jobs and files, not the UI jobs and files.
+        command = Vulcan::Snakemake::CommandBuilder.new
+        command.targets = all_targets
+        command.options[:config_path] = config_path
+        command.options[:profile_path] = Vulcan::Path.profile_dir(@workspace.path, "default")
+        command.options[:dry_run] = true
+        command.options[:summary] = true
+        # === COMPUTE STATE (from snakemake dry run) ===
+        # Get compute files/jobs in all three states: planned, completed, unscheduled
+        # Note that these are just the compute jobs and files, not the UI jobs and files.
 
-      dry_run_info = @snakemake_manager.dry_run_snakemake_files(@workspace.path, command.build)
-      files_planned = dry_run_info[:files_scheduled].to_set.to_a
-      jobs_planned = dry_run_info[:jobs_scheduled].to_set.to_a
-      files_completed = dry_run_info[:files_completed].to_set.to_a
-      jobs_completed = dry_run_info[:jobs_completed].to_set.to_a
+        dry_run_info = @snakemake_manager.dry_run_snakemake_files(@workspace.path, command.build)
+        files_planned = dry_run_info[:files_scheduled].to_set.to_a
+        jobs_planned = dry_run_info[:jobs_scheduled].to_set.to_a
+        files_completed = dry_run_info[:files_completed].to_set.to_a
+        jobs_completed = dry_run_info[:jobs_completed].to_set.to_a
+      end
 
       Vulcan.instance.logger.debug("Files scheduled: #{files_planned}")
       Vulcan.instance.logger.debug("Jobs scheduled: #{jobs_planned}")
@@ -108,13 +115,35 @@ class Vulcan
       end
     end
 
-
     def get_available_files
       output_files = @remote_manager.list_files(Vulcan::Path.workspace_output_dir(@workspace.path))
         .map { |file| "output/#{file}" }
       resources_files = @remote_manager.list_files(Vulcan::Path.workspace_resources_dir(@workspace.path))
         .map { |file| "resources/#{file}" }
       output_files + resources_files
+    end
+
+    def set_config(config_values, config_hash)
+      config_path = Vulcan::Path.workspace_config_path(@workspace.path, config_hash)
+      available_files = get_available_files
+      # Write file to workspace
+      @remote_manager.write_file(config_path, config_values.to_json)
+      # Fill filled values into the stub_config
+      stub_path = Vulcan::Path.stub_snakemake_config(@workspace.path)
+      @remote_manager.write_file(stub_path, @remote_manager.read_json_file(stub_path).merge(config_values).to_json)
+      # Determine state afterward
+      state = state(config_values.keys.map(&:to_s), stub_path, available_files)
+      # Create db entry
+      Vulcan::Config.create(
+        workspace_id: @workspace.id,
+        path: config_path,
+        hash: config_hash,
+        input_files: "{#{available_files.join(',')}}",
+        input_params: config_values,
+        state: state.to_json,
+        created_at: Time.now,
+        updated_at: Time.now
+      )
     end
 
     private

--- a/vulcan/spec/fixtures/v2/git-init.sh
+++ b/vulcan/spec/fixtures/v2/git-init.sh
@@ -9,4 +9,10 @@ if [ ! -d "/test-utils/available-workflows/snakemake-repo/.git" ]; then
     git -C /test-utils/available-workflows/snakemake-repo add .
     git -C /test-utils/available-workflows/snakemake-repo commit -m "Initial commit"
     git -C /test-utils/available-workflows/snakemake-repo tag v1
+    git -C /test-utils/available-workflows/snakemake-repo checkout -b no-default
+    grep -v "default:" /test-utils/available-workflows/snakemake-repo/vulcan_config.yaml > /test-utils/available-workflows/snakemake-repo/stub.txt
+    mv /test-utils/available-workflows/snakemake-repo/stub.txt /test-utils/available-workflows/snakemake-repo/vulcan_config.yaml
+    git -C /test-utils/available-workflows/snakemake-repo add /test-utils/available-workflows/snakemake-repo/vulcan_config.yaml
+    git -C /test-utils/available-workflows/snakemake-repo commit -m "remove defaults from vulcan_config.yaml"
+    git -C /test-utils/available-workflows/snakemake-repo checkout main
 fi

--- a/vulcan/spec/fixtures/v2/snakemake-repo/default-config.json
+++ b/vulcan/spec/fixtures/v2/snakemake-repo/default-config.json
@@ -1,8 +1,6 @@
 {
-  "poem": "output/poem.txt",
-  "poem_2": "output/poem_2.txt",
   "count_bytes": true,
   "count_chars": false,
-  "add": 2,
+  "add": true,
   "add_and_multiply_by": 3
 }

--- a/vulcan/spec/fixtures/v2/snakemake-repo/rules/core.smk
+++ b/vulcan/spec/fixtures/v2/snakemake-repo/rules/core.smk
@@ -1,9 +1,21 @@
+rule set_poem_1:
+    params:
+        ui=True
+    output:
+        "output/poem.txt"
+
+rule set_poem_2:
+    params:
+        ui=True
+    output:
+        "output/poem_2.txt"
+
 rule count:
     input:
         # Any jobs that use a config as input and are file paths, must make sure the config values
         # match the vulcan_config.yaml
-        poem1=config["poem"],
-        poem2=config["poem_2"]
+        poem1="output/poem.txt",
+        poem2="output/poem_2.txt"
     output:
         poem_count="output/count_poem.txt",
         poem_count_2="output/count_poem_2.txt"

--- a/vulcan/spec/fixtures/v2/snakemake-repo/vulcan_config.yaml
+++ b/vulcan/spec/fixtures/v2/snakemake-repo/vulcan_config.yaml
@@ -1,20 +1,39 @@
-# Lets assume that a ui component fetches some files from metis to populate in a dropdown
-- display: "location of files on metis to count"
-  ui_component: "metis_file_selector_dropdown"
+### Config UIs
+# For a real workflow, all config elements would have a UI
+- display: "count bytes"
+  ui_component: "boolean"
+  default: true
   output:
-    params: ["poem", "poem_2"] # These are the names of the params that would contain the file names down below
-                               # So the UI would send {poem: poem.txt and poem_2: poem_2.txt}
-    files: ["poem.txt", "poem_2.txt"] # Here the UI would call the /write API to write these files to the workspace
+    params: ["count_bytes"]
+- display: "count characters"
+  ui_component: "boolean"
+  default: false
+  output:
+    params: ["count_chars"]
 
-- display: "count selector to perform on files"
-  ui_component: "boolean_selector"
+- display: "whether to add a number"
+  ui_component: "boolean"
+  default: true
   output:
-    params: ["count_bytes", "count_chars"] # These are the names of the params
+    params: ["add"]
+- display: "number to multiply by"
+  ui_component: "integer"
+  default: 3
+  output:
+    params: ["add_and_multiply"]
 
-- display: "type of numeric arithmetic to perform"
-  ui_component: "boolean_selector"
+### File-Producing UIs
+- display: "poem to count"
+  name: "set_poem_1"
+  ui_component: "multiline-string"
   output:
-    params: ["add", "add_and_multiply"]
+    files: ["poem.txt"]
+
+- display: "poem 2 to count"
+  name: "set_poem_2"
+  ui_component: "multiline-string"
+  output:
+    files: ["poem_2.txt"]
 
 - display: "some ui component that does a job"
   ui_component: "text_box"

--- a/vulcan/spec/fixtures/v2/snakemake-repo/vulcan_config.yaml
+++ b/vulcan/spec/fixtures/v2/snakemake-repo/vulcan_config.yaml
@@ -13,12 +13,10 @@
 
 - display: "whether to add a number"
   ui_component: "boolean"
-  default: true
   output:
     params: ["add"]
 - display: "number to multiply by"
   ui_component: "integer"
-  default: 3
   output:
     params: ["add_and_multiply"]
 

--- a/vulcan/spec/snakemake_inference_spec.rb
+++ b/vulcan/spec/snakemake_inference_spec.rb
@@ -15,7 +15,9 @@ describe Vulcan::Snakemake::Inference do
       "ui_job_one" => ["checker"],
       "checker"    => ["arithmetic"],
       "arithmetic" => ["count"],
-      "count"      => [],
+      "count"      => ["set_poem_1", "set_poem_2"],
+      "set_poem_1" => [],
+      "set_poem_2" => [],
       "ui_job_two" => [],
       "summary"    => ["count", "arithmetic", "checker", "ui_job_one", "ui_job_two"]
     }
@@ -42,7 +44,7 @@ describe Vulcan::Snakemake::Inference do
 
     it 'correctly finds all targets with all params' do
       provided_params = ["count_bytes", "count_chars", "add", "add_and_multiply_by", "ui"]
-      available_files = ["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt", "output/ui_job_one.txt", "output/ui_job_two.txt"]
+      available_files = ["output/poem.txt", "output/poem_2.txt", "output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt", "output/ui_job_one.txt", "output/ui_job_two.txt"]
       targets = Vulcan::Snakemake::Inference.find_buildable_targets(target_mapping, provided_params, available_files)
       expect(targets).to eq(["output/count_poem.txt", "output/count_poem_2.txt", "output/arithmetic.txt", "output/check.txt", "output/summary.txt"])
     end
@@ -51,7 +53,7 @@ describe Vulcan::Snakemake::Inference do
   context 'find_ui_targets' do
     it 'correctly finds the ui targets' do
       result = Vulcan::Snakemake::Inference.ui_targets(target_mapping)
-      expect(result).to eq(["output/ui_job_one.txt", "output/ui_job_two.txt", "output/ui_summary.txt"])
+      expect(result).to eq(["output/poem.txt", "output/poem_2.txt", "output/ui_job_one.txt", "output/ui_job_two.txt", "output/ui_summary.txt"])
     end
   end
 
@@ -79,7 +81,7 @@ describe Vulcan::Snakemake::Inference do
   context 'flattens an adjacency list' do
     it 'correctly flattens the dag' do
       result = Vulcan::Snakemake::Inference.flatten_adjacency_list(job_adjacency_list)
-      expect(result).to eq(["count", "arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
+      expect(result).to eq(["set_poem_1", "set_poem_2", "count", "arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
     end
   end
 

--- a/vulcan/spec/snakemake_parser_spec.rb
+++ b/vulcan/spec/snakemake_parser_spec.rb
@@ -32,7 +32,9 @@ describe Vulcan::Snakemake::TargetParser do
         "output/count_poem.txt",
         "output/count_poem_2.txt",
         "output/arithmetic.txt",
-        "output/check.txt"
+        "output/check.txt",
+        "output/poem.txt",
+        "output/poem_2.txt"
         )
     end
 

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -27,6 +27,11 @@ describe VulcanV2Controller do
     }.merge(params))
   end
 
+  let(:expected_default_params) {{
+    count_bytes: true,
+    count_chars: false
+  }}
+
   def setup_workspace(workflow=nil, params={})
     workflow = create_workflow unless workflow
 
@@ -203,7 +208,7 @@ describe VulcanV2Controller do
       expect(workspace.git_sha).to_not eq(nil)
     end
 
-    it 'successfully creates a first config entry from the default-config.json' do
+    it 'successfully creates a first config, treating un-defaulted params as unfilled in state' do
       auth_header(:editor)
       post_workspace_create(workspace_request)
       expect(last_response.status).to eq(200)
@@ -211,6 +216,13 @@ describe VulcanV2Controller do
       config = Vulcan::Config.first(workspace_id: json_body[:workspace_id])
       # Make sure the corresponding config file exists
       expect(remote_manager.file_exists?(config.path)).to be_truthy
+      file_content = remote_manager.read_json_file(config.path)
+      # Confirm that the config file has the correct values
+      expect(file_content).to eq(expected_default_params.transform_keys(&:to_s))
+      # Steps downstream of un-defaulted params are deemed downstream
+      expect(config[:state]['jobs']['completed']).to match_array([])
+      expect(config[:state]['jobs']['planned']).to match_array([])
+      expect(config[:state]['jobs']['unscheduled']).to match_array(["count", "set_poem_1", "set_poem_2", "arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
     end
 
     it 'successfully sends back vulcan_config and dag, file_dag, and dag_flattened' do
@@ -266,10 +278,10 @@ describe VulcanV2Controller do
       workspace = Vulcan::Workspace.all[0]
       # We need to write some initial input files to the workspace.
       write_files_to_workspace(workspace.id)
-      # Next we run the first snakemake job
+      # Next we set a new config (values distinct from the default)
       request = {
           params: {
-            count_bytes: false,
+            count_bytes: true,
             count_chars: true
           },
           paramsChanged: [],
@@ -285,9 +297,10 @@ describe VulcanV2Controller do
       expect(remote_manager.file_exists?(config.path)).to be_truthy
 
       # Make sure the config file also has the correct default values as well as the new values
-      default_config_content = remote_manager.read_json_file(Vulcan::Path.default_snakemake_config(workspace.path))
-      expected_config_content = default_config_content.merge(JSON.parse(request[:params].to_json))
-      expect(remote_manager.read_json_file(config.path)).to eq(expected_config_content)
+      default_config_content = remote_manager.read_json_file(Vulcan::Path.stub_snakemake_config(workspace.path))
+      expected_stubbed_content = default_config_content.merge(JSON.parse(request[:params].to_json))
+      expect(remote_manager.read_json_file(config.path)).to eq(request[:params].transform_keys(&:to_s))
+      expect(remote_manager.read_json_file(Vulcan::Path.stub_snakemake_config(workspace.path))).to eq(expected_stubbed_content.transform_keys(&:to_s))
     end
 
     it 'creates a new config if the same config already exists' do  
@@ -295,7 +308,7 @@ describe VulcanV2Controller do
       workspace = Vulcan::Workspace.all[0]
       # We need to write some initial input files to the workspace.
       write_files_to_workspace(workspace.id)
-      # Next we run the first snakemake job
+      # Next we set a new config (but values same as the default)
       request = {
         params: {
           count_bytes: false,
@@ -305,12 +318,10 @@ describe VulcanV2Controller do
         uiFilesSent: []
       }
       post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request)
-      config_id = json_body[:config_id]
-      post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request)
       expect(last_response.status).to eq(200)
       # Make sure the config file exists
       config = Vulcan::Config.all
-      expect(config.count).to eq(3)
+      expect(config.count).to eq(2)
       config_1 = config.first
       config_2 = config.last
       expect(remote_manager.file_exists?(config_1.path)).to be_truthy
@@ -322,17 +333,10 @@ describe VulcanV2Controller do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
       write_files_to_workspace(workspace.id)
-      # Create a config and run a job
-      request = {
-        params: {
-          count_bytes: false,
-          count_chars: true 
-        },
-        paramsChanged: [],
-        uiFilesSent: []
-      }
-      post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request)
-      config_1 = Vulcan::Config.first(id: json_body[:config_id])
+      # Initial config from defaulted values
+      config_1 = Vulcan::Config.first(workspace_id: workspace.id)
+
+      # Next we set a new config (values distinct from the default)
       request_2 = {
         params: {
           count_bytes: false,
@@ -342,20 +346,11 @@ describe VulcanV2Controller do
         uiFilesSent: []
       }
 
-      # NOTE: when we set
-      # params: {
-      #   count_bytes: true,
-      #   count_chars: false 
-      # }
-      # after the first request snakemake does not detect that the config has changed.
-      # Not entirely sure why, but this just happens with our example workflow.
-
-
       post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request_2)
       config_2 = Vulcan::Config.first(id: json_body[:config_id])
 
       # Make sure the config object exists
-      expect(Vulcan::Config.where(workspace_id: workspace.id).count).to eq(3)
+      expect(Vulcan::Config.where(workspace_id: workspace.id).count).to eq(2)
 
       # Make sure the the 2 config files exists
       expect(remote_manager.file_exists?(config_1.path)).to be_truthy
@@ -368,7 +363,7 @@ describe VulcanV2Controller do
       expect(config_content_1).to_not eq(config_content_2)
 
       # Confirm that the config files have the correct values
-      request[:params].each do |key, expected_value|
+      expected_default_params.each do |key, expected_value|
         expect(config_content_1[key.to_s]).to eq(expected_value)
       end
 
@@ -472,7 +467,7 @@ describe VulcanV2Controller do
         params: {
           count_bytes: false,
           count_chars: true,
-          add: 4, # Change the add param
+          add: 4, # Change the add param -- affects arithmetic step and downstream.
           add_and_multiply_by: 2
         },
         paramsChanged: ["add"],
@@ -707,9 +702,7 @@ describe VulcanV2Controller do
       get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
       expect(last_response.status).to eq(200)
       # Make sure the config file also has the correct default values as well as the new values
-      default_config_content = remote_manager.read_json_file(Vulcan::Path.default_snakemake_config(workspace.path))
-      expected_config_content = default_config_content.merge(JSON.parse(request[:params].to_json))
-      expect(json_body[:last_config]).to eq(expected_config_content.transform_keys(&:to_sym))
+      expect(json_body[:last_config]).to eq(request[:params].transform_keys(&:to_sym))
       expect(json_body[:last_config_id]).to_not be_nil
       expect(json_body[:last_job_status]).to be_nil
       expect(json_body[:dag]).to_not be_nil
@@ -758,11 +751,8 @@ describe VulcanV2Controller do
 
       # Check that the last config is the second config
       get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
-      workspace = Vulcan::Workspace.first(id: workspace_id)
-      default_config_content = remote_manager.read_json_file(Vulcan::Path.default_snakemake_config(workspace.path))
-      expected_config_content = default_config_content.merge(JSON.parse(request_2[:params].to_json))
-      expect(json_body[:last_config]).to eq(expected_config_content.transform_keys(&:to_sym))
-      expect(json_body[:last_config_id]).to_not be_nil
+      expect(json_body[:last_config]).to eq(request_2[:params].transform_keys(&:to_sym))
+      expect(json_body[:last_config_id]).to eq(config_id)
       expect(json_body[:last_job_status]).to_not be_nil
       expect(json_body[:last_run_id]).to_not be_nil
       expect(json_body[:dag]).to_not be_nil

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -192,13 +192,25 @@ describe VulcanV2Controller do
         "ui_job_one"=>["checker"],
         "checker"=>["arithmetic"],
         "arithmetic"=>["count"],
-        "count"=>[],
+        "count"=>["set_poem_1", "set_poem_2"],
+        "set_poem_1"=>[],
+        "set_poem_2"=>[],
         "ui_job_two"=>[],
         "summary"=>["count", "arithmetic", "checker", "ui_job_one", "ui_job_two"]
       })
       expect(File.basename(workspace.path).match?(/\A[a-f0-9]{32}\z/)).to be_truthy
       expect(workspace.git_ref).to eq("v1")
       expect(workspace.git_sha).to_not eq(nil)
+    end
+
+    it 'successfully creates a first config entry from the default-config.json' do
+      auth_header(:editor)
+      post_workspace_create(workspace_request)
+      expect(last_response.status).to eq(200)
+      # Make sure a config object exists
+      config = Vulcan::Config.first(workspace_id: json_body[:workspace_id])
+      # Make sure the corresponding config file exists
+      expect(remote_manager.file_exists?(config.path)).to be_truthy
     end
 
     it 'successfully sends back vulcan_config and dag, file_dag, and dag_flattened' do
@@ -298,7 +310,7 @@ describe VulcanV2Controller do
       expect(last_response.status).to eq(200)
       # Make sure the config file exists
       config = Vulcan::Config.all
-      expect(config.count).to eq(2)
+      expect(config.count).to eq(3)
       config_1 = config.first
       config_2 = config.last
       expect(remote_manager.file_exists?(config_1.path)).to be_truthy
@@ -343,7 +355,7 @@ describe VulcanV2Controller do
       config_2 = Vulcan::Config.first(id: json_body[:config_id])
 
       # Make sure the config object exists
-      expect(Vulcan::Config.where(workspace_id: workspace.id).count).to eq(2)
+      expect(Vulcan::Config.where(workspace_id: workspace.id).count).to eq(3)
 
       # Make sure the the 2 config files exists
       expect(remote_manager.file_exists?(config_1.path)).to be_truthy
@@ -371,7 +383,7 @@ describe VulcanV2Controller do
     it 'correctly returns the scheduled and downstream files (first job)' do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
-      # We need to write some initial input files to the workspace.
+      # We need to write some initial input files to the workspace (the outputs of 2 ui-steps)
       write_files_to_workspace(workspace.id)
       # Next we run the first snakemake job
       request = {
@@ -386,11 +398,11 @@ describe VulcanV2Controller do
       post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request)
       expect(json_body[:jobs][:planned]).to match_array(["count"])
       expect(json_body[:jobs][:unscheduled]).to match_array(["arithmetic", "checker", "ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
-      expect(json_body[:jobs][:completed]).to match_array([])
+      expect(json_body[:jobs][:completed]).to match_array(["set_poem_1", "set_poem_2"])
 
       expect(json_body[:files][:planned]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt"])
       expect(json_body[:files][:unscheduled]).to match_array(["output/arithmetic.txt", "output/check.txt", "output/ui_job_one.txt", "output/ui_job_two.txt", "output/summary.txt", "output/ui_summary.txt", "output/final.txt"])
-      expect(json_body[:files][:completed]).to match_array([])
+      expect(json_body[:files][:completed]).to match_array(["output/poem.txt", "output/poem_2.txt"])
        
       config = Vulcan::Config.first(id: json_body[:config_id])
       expect(config.input_files).to eq(["output/poem.txt", "output/poem_2.txt", "resources/number_to_add.txt"])
@@ -401,7 +413,7 @@ describe VulcanV2Controller do
     it 'correctly returns scheduled and downstream files and jobs (three jobs)' do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
-      # We need to write some initial input files to the workspace.
+      # We need to write some initial input files to the workspace (the outputs of 2 ui-steps)
       write_files_to_workspace(workspace.id)
       # Next we run the first 3 snakemake jobs
       request = {
@@ -418,11 +430,11 @@ describe VulcanV2Controller do
       # TODO: figure maybe change algorithm to include ui_job_two and output/ui_job_two.txt
       # Both are root nodes but should probably be included
       post("/api/v2/#{PROJECT}/workspace/#{workspace.id}/config", request)
-      expect(json_body[:jobs][:completed]).to match_array([])
+      expect(json_body[:jobs][:completed]).to match_array(["set_poem_1", "set_poem_2"])
       expect(json_body[:jobs][:planned]).to match_array(["count", "arithmetic", "checker"])
       expect(json_body[:jobs][:unscheduled]).to match_array(["ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
 
-      expect(json_body[:files][:completed]).to match_array([])
+      expect(json_body[:files][:completed]).to match_array(["output/poem.txt", "output/poem_2.txt"])
       expect(json_body[:files][:planned]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt", "output/arithmetic.txt", "output/check.txt"])
       expect(json_body[:files][:unscheduled]).to match_array(["output/ui_job_one.txt", "output/ui_job_two.txt", "output/summary.txt", "output/ui_summary.txt", "output/final.txt"])
 
@@ -434,7 +446,7 @@ describe VulcanV2Controller do
     it 'it correctly returns scheduled and downstream files and jobs after a config has been run and then changed' do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
-      # We need to write some initial input files to the workspace.
+      # We need to write some initial input files to the workspace (the outputs of 2 ui-steps)
       write_files_to_workspace(workspace.id)
       # Next we run the first 3 snakemake jobs
       request = {
@@ -474,20 +486,21 @@ describe VulcanV2Controller do
         get("/api/v2/#{PROJECT}/workspace/#{workspace.id}/run/#{run_id}") 
       end 
       expect(last_response.status).to eq(200)
-      expect(config_request[:jobs][:completed]).to match_array(["count"])
+      expect(config_request[:jobs][:completed]).to match_array(["count", "set_poem_1", "set_poem_2"])
       expect(config_request[:jobs][:planned]).to match_array(["arithmetic", "checker"])
       expect(config_request[:jobs][:unscheduled]).to match_array(["ui_job_one", "ui_job_two", "summary", "ui_summary", "final"])
 
-      expect(config_request[:files][:completed]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt"])
+      expect(config_request[:files][:completed]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt", "output/poem.txt", "output/poem_2.txt"])
       expect(config_request[:files][:planned]).to match_array(["output/arithmetic.txt", "output/check.txt"])
       expect(config_request[:files][:unscheduled]).to match_array(["output/ui_job_one.txt", "output/ui_job_two.txt", "output/summary.txt", "output/ui_summary.txt", "output/final.txt"])
 
     end
 
+    # This test alone takes almost 3 minutes to run
     it 'correctly returns ui_jobs in completed and unscheduled' do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
-      write_files_to_workspace(workspace.id)
+      write_files_to_workspace(workspace.id) # (the outputs of 2 ui-steps)
       
       # Run the first 3 jobs (count, arithmetic, checker)
       request = {
@@ -534,6 +547,8 @@ describe VulcanV2Controller do
         "output/count_poem_2.txt", 
         "output/arithmetic.txt", 
         "output/check.txt", 
+        "output/poem.txt",
+        "output/poem_2.txt",
         "output/ui_job_one.txt"
       )
       expect(json_body[:files][:unscheduled]).to contain_exactly(
@@ -544,7 +559,7 @@ describe VulcanV2Controller do
       )
       
       expect(json_body[:jobs][:planned]).to eq([])
-      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "ui_job_one")
+      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "set_poem_1", "set_poem_2", "ui_job_one")
       expect(json_body[:jobs][:unscheduled]).to contain_exactly("summary", "final", "ui_job_two", "ui_summary")
 
       # Now change upstream by modifying the add param and re-running checker
@@ -569,7 +584,7 @@ describe VulcanV2Controller do
       
       # After changing add param, arithmetic and checker need to be re-run
       expect(json_body[:files][:planned]).to contain_exactly("output/arithmetic.txt", "output/check.txt")
-      expect(json_body[:files][:completed]).to contain_exactly("output/count_poem.txt", "output/count_poem_2.txt")
+      expect(json_body[:files][:completed]).to contain_exactly("output/count_poem.txt", "output/count_poem_2.txt", "output/poem.txt", "output/poem_2.txt")
       expect(json_body[:files][:unscheduled]).to contain_exactly(
         "output/summary.txt", 
         "output/final.txt", 
@@ -579,7 +594,7 @@ describe VulcanV2Controller do
       )
       
       expect(json_body[:jobs][:planned]).to contain_exactly("arithmetic", "checker")
-      expect(json_body[:jobs][:completed]).to contain_exactly("count")
+      expect(json_body[:jobs][:completed]).to contain_exactly("count", "set_poem_1", "set_poem_2")
       expect(json_body[:jobs][:unscheduled]).to contain_exactly("summary", "final", "ui_job_one", "ui_job_two", "ui_summary")
       
       # Run the workflow with changed params
@@ -615,7 +630,9 @@ describe VulcanV2Controller do
         "output/count_poem_2.txt", 
         "output/arithmetic.txt", 
         "output/check.txt", 
-        "output/ui_job_one.txt"
+        "output/ui_job_one.txt",
+        "output/poem.txt",
+        "output/poem_2.txt"
       )
       expect(json_body[:files][:unscheduled]).to contain_exactly(
         "output/summary.txt", 
@@ -625,7 +642,7 @@ describe VulcanV2Controller do
       )
       
       expect(json_body[:jobs][:planned]).to eq([])
-      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "ui_job_one")
+      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "set_poem_1", "set_poem_2", "ui_job_one")
       expect(json_body[:jobs][:unscheduled]).to contain_exactly("summary", "final", "ui_job_two", "ui_summary")
       
       # Now write ui_job_two.txt and verify it moves to completed
@@ -652,7 +669,9 @@ describe VulcanV2Controller do
         "output/arithmetic.txt", 
         "output/check.txt", 
         "output/ui_job_one.txt",
-        "output/ui_job_two.txt"
+        "output/ui_job_two.txt",
+        "output/poem.txt",
+        "output/poem_2.txt"
       )
       expect(json_body[:files][:unscheduled]).to contain_exactly(
         "output/final.txt", 
@@ -660,7 +679,7 @@ describe VulcanV2Controller do
       )
       
       expect(json_body[:jobs][:planned]).to eq(["summary"])
-      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "ui_job_one", "ui_job_two")
+      expect(json_body[:jobs][:completed]).to contain_exactly("count", "arithmetic", "checker", "set_poem_1", "set_poem_2", "ui_job_one", "ui_job_two")
       expect(json_body[:jobs][:unscheduled]).to contain_exactly("final", "ui_summary")
     end
 
@@ -749,13 +768,15 @@ describe VulcanV2Controller do
       expect(json_body[:vulcan_config]).to_not be_nil
     end
 
-    it 'returns no configs if they do not exist' do
-      workspace_id = json_body[:workspace_id]
-      get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
-      expect(last_response.status).to eq(200)
-      expect(json_body[:last_config]).to be_nil
-      expect(json_body[:last_job_status]).to be_nil
-    end
+    # With the test workflow, a first config is now established during workspace_creation
+    # To bring back test, an alternate workflow is required.
+    # it 'returns no configs if they do not exist' do
+    #   workspace_id = json_body[:workspace_id]
+    #   get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
+    #   expect(last_response.status).to eq(200)
+    #   expect(json_body[:last_config]).to be_nil
+    #   expect(json_body[:last_job_status]).to be_nil
+    # end
 
     it 'updates the token in the dl_config.yaml when the author views the workspace' do
       workspace_id = json_body[:workspace_id]
@@ -1041,7 +1062,7 @@ describe VulcanV2Controller do
     it 'returns different state after we have run the config' do
       auth_header(:editor)
       workspace = Vulcan::Workspace.all[0]
-      write_files_to_workspace(workspace.id)
+      write_files_to_workspace(workspace.id) # (the outputs of 2 ui-steps)
       
       # Create a config
       request = {
@@ -1082,8 +1103,8 @@ describe VulcanV2Controller do
       # Verify that the state has changed after running the workflow
       # Files that were planned should now be completed
       current_state = json_body
-      expect(current_state[:files][:completed]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt"])
-      expect(current_state[:jobs][:completed]).to match_array(["count"])
+      expect(current_state[:files][:completed]).to match_array(["output/count_poem.txt", "output/count_poem_2.txt", "output/poem.txt", "output/poem_2.txt"])
+      expect(current_state[:jobs][:completed]).to match_array(["count", "set_poem_1", "set_poem_2"])
       
       # The completed files/jobs should be different from the initial planned state
       expect(current_state[:files][:completed]).to_not eq(initial_state[:files][:completed])

--- a/vulcan/spec/workflow_v2_spec.rb
+++ b/vulcan/spec/workflow_v2_spec.rb
@@ -41,7 +41,6 @@ describe VulcanV2Controller do
     request = {
       workflow_id: workflow.id,
       workspace_name: "running-tiger",
-      branch: "main",
       git_request: "v1"
     }.merge(params)
     post("/api/v2/#{project_name}/workspace/create", request)
@@ -759,16 +758,6 @@ describe VulcanV2Controller do
       expect(json_body[:vulcan_config]).to_not be_nil
     end
 
-    # With the test workflow, a first config is now established during workspace_creation
-    # To bring back test, an alternate workflow is required.
-    # it 'returns no configs if they do not exist' do
-    #   workspace_id = json_body[:workspace_id]
-    #   get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
-    #   expect(last_response.status).to eq(200)
-    #   expect(json_body[:last_config]).to be_nil
-    #   expect(json_body[:last_job_status]).to be_nil
-    # end
-
     it 'updates the token in the dl_config.yaml when the author views the workspace' do
       workspace_id = json_body[:workspace_id]
       stub_generate_token(PROJECT, "another_token")
@@ -792,6 +781,24 @@ describe VulcanV2Controller do
       # Token should remain unchanged
       expect(remote_manager.read_yaml_file(Vulcan::Path.dl_config(json_body[:workspace_path]))["token"]).to eq(original_token)
       expect(remote_manager.read_yaml_file(Vulcan::Path.dl_config(json_body[:workspace_path]))["token"]).to_not eq("editor_token")
+    end
+
+  end
+
+  context 'list a specific workspace' do
+
+    before do
+      setup_workspace(nil, {git_request: 'no-default'})
+    end
+
+    # With the test workflow, a first config is now established during workspace_creation
+    # To bring back test, an alternate workflow is required.
+    it 'returns no configs if they do not exist' do
+      workspace_id = json_body[:workspace_id]
+      get("/api/v2/#{PROJECT}/workspace/#{workspace_id}")
+      expect(last_response.status).to eq(200)
+      expect(json_body[:last_config]).to be_nil
+      expect(json_body[:last_job_status]).to be_nil
     end
 
   end


### PR DESCRIPTION
This PR aims to more fully make use of defaults set by a workflow creator, and lessen a sometimes significant workspace initialization burden on users.

Currently, the Front-end reads and plugs these in for the user, but the user must click 'Save Choices' for each and every UI before those defaults are known to the back-end for a 'Run' of the workspace.  But each click of 'Save Choices' takes multiple seconds to complete before the next can be clicked.  For workflows where multiple config parameters exist that are fully defaulted, this amounts to an unnecessary stage of having to return to the workspace every ~30s, click the next 'Save Choices' button, for each and every defaults parameter.

Instead, this PR:
- Adds interpretation in the Back-End of those same defaults in the `vulcan_config.yaml` that the Front-End already reads.
- If any config-param defaults exist, it establishes these values as a first 'config' during `create_workspace`.
- **Of major note:** this allows configs to not include values of all possible parameters, which snakemake does not like, so...
- Adjusts `get_state` and `run_workflow` commands to overwrite values of the workspace's stub 'default-config.json'  with the actual values of the target-config, then utilize that as the '--configfile' (while still directing snakemake towards only the targets we know can be generated).

This PR also:
- Adjusts the 'snakemake-repo' backing vulcan unit tests to be more in-line with established vulcan mechanics.  The original form would have been invalid to the Front-End, and missed step definitions, encoding the files generated by ui-inputs, in its Snakefile.
- Changes the name of the <del>`default_snakemake_config`</del> to `stub_snakemake_config` in Vulcan::Path to reflect that this file holds stubs, not true defaults!