### PR TITLE
fix polyphemus log#read to not load payloads

### DIFF
--- a/polyphemus/lib/client/jsx/polyphemus-logs.tsx
+++ b/polyphemus/lib/client/jsx/polyphemus-logs.tsx
@@ -182,15 +182,19 @@ const PolyphemusLogs = ({project_name}: {project_name: string}) => {
     ).then(({logs}) => setLogs(logs));
   }, [ filterApplications, filterUser, filterEvent, filterMessage, filterFrom, filterTo, filterProjects ]);
 
+  const updateLogs = useCallback( () => {
+    if (!filterTo) getLogs();
+  }, [ getLogs ]);
+
   useEffect(() => {
     getLogs();
   }, []);
 
   useEffect(() => {
-    const timeout = setInterval(getLogs, 10000);
+    const timeout = setInterval(updateLogs, 10000);
 
     return () => clearInterval(timeout);
-  }, [getLogs]);
+  }, [updateLogs]);
 
   const headCells = [
     {

--- a/polyphemus/lib/polyphemus/controllers/log_controller.rb
+++ b/polyphemus/lib/polyphemus/controllers/log_controller.rb
@@ -71,7 +71,11 @@ class LogController < Polyphemus::Controller
 
     logs = Polyphemus::Log.where(
       query
-    ).order(Sequel.desc(:created_at)).all
+    ).order(Sequel.desc(:created_at)).select(
+      :application, :created_at, :event, :message, :project_name, :user, :id
+    ).select_append {
+      Sequel.~(payload: nil).as(:payload)
+    }.all
 
     success_json(logs: logs.map(&:to_report))
   end


### PR DESCRIPTION
After exposing the new log stuff, it became apparent that the log#read endpoint is loading all of the log payloads into memory when it queries! Which quickly kills polyphemus if anyone is browsing the logs. This PR makes this not happen, instead returning a boolean value from the SQL query.