### PR TITLE
vesta updates per feedback

### DIFF
--- a/vesta/vesta_ui/src/components/about/about-carousel.tsx
+++ b/vesta/vesta_ui/src/components/about/about-carousel.tsx
@@ -286,9 +286,9 @@ export function _AboutCarousel({ items }: Props) {
                         },
                     }}
                 >
-                    {items.map((item) => {
+                    {items.map((item, index) => {
                         return (
-                            <SwiperSlide key={item.header}>
+                            <SwiperSlide key={item.header} onClick={() => handleClickCarouselIndexIndicator(index)}>
                                 <AboutItem
                                     header={item.header}
                                     body={item.body}

--- a/vesta/vesta_ui/src/components/project-explorer/filter-list.tsx
+++ b/vesta/vesta_ui/src/components/project-explorer/filter-list.tsx
@@ -128,13 +128,22 @@ const OpenCloseToggle = ({open, onClick}:{
   />
 }
 
-const Filter = ({title, highlight, children}:{
+const Filter = ({title, highlight, children, inputRef}:{
   title: string;
   highlight: boolean;
   children: React.ReactNode;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
 }) => {
   const [ active, setActive ] = React.useState(false);
   const [ fold, setFold ] = React.useState(true);
+  const [ doFocus, setDoFocus ] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!fold && doFocus) {
+      inputRef?.current?.focus();
+      setDoFocus(false);
+    }
+  }, [fold, inputRef]);
 
   const { state: { visibleColumns }, toggleColumnVisibility } = React.useContext(ProjectExplorerContext);
 
@@ -154,7 +163,12 @@ const Filter = ({title, highlight, children}:{
       </Box>
       <Box sx={{ width: '76px' }}>
         <ShowHideToggle shown={visible} onClick={ () => toggleColumnVisibility(title) }/>
-        <OpenCloseToggle open={!fold} onClick={ () => setFold(!fold) }/>
+        <OpenCloseToggle open={!fold}
+          onClick={ () => {
+            if (fold) setDoFocus(true);
+            setFold(!fold);
+          }}
+        />
       </Box>
     </Box>
     {
@@ -173,6 +187,7 @@ const BasicFilter = ({title, filter, items, render}:{
   filter: FilterFunction,
   render: (params:any) => any;
 }) => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const {
     state: { projectData, filters, filterItemSet },
     createFilter,
@@ -207,13 +222,15 @@ const BasicFilter = ({title, filter, items, render}:{
     }, [filterItemSet]
   );
 
-  return <Filter title={title} highlight={ title in filterItemSet }>
+  return <Filter title={title} highlight={ title in filterItemSet } inputRef={inputRef}>
     <Autocomplete<string>
       size='small'
       multiple
       filterSelectedOptions
       icon={searchDarkIcon}
       options={itemNames}
+      inputRef={inputRef}
+      openOnFocus
       // @ts-ignore
       onChange={(_, value:string[] | null, reason) => {
           if (reason === 'removeOption') return;

--- a/vesta/vesta_ui/src/components/searchable-list/controls/autocomplete.tsx
+++ b/vesta/vesta_ui/src/components/searchable-list/controls/autocomplete.tsx
@@ -32,6 +32,7 @@ interface AutocompleteProps<Value> extends UseAutocompleteProps<Value, boolean, 
   renderGroup?: (params: _AutocompleteGroupedOption<Value>) => React.ReactNode;
   renderNoResults?: () => React.ReactNode;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
   sx?: SxProps;
   size?: string;
 }
@@ -52,6 +53,9 @@ function Autocomplete<Value>(
     anchorEl,
     setAnchorEl,
   } = useAutocomplete(props);
+
+  const { ref: inputPropsRef, ...inputProps } = getInputProps();
+  const inputRef = useForkRef(props.inputRef, inputPropsRef);
 
   const rootRef = useForkRef(ref, setAnchorEl);
 
@@ -153,7 +157,8 @@ function Autocomplete<Value>(
           />
 
           <StyledInput
-            {...getInputProps()}
+            {...inputProps}
+            ref={inputRef}
             placeholder={props.placeholder}
             onKeyDown={props.onKeyDown}
             sx={{


### PR DESCRIPTION
PR aims to tackle 2 updates per user feedback:
- [x]  In the projects explorer, when you click to open a filter it should immediately open to show all options (instead of requiring a second click)
    1. Adds functionality Vesta's customized Autocomplete component:
        - injected reference hook to allow targeting by distantly established components
        - `openOnFocus` option
    2. Adds optional provision of an `inputRef` reference to the base `Filter` component, and adds triggering of focus on said reference after the `OpenCloseToggle` triggers opening.
    3. Sets the `BasicFilter` element behind the dropdown-style filters to create and pass this reference along and and to set `openOnFocus` on the target Autocomplete-dropdowns
- [x] The carousel for the About the Data Library should cycle if you click one of the cards on the side. Currently, you can only access cards by clicking the tabs.
    1. a simple `onClick` addition