### PR TITLE
Vulcan HotFix from recent config defaulting and state determination changes

### DIFF
--- a/vulcan/lib/workspace_state.rb
+++ b/vulcan/lib/workspace_state.rb
@@ -13,7 +13,7 @@ class Vulcan
         params, 
         available_files
       )
-      if all_targets.empty?
+      if all_targets.empty? && ! @workspace.target_mapping.empty?
         files_planned = []
         jobs_planned = []
         files_completed = []

--- a/vulcan/lib/workspace_state.rb
+++ b/vulcan/lib/workspace_state.rb
@@ -13,6 +13,7 @@ class Vulcan
         params, 
         available_files
       )
+      # ToDo: Fix target_mapping calculation and remove the "&& ! @workspace.target_mapping.empty?" hotfix below
       if all_targets.empty? && ! @workspace.target_mapping.empty?
         files_planned = []
         jobs_planned = []


### PR DESCRIPTION
The real issue: The target_mapping calculation fails to produce any targets for the https://github.com/UCSF-DSCOLAB/vulcan_hidras_aggregation workflow.

But, it's a simple workflow with no breakpoints & a fully defaulted config setup.  Thus, the snakemake dryrun in state determination is safe to run, and accurate, even without provision of any specific build targets.  That provision became required in #1503.

Quick-Fix:
- Because this is the only current workflow with a target_mapping calculated to `{}`, it's simple to add a (temporary) conditional code fix!