### PR TITLE
Polyphemus log improvements

### DIFF
--- a/etna/.eslintrc.js
+++ b/etna/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'react', 'react-hooks'],
   rules: {
     'no-undef': 'error',
-    quotes: ['error', 'single', { avoidEscape: true }],
+    quotes: ['warn', 'single', { avoidEscape: true }],
     semi: 'warn',
     'no-var': 'warn',
     curly: ['warn', 'multi-line'],

--- a/etna/packages/etna-js/plots/components/legend.jsx
+++ b/etna/packages/etna-js/plots/components/legend.jsx
@@ -1,15 +1,37 @@
 import React, {Component} from 'react';
+import Box from '@material-ui/core/Box';
 
-const Legend = ({labels, width}) =>
-  <div className='legend-container' style={ { width } } >
+const Legend = ({labels, width, height}) =>
+  <Box sx={{
+    display: 'flex',
+    justifyContent: 'center',
+          position: 'absolute',
+          top: '0px',
+    width, height
+  }}>
     {
       labels.flat().map(({name,color}) =>
-        <div key={ name } className='category-group'>
-          <div className='label-rect' style={{background: color}}/>
-          <div className='label-text'>{name}</div>
-        </div>
+        <Box key={ name } sx={{
+          display: 'flex',
+          height: '100%',
+          marginRight: '24px',
+          alignItems: 'center',
+        }}>
+          <Box sx={{
+            background: color,
+            display: 'inline-block',
+            marginRight: '8px',
+            width: '16px',
+            height: '8px',
+            verticalAlign: 'middle',
+          }}/>
+          <Box sx={{
+            display: 'inline',
+            fontSize: '12px'
+          }}>{name}</Box>
+        </Box>
       )
     }
-  </div>;
+  </Box>;
 
 export default Legend;

--- a/etna/packages/etna-js/plots/components/legend.jsx
+++ b/etna/packages/etna-js/plots/components/legend.jsx
@@ -5,8 +5,6 @@ const Legend = ({labels, width, height}) =>
   <Box sx={{
     display: 'flex',
     justifyContent: 'center',
-          position: 'absolute',
-          top: '0px',
     width, height
   }}>
     {

--- a/magma/lib/magma/server/query.rb
+++ b/magma/lib/magma/server/query.rb
@@ -33,9 +33,13 @@ class QueryController < Magma::Controller
           message: 'made a query',
           consolidate: true,
           payload: {
-            query: @params[:query],
-            show_disconnected: @params[:show_disconnected]
-          }.compact
+            queries: [
+              {
+                query: @params[:query],
+                show_disconnected: @params[:show_disconnected]
+              }.compact
+            ]
+          }
         )
       end
 

--- a/magma/lib/magma/server/retrieve.rb
+++ b/magma/lib/magma/server/retrieve.rb
@@ -67,6 +67,24 @@ class RetrieveController < Magma::Controller
 
       @payload = Magma::Payload.new
 
+      if @params[:event_log] && (!@params[:page] || @params[:page] == 1)
+        event_log(
+          event: 'search',
+          message: 'did a search',
+          consolidate: true,
+          payload: {
+            search: [
+              {
+                model_name: @model_name,
+                record_names: @record_names,
+                attribute_names: @attribute_names,
+                show_disconnected: @params[:show_disconnected]
+              }.compact
+            ]
+          }
+        )
+      end
+
       case @format
       when 'tsv'
         return tsv_payload

--- a/polyphemus/lib/client/jsx/polyphemus-log-chart.jsx
+++ b/polyphemus/lib/client/jsx/polyphemus-log-chart.jsx
@@ -1,0 +1,204 @@
+import React, {useState, useEffect, useCallback, useContext} from 'react';
+import Axis from 'etna-js/plots/components/axis';
+import Legend from 'etna-js/plots/components/legend';
+import * as d3 from 'd3';
+import Box from '@material-ui/core/Box';
+import { APP_COLORS } from './polyphemus-logs';
+
+const scale = (domain, range) => {
+  let s;
+
+  if (domain[0] instanceof Date) {
+    s = d3.scaleTime();
+    s.type = 'time';
+    console.log({s});
+  } else if (typeof domain[0] === 'string') {
+    s = d3.scaleBand().padding(0.2);
+    s.type = 'band';
+  } else {
+    s = d3.scaleLinear();
+    s.type = 'linear';
+  }
+
+  s = s.domain(domain).range(range);
+  if (s.nice) s = s.nice();
+
+  return s;
+}
+
+const PlotCanvas = ({
+    labels,
+    xdomain,
+    ydomain,
+    xlabel,
+    ylabel,
+    children
+  }) => {
+    console.log({xdomain,ydomain});
+  const margin = { left: 40, right: 40, top: 40, bottom: 40 };
+
+  const [stageSize, setStageSize] = useState({width: 100, height: 100});
+  const stage = React.useRef(null);
+
+  const resize = () => {
+    if (stage.current) setStageSize(stage.current.getBoundingClientRect());
+  }
+
+  useEffect( () => {
+    resize();
+  }, [stage] );
+
+  useEffect(() => {
+    window.addEventListener('resize', resize);
+    return () => {
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  let xScale = scale(xdomain, [
+    margin.left,
+    stageSize.width - margin.right
+  ]);
+
+  let yScale = scale(
+    ydomain,
+    [
+      stageSize.height - margin.bottom,
+      margin.top
+    ]
+  );
+
+  let xsize = stageSize.width - margin.left - margin.right;
+  let ysize = stageSize.height - margin.top - margin.bottom;
+
+  return (
+    <Box
+      sx={
+        {
+          position: 'relative',
+          width: '100%', height: '100%',
+          '& .tick': {
+            color: 'skyblue',
+            '& text': {
+              color: 'black',
+            }
+          },
+          '& .line': {
+            strokeWidth: 5,
+            strokeLinecap: 'round',
+            strokeLineround: 'round'
+          }
+        }
+      }
+      ref={stage}>
+      <Legend width={stageSize.width} height={margin.top} labels={labels} />
+      <svg width={stageSize.width} height={stageSize.height}>
+        <rect
+          fill='aliceblue'
+          x={ margin.right }
+          y={ margin.top }
+          width={ stageSize.width - margin.right - margin.left }
+          height={ stageSize.height - margin.top - margin.bottom } />
+        {xlabel && (
+          <text
+            x={xsize / 2 + parseInt(margin.left)}
+            y={parseInt(margin.top) + ysize + 50}
+            fontSize='12px'
+            textAnchor='middle'
+          >
+            {xlabel}
+          </text>
+        )}
+        <Axis
+          orient='Bottom'
+          scale={xScale}
+          translate={`translate(0, ${stageSize.height - margin.bottom})`}
+          tickSize={ysize}
+        />
+        {ylabel && (
+          <text
+            x={-ysize / 2 - parseInt(margin.top)}
+            y={margin.left - 50}
+            fontSize='12px'
+            transform='rotate(-90)'
+            textAnchor='middle'
+          >
+            {ylabel}
+          </text>
+        )}
+        <Axis
+          orient='Left'
+          scale={yScale}
+          translate={`translate(${margin.left}, 0)`}
+          tickSize={xsize}
+        />
+        {
+          React.Children.map(children, child =>
+            React.cloneElement(child, { xScale, yScale }))
+        }
+      </svg>
+    </Box>
+  );
+}
+
+const Line = ({ name, series, xScale, yScale, color }) => {
+  const linePath = d3
+    .line()
+    .x(d => d.x)
+    .y(d => d.y);
+
+  const points = series.map((p, i) => ({ x: xScale(p.x), y: yScale(p.y) }));
+  const path = linePath(points);
+
+  return <path 
+    className="line"
+    d={ linePath(points) }
+    fill="none"
+    stroke={ color }
+  />;
+}
+
+const HistogramChart = ({logs}) => {
+  const fromDate = logs.reduce((min, d) => (min > d.created_at ? d.created_at : min), '3000-01-01');
+  const toDate = logs.reduce((max, d) => (max < d.created_at ? d.created_at : max), '1970-01-01');
+
+  let groups = Object.groupBy(logs, log => log.application);
+  groups.all = logs
+
+  const xdomain = [new Date(fromDate), new Date(toDate)];
+
+  const xScale = scale(xdomain, [ 0, 1 ]);
+  const hist = d3.histogram().value(d => d).domain(xdomain).thresholds(xScale.ticks(d3.timeMonth));
+
+  groups = Object.fromEntries( Object.keys(groups).map(
+    group => [ group, {
+      data: groups[group],
+      bins: hist(groups[group].map( l => new Date(l.created_at)))
+    } ]
+  ) );
+
+  const maxBinSize = Math.max( ...Object.keys(groups).map( group => Math.max( ...groups[group].bins.map( bin => bin.length ) ) ) );
+
+  console.log({fromDate,toDate, logs, groups, maxBinSize});
+
+  return <PlotCanvas
+    xdomain={xdomain}
+    ydomain={[-0.5,maxBinSize+1]}
+    labels={Object.keys(groups).map(name => ({name, color: APP_COLORS[name] || 'pink' }))}
+  >
+  {
+    Object.keys(groups).map( group => <Line
+      key={group}
+      name={group}
+      color={ APP_COLORS[group] || 'pink' }
+      series={
+        groups[group].bins.map(
+          bin => ({ x: bin.x0, y: bin.length })
+        )
+      }
+    /> )
+  }
+  </PlotCanvas>;
+}
+
+export default HistogramChart;

--- a/polyphemus/lib/client/jsx/polyphemus-log-chart.jsx
+++ b/polyphemus/lib/client/jsx/polyphemus-log-chart.jsx
@@ -4,6 +4,8 @@ import Legend from 'etna-js/plots/components/legend';
 import * as d3 from 'd3';
 import Box from '@material-ui/core/Box';
 import { APP_COLORS } from './polyphemus-logs';
+import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
 
 const scale = (domain, range) => {
   let s;
@@ -91,7 +93,9 @@ const PlotCanvas = ({
         }
       }
       ref={stage}>
-      <Legend width={stageSize.width} height={margin.top} labels={labels} />
+      <Box sx={{ display: 'flex', gap: '15px', position: 'absolute', alignItems: 'center', paddingLeft: margin.left }}>
+        <Legend height={margin.top} labels={labels} />
+      </Box>
       <svg width={stageSize.width} height={stageSize.height}>
         <rect
           fill='aliceblue'
@@ -162,13 +166,15 @@ const HistogramChart = ({logs}) => {
   const fromDate = logs.reduce((min, d) => (min > d.created_at ? d.created_at : min), '3000-01-01');
   const toDate = logs.reduce((max, d) => (max < d.created_at ? d.created_at : max), '1970-01-01');
 
+  const [interval, setInterval] = useState('week');
+
   let groups = Object.groupBy(logs, log => log.application);
   groups.all = logs
 
   const xdomain = [new Date(fromDate), new Date(toDate)];
 
   const xScale = scale(xdomain, [ 0, 1 ]);
-  const hist = d3.histogram().value(d => d).domain(xdomain).thresholds(xScale.ticks(d3.timeMonth));
+  const hist = d3.histogram().value(d => d).domain(xdomain).thresholds(xScale.ticks(interval == 'month' ? d3.timeMonth : d3.timeWeek));
 
   groups = Object.fromEntries( Object.keys(groups).map(
     group => [ group, {
@@ -181,24 +187,35 @@ const HistogramChart = ({logs}) => {
 
   console.log({fromDate,toDate, logs, groups, maxBinSize});
 
-  return <PlotCanvas
-    xdomain={xdomain}
-    ydomain={[-0.5,maxBinSize+1]}
-    labels={Object.keys(groups).map(name => ({name, color: APP_COLORS[name] || 'pink' }))}
-  >
-  {
-    Object.keys(groups).map( group => <Line
-      key={group}
-      name={group}
-      color={ APP_COLORS[group] || 'pink' }
-      series={
-        groups[group].bins.map(
-          bin => ({ x: bin.x0, y: bin.length })
-        )
-      }
-    /> )
-  }
-  </PlotCanvas>;
+  return <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+    <PlotCanvas
+      xdomain={xdomain}
+      ydomain={[-0.5,maxBinSize+1]}
+      labels={Object.keys(groups).map(name => ({name, color: APP_COLORS[name] || 'pink' }))}
+    >
+    {
+      Object.keys(groups).map( group => <Line
+        key={group}
+        name={group}
+        color={ APP_COLORS[group] || 'pink' }
+        series={
+          groups[group].bins.map(
+            bin => ({ x: bin.x0, y: bin.length })
+          )
+        }
+      /> )
+    }
+    </PlotCanvas>
+    <Box sx={{ position: 'absolute', right: 39, top: 0 }} >
+      <TextField select size='small' style={{ width: '100px' }} margin='dense'
+          value={interval}
+          onChange={ e => setInterval(e.target.value)}
+      >
+        <MenuItem fontSize='small' value={'week'}>Week</MenuItem>
+        <MenuItem fontSize='small' value={'month'}>Month</MenuItem>
+      </TextField>
+    </Box>
+  </Box>;
 }
 
 export default HistogramChart;

--- a/polyphemus/lib/client/jsx/polyphemus-logs.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-logs.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect, useCallback, useContext} from 'react';
 import {json_post} from 'etna-js/utils/fetch';
 import {getModels} from 'etna-js/api/magma_api';
 import {MagmaContext} from 'etna-js/contexts/magma-context';
+import {downloadTSV} from 'etna-js/utils/tsv';
 
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
@@ -25,16 +26,30 @@ import TableHead from '@material-ui/core/TableHead';
 import Paper from '@material-ui/core/Paper';
 import Chip from '@material-ui/core/Chip';
 import CodeIcon from '@material-ui/icons/Code';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import TimelineIcon from '@material-ui/icons/Timeline';
 import IconButton from '@material-ui/core/IconButton';
 import Collapse from '@material-ui/core/Collapse';
 
 import {formatTime} from './workflow/run-state';
 import {Log} from './polyphemus';
+import Chart from './polyphemus-log-chart';
 import { getItem } from 'etna-js/utils/cookies';
 import { parseToken } from 'etna-js/utils/janus';
 
 declare var CONFIG: { [key: string]: string };
 
+
+export const APP_COLORS= {
+  janus: 'rgba(155,86,255,0.33)',
+  magma: '#cd4a34',
+  timur: 'rgba(117,255,117,0.30)',
+  metis: '#5fe2e4',
+  gnomon: '#e6e6e6',
+  polyphemus: '#d0d835',
+  vulcan: 'rgba(255,8,4,0.49)'
+}
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -63,27 +78,9 @@ const useStyles = makeStyles((theme) => ({
   app_filter: {
     minWidth: '120px'
   },
-  janus: {
-    background: 'rgba(155,86,255,0.33)'
-  },
-  magma: {
-    background: '#cd4a34'
-  },
-  timur: {
-    background: 'rgba(117,255,117,0.30)'
-  },
-  metis: {
-    background: '#5fe2e4'
-  },
-  gnomon: {
-    background: '#e6e6e6'
-  },
-  polyphemus: {
-    background: '#d0d835'
-  },
-  vulcan: {
-    background: 'rgba(255,8,4,0.49)'
-  }
+  ...Object.fromEntries(
+    Object.entries(APP_COLORS).map( ([app,background]) => [ app, {background}] )
+  )
 }));
 
 const applications = [
@@ -140,14 +137,15 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
   const [order, setOrder] = useState< 'desc' | 'asc' | undefined>('asc');
   const [orderBy, setOrderBy] = useState('Job Type');
   const [logs, setLogs] = useState<Log[]>([]);
+  const [chartShown, setChartShown] = useState(true);
 
   const [ filterApplications, setFilterApplications ] = useState<string[]>([]);
   const [ filterUser, setFilterUser ] = useState('');
   const [ filterEvent, setFilterEvent ] = useState('');
   const [ filterMessage, setFilterMessage ] = useState('');
   const [ filterProjects, setFilterProjects ] = useState<string[]>([]);
-  const [ filterFrom, setFilterFrom ] = useState('');
-  const [ filterTo, setFilterTo ] = useState('');
+  const [ filterFrom, setFilterFrom ] = useState('1980-01-01');
+  const [ filterTo, setFilterTo ] = useState('2980-01-01');
 
   const token = parseToken(getItem(CONFIG.token_name) as string);
 
@@ -158,6 +156,14 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
     token.permissions[project_name].privileged
   );
 
+  const downloadLogs = useCallback( () => {
+    downloadTSV(
+      logs,
+      [ 'created_at', 'application', 'project_name', 'user', 'event', 'message' ],
+      `polyphemus-${project_name}-logs-${(new Date()).toISOString().slice(0,10)}.tsv`
+    );
+  }, [ logs ] );
+
   const getLogs = useCallback(() => {
     let params: any = {};
 
@@ -165,10 +171,8 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
     if (filterEvent) params.event = filterEvent;
     if (filterMessage) params.message = filterMessage;
     if (filterApplications.length) params.application = filterApplications;
-    if (filterTo && filterFrom) {
-      params.from = filterFrom;
-      params.to = filterTo;
-    }
+    if (filterTo) params.to = filterTo;
+    if (filterFrom) params.from = filterFrom;
     if (filterProjects.length && project_name == 'administration') {
       params.project_names = filterProjects;
     }
@@ -183,7 +187,7 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
   }, []);
 
   useEffect(() => {
-    const timeout = setInterval(getLogs, 10000);
+    const timeout = setInterval(getLogs, 1000000);
 
     return () => clearInterval(timeout);
   }, [getLogs]);
@@ -296,7 +300,13 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
               }
             </Select>
           </FormControl>
+          <IconButton title="Refresh" onClick={ getLogs } size="small"><RefreshIcon fontSize="small"/></IconButton>
+          <IconButton title="Download TSV" onClick={ downloadLogs } size="small"><ArrowDownwardIcon fontSize="small"/></IconButton>
+          <IconButton color={ chartShown ? 'primary' : 'default' } title={ chartShown ? "Show table" : "Show Chart" } onClick={ () => setChartShown(!chartShown) } size="small"><TimelineIcon fontSize="small"/></IconButton>
         </Grid>
+        { chartShown ? <div style={{ width: '100%', height: 'calc(100% - 75px)' }}>
+          <Chart logs={logs}/>
+        </div> :
         <Table size="small" stickyHeader>
           <TableHead>
             <TableRow>
@@ -329,6 +339,7 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
               ))}
           </TableBody>
         </Table>
+        }
       </TableContainer>
     </Grid>
   </Grid>

--- a/polyphemus/lib/client/jsx/polyphemus-logs.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-logs.tsx
@@ -42,13 +42,13 @@ declare var CONFIG: { [key: string]: string };
 
 
 export const APP_COLORS= {
-  janus: 'rgba(155,86,255,0.33)',
+  janus: '#dec7ff',
   magma: '#cd4a34',
-  timur: 'rgba(117,255,117,0.30)',
+  timur: '#d6ffd6',
   metis: '#5fe2e4',
   gnomon: '#e6e6e6',
   polyphemus: '#d0d835',
-  vulcan: 'rgba(255,8,4,0.49)'
+  vulcan: '#ff8684'
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -69,7 +69,7 @@ const useStyles = makeStyles((theme) => ({
   filters: {
     borderBottom: '1px solid #ccc',
     padding: '10px',
-    height: '70px',
+    height: '75px',
     alignItems: 'end'
   },
   filter: {
@@ -137,15 +137,15 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
   const [order, setOrder] = useState< 'desc' | 'asc' | undefined>('asc');
   const [orderBy, setOrderBy] = useState('Job Type');
   const [logs, setLogs] = useState<Log[]>([]);
-  const [chartShown, setChartShown] = useState(true);
+  const [chartShown, setChartShown] = useState(false);
 
   const [ filterApplications, setFilterApplications ] = useState<string[]>([]);
   const [ filterUser, setFilterUser ] = useState('');
   const [ filterEvent, setFilterEvent ] = useState('');
   const [ filterMessage, setFilterMessage ] = useState('');
   const [ filterProjects, setFilterProjects ] = useState<string[]>([]);
-  const [ filterFrom, setFilterFrom ] = useState('1980-01-01');
-  const [ filterTo, setFilterTo ] = useState('2980-01-01');
+  const [ filterFrom, setFilterFrom ] = useState('');
+  const [ filterTo, setFilterTo ] = useState('');
 
   const token = parseToken(getItem(CONFIG.token_name) as string);
 
@@ -187,7 +187,7 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
   }, []);
 
   useEffect(() => {
-    const timeout = setInterval(getLogs, 1000000);
+    const timeout = setInterval(getLogs, 10000);
 
     return () => clearInterval(timeout);
   }, [getLogs]);

--- a/polyphemus/lib/client/jsx/polyphemus-logs.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-logs.tsx
@@ -302,7 +302,7 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
           </FormControl>
           <IconButton title="Refresh" onClick={ getLogs } size="small"><RefreshIcon fontSize="small"/></IconButton>
           <IconButton title="Download TSV" onClick={ downloadLogs } size="small"><ArrowDownwardIcon fontSize="small"/></IconButton>
-          <IconButton color={ chartShown ? 'primary' : 'default' } title={ chartShown ? "Show table" : "Show Chart" } onClick={ () => setChartShown(!chartShown) } size="small"><TimelineIcon fontSize="small"/></IconButton>
+          <IconButton color={ chartShown ? 'primary' : 'default' } title={ chartShown ? 'Show table' : 'Show Chart' } onClick={ () => setChartShown(!chartShown) } size="small"><TimelineIcon fontSize="small"/></IconButton>
         </Grid>
         { chartShown ? <div style={{ width: '100%', height: 'calc(100% - 75px)' }}>
           <Chart logs={logs}/>

--- a/polyphemus/lib/polyphemus/controllers/log_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/log_controller.rb
@@ -63,13 +63,15 @@ class LogController < Polyphemus::Controller
       user: @params[:user] ? Regexp.new(@params[:user]) : nil,
       event: @params[:event] ? Regexp.new(@params[:event]) : nil,
       message: @params[:message] ? Regexp.new(@params[:message]) : nil,
-      created_at: @params[:from] && @params[:to] ? DateTime.parse(@params[:from])..DateTime.parse(@params[:to]) : nil,
+      created_at: (@params[:from] || @params[:to]) ?
+        DateTime.parse(@params[:from] || '1970-01-01')..(@params[:to] ? DateTime.parse(@params[:to]) : DateTime.now) :
+        (DateTime.now - 7)..DateTime.now,
       hidden: false,
     }.compact
 
     logs = Polyphemus::Log.where(
       query
-    ).order(Sequel.desc(:created_at)).limit(100).all
+    ).order(Sequel.desc(:created_at)).all
 
     success_json(logs: logs.map(&:to_report))
   end

--- a/timur/lib/client/jsx/components/search/search.jsx
+++ b/timur/lib/client/jsx/components/search/search.jsx
@@ -84,6 +84,7 @@ export function Search({
         attribute_names: queryableAttributes,
         filter: filter_string,
         show_disconnected,
+	event_log: true,
         page: page,
         page_size: pageSize,
         collapse_tables: true,


### PR DESCRIPTION
A few changes to the Polyphemus log view:
- The log query no longer has a limit of 100 records, it can return every log event ever if so specified.
- The default log query with no params will return the last week's worth of records (however many)
- A one-sided query will complete (e.g., just setting "to" date will have a "from" of -infinity)
- There is a "refresh" button which can be pushed to update logs without waiting for the 10s refresh
- There is a download TSV button
- A "chart" view shows a line graph of the events
- Search events on timur now appear in the log