### PR TITLE
vesta - bump nextjs from security concern

### DIFF
--- a/vesta/vesta_ui/package.json
+++ b/vesta/vesta_ui/package.json
@@ -24,7 +24,7 @@
     "html-to-image": "^1.11.11",
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.1",
-    "next": "^14.2.3",
+    "next": "^14.2.25",
     "react": "^18",
     "react-dom": "^18",
     "react-spring": "^9.7.3",


### PR DESCRIPTION
Per a security vulnerability, bumps the version of nextjs from v14.2.3 to v14.2.25 